### PR TITLE
fix: harden Busabase CLI npx entry

### DIFF
--- a/packages/busabase-core/src/skill-doc.ts
+++ b/packages/busabase-core/src/skill-doc.ts
@@ -491,7 +491,8 @@ connection to \`~/.busabase/.env\` **for you** — base URL, a login session tok
 space (it even asks which space when the user belongs to more than one):
 
 \`\`\`bash
-npx -y busabase-cli login    # opens the browser; prints a URL to paste if it can't
+npm exec -y --package busabase-cli@latest -- busabase-cli login
+# opens the browser; prints a URL to paste if it can't
 \`\`\`
 
 When it prints **"Signed in"**, the connection is saved — just read it back and continue:
@@ -589,8 +590,9 @@ printf 'BUSABASE_BASE_URL=%s\\n' "${local}" > ~/.busabase/.env
   const step1 = isCloud
     ? `## Step 1 — Get credentials (only if you don't have any)
 
-**Easiest: \`npx -y busabase-cli login\`** — browser sign-in that saves everything to
-\`~/.busabase/.env\`, no key to copy. Use the manual key below only when there's no browser.
+**Easiest: \`npm exec -y --package busabase-cli@latest -- busabase-cli login\`** — browser
+sign-in that saves everything to \`~/.busabase/.env\`, no key to copy. Use the manual key below
+only when there's no browser.
 
 Manual API key: tell the user in plain words to sign in at \`${site}/dashboard\`, open
 **Settings → API Keys**, and **Create key** — copy it (it is shown only once). Then save it so


### PR DESCRIPTION
## Summary
- add a stable `bin/busabase-cli.mjs` wrapper so the package bin no longer points directly at build-only `dist/cli.js`
- bump `busabase-cli` to `0.1.4` so the publish workflow will ship the bin-entry fix instead of skipping the already-published `0.1.3`
- extend `assert-help` to execute the real package bin wrapper before publish
- update SETUP_SKILL's recommended login command to the package-explicit `npm exec --package busabase-cli@latest` form for onboarding reliability

## Why
`npx busabase-cli` should work for the published package. It does on the registry path, but inside a source/workspace checkout a local unbuilt `busabase-cli` package can leave the bin pointing at missing `dist/cli.js`, producing `busabase-cli: not found`. The wrapper gives source checkouts a stable entry and a clear recovery message, while the published package continues to execute the built CLI.

## Validation
- `npx -y busabase-cli --version` -> `0.1.3` for current published package
- `npm exec -y --package busabase-cli@latest -- busabase-cli --version` -> `0.1.3`
- `node apps/busabase-cli/bin/busabase-cli.mjs --version` in an unbuilt source checkout prints a clear build/published-package recovery message instead of disappearing as `command not found`
- `npm pack ./apps/busabase-cli --ignore-scripts --json` confirms `bin/busabase-cli.mjs` is included and executable

## Notes
- Full package build/pack was not run locally because this clean temporary worktree has no installed dev dependencies; CI installs dependencies before building and publish checks now exercise the wrapper.
