### PR TITLE
feat: sync Busabase realtime and write-model updates

### DIFF
--- a/apps/busabase/tests/cli-golden-path.test.ts
+++ b/apps/busabase/tests/cli-golden-path.test.ts
@@ -151,7 +151,7 @@ describe("busabase-cli golden path (skill commands, in-process)", () => {
     expect(queue.length).toBeGreaterThan(0);
   });
 
-  it("proposes, approves, and merges a folder node through the CLI", async () => {
+  it("creates an auto-merged folder node through the CLI", async () => {
     const created = (await cli(
       "nodes",
       "create-change-request",
@@ -162,17 +162,7 @@ describe("busabase-cli golden path (skill commands, in-process)", () => {
       "--name",
       "CLI Folder",
     )) as { id: string; status: string };
-    expect(created.status).toBe("in_review");
-
-    await cli(
-      "change-requests",
-      "review",
-      "--change-request-id",
-      created.id,
-      "--verdict",
-      "approved",
-    );
-    await cli("change-requests", "merge", "--change-request-id", created.id);
+    expect(created.status).toBe("merged");
 
     const tree = await cli("nodes", "list");
     expect(JSON.stringify(tree)).toContain("CLI Folder");

--- a/packages/busabase-contract/src/contract/busabase.ts
+++ b/packages/busabase-contract/src/contract/busabase.ts
@@ -1,4 +1,4 @@
-import { oc } from "@orpc/contract";
+import { eventIterator, oc } from "@orpc/contract";
 import { attachmentsContract } from "open-domains/attachments/contract";
 import { z } from "zod";
 import { assetsContract } from "../domains/assets/contract";
@@ -23,6 +23,7 @@ import {
   createCommentInputSchema,
   createNodeChangeRequestInputSchema,
   listInputSchema,
+  liveEventSchema,
   nodeSchema,
   reviewChangeRequestInputSchema,
   reviseOperationInputSchema,
@@ -163,6 +164,11 @@ export const busabaseContractRoutes = {
           "Change requests awaiting an external agent (request-changes or @ai mentions).",
       })
       .output(z.array(agentTaskSchema)),
+  },
+  live: {
+    // RPC-only by design: no `.route(...)`, so OpenAPI generation and MCP tool
+    // discovery skip this long-lived Event Iterator while `/api/rpc` stays typed.
+    subscribe: oc.output(eventIterator(liveEventSchema)),
   },
   bases: baseContract,
   skills: skillContract,
@@ -306,6 +312,7 @@ export {
   createCommentInputSchema,
   createDeleteChangeRequestInputSchema,
   listInputSchema,
+  liveEventSchema,
   nodeSchema,
   operationSchema,
   reviewChangeRequestInputSchema,

--- a/packages/busabase-contract/src/contract/schemas.ts
+++ b/packages/busabase-contract/src/contract/schemas.ts
@@ -183,6 +183,18 @@ const searchResponseSchema = z.object({
   results: z.array(searchResultSchema),
 });
 
+const liveEventSchema = z.object({
+  kind: z.literal("change_request.merged"),
+  spaceId: z.string(),
+  actorId: z.string(),
+  changeRequestId: z.string(),
+  baseId: z.string().nullable(),
+  nodeIds: z.array(z.string()),
+  recordIds: z.array(z.string()),
+  viewIds: z.array(z.string()),
+  operationCount: z.number(),
+});
+
 const auditActionSchema = z.enum([
   "record.viewed",
   "change_request.created",
@@ -424,6 +436,7 @@ export {
   agentTaskSchema,
   searchResultSchema,
   searchResponseSchema,
+  liveEventSchema,
   auditActionSchema,
   auditEventSchema,
   createAuditEventInputSchema,

--- a/packages/busabase-contract/src/domains/base/contract/base-schemas.ts
+++ b/packages/busabase-contract/src/domains/base/contract/base-schemas.ts
@@ -85,7 +85,16 @@ export const fieldOptionsSchema = z
         locale: z.string().optional(),
       })
       .optional(),
-    targetBaseId: z.string().optional(),
+    targetBaseId: z
+      .string()
+      .optional()
+      .describe("Relation target Base id (bse_…). Or pass targetBaseSlug to name it by slug."),
+    targetBaseSlug: z
+      .string()
+      .optional()
+      .describe(
+        "Relation target Base by slug — a convenience alias for targetBaseId, resolved server-side (active bases in the current space). If both are given, targetBaseId wins.",
+      ),
   })
   .default({});
 

--- a/packages/busabase-core/docs/write-model-cr-unification.md
+++ b/packages/busabase-core/docs/write-model-cr-unification.md
@@ -1,0 +1,113 @@
+# Spec: Unify the busabase write model on ChangeRequests (auto-merge for structural ops)
+
+Status: **Draft / awaiting approval** · Date: 2026-07-06 · Scope: `packages/busabase-core` (consumed by busabase, busabase-cloud, busabase-desktop, busabase-cli, busabase-mobile)
+
+## 1. User value — why this exists
+
+Busabase's promise to its users is **"nothing becomes true without a trace, and dangerous changes are reviewable."** Two gaps break that promise today:
+
+1. **Silent structural writes.** Creating a base, a doc, a skill, adding a field, deleting an asset, or purging a node happens as a **direct DB write**. It leaves an `audit_events` row but **no `change_request`** — so it is *not* part of the version/diff/rollback story and *not* visible in the review/history surfaces the product is built around. An agent (or a bug) can reshape a workspace and the only trace is a thin audit line.
+2. **Split, surprising rules.** Creating a *base* is a direct write, but creating a *folder* — literally a sibling node — goes through a ChangeRequest. Agents must hold two mental models of "how do I write," and pick wrong. This is the #1 source of the field feedback that triggered this work.
+
+**The value we deliver:** every mutation leaves a first-class `change_request` (so everything is auditable *and* reviewable *and* reversible through one surface), while the everyday structural actions still *feel* instant — the agent calls `createBase` and gets a `BaseVO` back, exactly as today.
+
+**Non-goal:** we are **not** making AI-authored *content* auto-merge. Records — the reviewable content — keep the human approval loop untouched. This spec only changes how *structural* writes are recorded.
+
+## 2. Who does what (user operations)
+
+| Actor | Operation | Today | After |
+| --- | --- | --- | --- |
+| Owner / agent w/ write role | create base / doc / skill / folder | direct write, no CR | **auto-merged CR** → returns the VO, leaves a merged `change_request` |
+| Owner | add / edit a base field via the convenience endpoint | direct write | **auto-merged CR** → returns updated `BaseVO` |
+| Owner / admin | delete asset, purge node | direct write | **auto-merged CR** (recorded; purge is still a hard delete) |
+| Agent | propose a **record** (content) | CR → human review → merge | **unchanged** — still human-reviewed |
+| Agent | governed field/schema change (explicit CR endpoint) | CR → review → merge | **unchanged** |
+
+**The dividing line:** *structural / administrative* mutations auto-merge (recorded); *content* mutations (records) keep human review. All seven of today's direct writes are structural — none is a content record — so this line maps exactly onto them.
+
+## 3. User-perceived failure modes (what must NOT regress)
+
+- **F1 — "I called `createBase` and didn't get my base back."** The 5 VO-returning functions (`createBase`, `createBaseField`, `createDoc`, `updateDocBody`, `createSkill`) MUST keep returning the same VO synchronously. Callers: `domains/*/router.ts`, `apps/busabase-cloud/src/db/seed/seed-workbench.ts`, `apps/busabase/tests/busabase-pglite.test.ts`, `apps/busabase/scripts/verify-busabase-domains.ts`.
+- **F2 — "My content got merged without me."** No record/content path may become auto-merge. Auto-merge is gated to structural op kinds only.
+- **F3 — "Creating a folder then moving into it still needs two round-trips."** The original complaint. Must be fixable in one CR (temp-id).
+- **F4 — "The base created via a CR looks different from before."** The CR/materializer path must produce byte-identical node + base + field rows to today's direct `createBase`.
+- **F5 — double audit / broken history.** Each structural op must yield exactly one coherent CR (status `merged`) + its normal merge audit event — not a duplicate `base.created` *and* a `change_request.merged` that disagree.
+
+## 4. Acceptance criteria / test cases (derive from behavior, not internals)
+
+1. `createBase({slug,name,fields})` returns a `BaseVO` **and** `GET /change-requests` now lists a `merged` CR whose `primaryOperation` is `node_create`(base). (F1, F5)
+2. Same for `createDoc`, `createSkill`, `createBaseField`, `updateDocBody`, `deleteAsset`, `purgeNode`. (F1)
+3. A **record** create still returns an `in_review` CR and is **not** merged until a human `review approved` + `merge`. (F2)
+4. One node CR with `[{kind:create,tempId:"f1",nodeType:folder,...}, {kind:move,nodeId:X,parentTempId:"f1"}]` auto-merges and, on read-back, node X is a child of the newly-created folder. (F3)
+5. Rows produced by `createBase` (CR path) are diff-identical to a pre-change snapshot of direct `createBase` for the same input. (F4) — golden test.
+6. `pnpm db:generate` produces **zero** schema diff (we reuse existing `change_requests` / `operations` / `commits` tables). (migration safety)
+7. All existing busabase-core tests + `apps/busabase` e2e pass unchanged (consumer contracts preserved).
+
+## 5. Technical design
+
+### 5.1 One write model, one seam
+
+Reimplement each of the 7 direct-write functions as a thin wrapper over the existing CR machinery + a new **auto-merge** step, keeping the outer signature/return identical:
+
+```
+createBase(input): BaseVO
+  └─ createNodeChangeRequest({ operations:[{kind:create,nodeType:"base",...}], autoMerge:true })
+        ├─ (existing) insert change_request(in_review) + operation(pending) + commit
+        └─ autoMergeIfEligible(cr, actor)      // NEW
+              ├─ resolveReviewPolicy(op, target, actor) → { requiresHumanReview }
+              ├─ if requiresHumanReview → return cr (in_review)   // governed path
+              └─ else → approve(cr, system) → _mergeChangeRequest(cr) → return materialized VO
+```
+
+The merge already materializes a base node via `mergeNodeCreate` + the base materializer, so `createBase` becomes: build the CR, auto-merge, then `getBase(materializedNodeId)` → the same `BaseVO`. (Verify F4 with a golden test.)
+
+### 5.2 Auto-merge eligibility — `resolveReviewPolicy(op, target, actor)`
+
+The single decision function. Rules (MVP):
+
+- **Structural op kinds** (`node_create`/`node_rename`/`node_move`/`node_delete`/`node_restore`, base-field convenience, `asset_delete`, `node_purge`): **auto-merge** when the actor has a write role in the space (owner/admin/member-with-write). No human review.
+- **Content op kinds** (`record_*`): **always** `requiresHumanReview = true` (unless the caller is explicitly self-approving per today's rules). Never auto-merge by policy.
+- A space MAY later opt structural ops into governance via a space-level policy; out of scope for MVP (default = structural auto-merges).
+
+Auto-merge records a review row with reviewer = a **system actor** (e.g. `submittedBy` + `verdict:"approved", reason:"auto-merge: structural op"`) so the ledger is honest about *why* it merged without a human. This keeps "never approve your own *content* work" intact — it's scoped to structural ops and attributed.
+
+### 5.3 Temp-id references (one-CR folder + move)
+
+- Extend the node operation input union: `create` gains optional `tempId: string`; `move` (and any op needing a not-yet-real parent) gains optional `parentTempId: string` (mutually exclusive with `parentNodeId`).
+- Add `tempIdToNodeId: Map<string,string>` to `MergeCtx`. In `mergeNodeCreate`, after `id("nod")`, record `ctx.tempIdToNodeId.set(op.tempId, nodeId)`. In `mergeNodeMove` (and create-with-`parentTempId`), resolve `parentNodeId = op.parentNodeId ?? ctx.tempIdToNodeId.get(op.parentTempId)`; error if unresolved.
+- The merge loop is already sequential-in-transaction, so ordering holds. Validate at CR-create time that every `parentTempId` refers to a `create.tempId` earlier in the array.
+
+### 5.4 Collapse the doc dual path
+
+`updateDocBody` (direct) and the doc-edit CR both exist. Make `updateDocBody` an auto-merge structural CR (same as the rest) and delete the direct storage-write path, so there is one doc-write code path.
+
+### 5.5 Audit reconciliation (F5)
+
+Structural ops currently emit their own action (`base.created`, `doc.created`, …). After the change they flow through CR merge, which emits `change_request.created` + `change_request.merged`. Decision: **drop the bespoke `base.created`/`doc.created`/… emissions** from the (now CR-backed) functions and rely on the CR lifecycle events, so there's one coherent trail. Keep the action enum values for back-compat of historical rows. (`node.purged` stays as-is inside the purge op's merge.)
+
+## 6. Rollout / sequencing (safe, incremental)
+
+Each slice is independently shippable and preserves all consumer signatures:
+
+1. **S1 — infra:** add `autoMerge` support: `resolveReviewPolicy`, `autoMergeIfEligible`, a system-actor review row. No behavior change yet (nothing calls it).
+2. **S2 — nodes:** route `createNodeChangeRequest` structural ops through auto-merge; add temp-id. Fixes F3. Node create/move/rename now leave merged CRs.
+3. **S3 — base/doc/skill creates:** reimplement `createBase`, `createDoc`, `createSkill` over S2. Golden test for F4.
+4. **S4 — field + destructive:** `createBaseField`, `deleteAsset`, `purgeNode`; collapse `updateDocBody` (S4 = §5.4).
+5. **S5 — cleanup:** remove now-dead direct-insert code + reconcile audit emissions (§5.5).
+
+Ship S1–S3 first (covers the headline complaints), review, then S4–S5.
+
+## 7. Risks / open questions
+
+- **R1 — materializer parity (F4).** The base/doc/skill CR materializers must equal the direct-create inserts (fields, slugs, positions, storage prefixes). *Mitigation:* golden snapshot tests before/after per type.
+- **R2 — self-approval optics.** Auto-merge writes a system-actor approval. Confirm the review UI renders "auto-merged (structural)" distinctly from a human approval so trust isn't muddied.
+- **R3 — performance.** Structural creates now do CR+commit+merge in one tx instead of a single insert. Low volume (setup-time ops), acceptable; measure `createBase` latency in a seed run.
+- **Q1 — governance toggle.** Do we want a space-level "structural ops also require review" policy now, or defer? (Spec defers.)
+- **Q2 — `updateDocBody` removal.** Any external caller depends on the *direct* (non-CR) doc update semantics? Audit before deleting (§5.4).
+
+## 8. What does NOT change
+
+- Record (content) review flow, contracts, and VO/DTO shapes.
+- DB schema (reuses `change_requests`/`operations`/`commits`).
+- Consumer call sites — every public function keeps its signature and return type.
+- org/auth/member/api-key/settings writes stay **audit-only** (not content, no review need) — per the locked scope decision.

--- a/packages/busabase-core/src/context.ts
+++ b/packages/busabase-core/src/context.ts
@@ -47,6 +47,14 @@ export interface BusabaseContext {
   db?: BusabaseDatabase;
   actorId?: string;
   spaceId?: string;
+  /**
+   * API-key scoped environment variables injected by the host runtime.
+   *
+   * This is intentionally context-scoped rather than written to the host
+   * process.env: Busabase Cloud is a shared Node process, so per-key secrets must
+   * only be exposed to the request / hosted execution they belong to.
+   */
+  envVars?: Record<string, string>;
   /** When true, the request is served by the stateless demo router (no DB). */
   isDemo?: boolean;
   /**
@@ -85,6 +93,16 @@ export function getContextSpaceId(): string {
  */
 export function resolveActorId(inputActorId: string): string {
   return storage.getStore()?.actorId ?? inputActorId;
+}
+
+/** API-key scoped env values for the current hosted/request execution. */
+export function getContextEnvVars(): Record<string, string> {
+  return storage.getStore()?.envVars ?? {};
+}
+
+/** Read one API-key scoped env value from the current hosted/request execution. */
+export function getContextEnvVar(key: string): string | undefined {
+  return getContextEnvVars()[key];
 }
 
 /** True when the current request is served by the stateless demo router. */

--- a/packages/busabase-core/src/domains/base/logic/field-ops.ts
+++ b/packages/busabase-core/src/domains/base/logic/field-ops.ts
@@ -23,14 +23,19 @@ import {
   busabaseOperations,
 } from "../../../db/schema";
 import { insertAuditEvent } from "../../../logic/audit";
-import { closeChangeRequest, getChangeRequest } from "../../../logic/cr-lifecycle";
-import { id, now } from "../../../logic/kernel";
+import {
+  closeChangeRequest,
+  getChangeRequest,
+  recordMergedOperation,
+} from "../../../logic/cr-lifecycle";
+import { CURRENT_USER_ID, id, now } from "../../../logic/kernel";
 import { ensureReady } from "../../../logic/seed";
 import { fieldSchema } from "../../../logic/store";
 import { isSystemFieldType } from "../field-types";
 import { busabaseFieldValues } from "../schema";
 import { ConversionNotSupportedError, convertFieldValue } from "../utils/field-conversion";
 import { getBase } from "./queries";
+import { resolveRelationFieldOptions } from "./relation-options";
 
 export {
   convertFieldChangeRequestInputSchema,
@@ -51,7 +56,8 @@ export const createBaseField = async (baseId: string, input: z.infer<typeof fiel
     throw new Error(`Base not found: ${baseId}`);
   }
   const parsed = fieldSchema.parse(input);
-  if (parsed.type === "relation" && !parsed.options.targetBaseId) {
+  const options = await resolveRelationFieldOptions(db, parsed.options);
+  if (parsed.type === "relation" && !options.targetBaseId) {
     throw new Error("Relation field requires a target Base");
   }
   const [existing] = await db
@@ -77,17 +83,30 @@ export const createBaseField = async (baseId: string, input: z.infer<typeof fiel
     type: parsed.type,
     required: parsed.required,
     position: fieldCount,
-    options: parsed.options,
+    options,
   });
   const updatedBase = await getBase(base.id);
   if (!updatedBase) {
     throw new Error("Failed to create field");
   }
-  // Direct create (no change request) — record it so the audit trail is complete.
-  await insertAuditEvent(db, {
-    action: "field.created",
+  // Record the field add as an auto-merged ChangeRequest (audit + history +
+  // rollback), replacing the old bespoke `field.created` audit action.
+  await recordMergedOperation({
+    operation: "base_add_field",
+    targetType: "base",
     baseId: base.id,
-    metadata: { slug: parsed.slug, name: parsed.name, type: parsed.type },
+    fields: {
+      name: parsed.name,
+      slug: parsed.slug,
+      type: parsed.type,
+      required: parsed.required,
+      options: parsed.options,
+    },
+    message: `Add field ${parsed.slug}`,
+    submittedBy: resolveActorId(CURRENT_USER_ID),
+    reviewPolicySnapshot: base.reviewPolicy,
+    sourceMeta: { subject: "base_field", fieldSlug: parsed.slug },
+    auditMetadata: { fieldSlug: parsed.slug },
   });
   return updatedBase;
 };
@@ -104,7 +123,8 @@ export const createFieldChangeRequest = async (
   }
 
   const parsed = createFieldChangeRequestInputSchema.parse(input);
-  if (parsed.type === "relation" && !parsed.options.targetBaseId) {
+  const options = await resolveRelationFieldOptions(db, parsed.options);
+  if (parsed.type === "relation" && !options.targetBaseId) {
     throw new Error("Relation field requires a target Base");
   }
   const [existing] = await db
@@ -131,7 +151,7 @@ export const createFieldChangeRequest = async (
     slug: parsed.slug,
     type: parsed.type,
     required: parsed.required,
-    options: parsed.options,
+    options,
   };
 
   await db.insert(busabaseCommits).values({
@@ -324,13 +344,17 @@ export const createUpdateFieldChangeRequest = async (
   const operationId = id("opr");
   const commitId = id("cmt");
   const timestamp = now();
+  const options =
+    patch.options !== undefined
+      ? await resolveRelationFieldOptions(db, patch.options)
+      : field.options;
   const fields = {
     fieldId: field.id,
     slug: field.slug,
     name: patch.name ?? iStringFromText(field.name),
     type: field.type,
     required: patch.required ?? field.required,
-    options: patch.options !== undefined ? patch.options : field.options,
+    options,
   };
 
   await db.insert(busabaseCommits).values({

--- a/packages/busabase-core/src/domains/base/logic/merge/base.ts
+++ b/packages/busabase-core/src/domains/base/logic/merge/base.ts
@@ -16,6 +16,7 @@ import {
 import type { MergeCtx } from "../../../../logic/cr-lifecycle";
 import { id } from "../../../../logic/kernel";
 import { type MaterializeArgs, registerMaterializer } from "../../../../logic/materialize";
+import { resolveRelationFieldOptions } from "../relation-options";
 
 export const materializeBaseNode = async (
   ctx: MergeCtx,
@@ -51,25 +52,30 @@ export const materializeBaseNode = async (
       ? fields.fields
       : [{ slug: "title", name: "Title", type: "text" as const, required: true, options: {} }];
   await db.insert(busabaseBaseFields).values(
-    (
-      baseFields as Array<{
-        slug: string;
-        name: import("openlib/i18n/i-string").iString;
-        type?: import("busabase-contract/types").FieldType;
-        required?: boolean;
-        options?: Record<string, unknown>;
-      }>
-    ).map((field, index) => ({
-      id: id("bsf"),
-      spaceId: getContextSpaceId(),
-      baseId,
-      slug: field.slug,
-      name: iStringToText(field.name),
-      type: field.type ?? "text",
-      required: field.required ?? false,
-      position: index,
-      options: field.options ?? {},
-    })),
+    await Promise.all(
+      (
+        baseFields as Array<{
+          slug: string;
+          name: import("openlib/i18n/i-string").iString;
+          type?: import("busabase-contract/types").FieldType;
+          required?: boolean;
+          options?: Record<string, unknown>;
+        }>
+      ).map(async (field, index) => ({
+        id: id("bsf"),
+        spaceId: getContextSpaceId(),
+        baseId,
+        slug: field.slug,
+        name: iStringToText(field.name),
+        type: field.type ?? "text",
+        required: field.required ?? false,
+        position: index,
+        // Resolve targetBaseSlug → id on the SAME merge transaction (ctx.db) — a
+        // node-CR base-create commit stores field options verbatim, so this is
+        // where the node path's relation slug is resolved.
+        options: await resolveRelationFieldOptions(db, field.options ?? {}),
+      })),
+    ),
   );
   return baseNodeId;
 };

--- a/packages/busabase-core/src/domains/base/logic/record-ops.ts
+++ b/packages/busabase-core/src/domains/base/logic/record-ops.ts
@@ -16,9 +16,9 @@ import {
   busabaseRecords,
 } from "../../../db/schema";
 import { insertAuditEvent } from "../../../logic/audit";
-import { getChangeRequest } from "../../../logic/cr-lifecycle";
+import { getChangeRequest, recordMergedNodeCreate } from "../../../logic/cr-lifecycle";
 import { projectCommitFields } from "../../../logic/field-values";
-import { id, now, rootNodeIdForSpace } from "../../../logic/kernel";
+import { CURRENT_USER_ID, id, now, rootNodeIdForSpace } from "../../../logic/kernel";
 import { ensureReady } from "../../../logic/seed";
 import {
   createBaseInputSchema,
@@ -30,6 +30,7 @@ import {
 import { validateRecordFields } from "../field-rules";
 import type { FieldDef } from "../field-types";
 import { getBase } from "./queries";
+import { resolveRelationFieldOptions } from "./relation-options";
 
 export {
   createBaseInputSchema,
@@ -154,17 +155,19 @@ export const createBase = async (input: z.infer<typeof createBaseInputSchema>) =
   });
   if (parsed.fields.length > 0) {
     await db.insert(busabaseBaseFields).values(
-      parsed.fields.map((field, index) => ({
-        id: id("bsf"),
-        spaceId,
-        baseId,
-        slug: field.slug,
-        name: iStringToText(field.name),
-        type: field.type,
-        required: field.required,
-        position: index,
-        options: field.options,
-      })),
+      await Promise.all(
+        parsed.fields.map(async (field, index) => ({
+          id: id("bsf"),
+          spaceId,
+          baseId,
+          slug: field.slug,
+          name: iStringToText(field.name),
+          type: field.type,
+          required: field.required,
+          position: index,
+          options: await resolveRelationFieldOptions(db, field.options),
+        })),
+      ),
     );
   }
 
@@ -172,11 +175,18 @@ export const createBase = async (input: z.infer<typeof createBaseInputSchema>) =
   if (!base) {
     throw new Error("Failed to create base");
   }
-  // Direct create (no change request) — record it so the audit trail is complete.
-  await insertAuditEvent(db, {
-    action: "base.created",
+  // Record the create as an auto-merged structural ChangeRequest (audit +
+  // history + rollback), replacing the old bespoke `base.created` audit action.
+  await recordMergedNodeCreate({
+    nodeId,
     baseId,
-    metadata: { slug: parsed.slug, name: parsed.name, nodeId },
+    nodeType: "base",
+    slug: parsed.slug,
+    name: parsed.name,
+    description: parsed.description,
+    parentNodeId: parentNode.id,
+    message: `Create base ${parsed.name}`,
+    submittedBy: resolveActorId(CURRENT_USER_ID),
   });
   return base;
 };

--- a/packages/busabase-core/src/domains/base/logic/relation-options.ts
+++ b/packages/busabase-core/src/domains/base/logic/relation-options.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { ORPCError } from "@orpc/server";
+import { and, eq, isNull } from "drizzle-orm";
+import { getContextSpaceId } from "../../../context";
+import type { getDb } from "../../../db";
+import { busabaseBases } from "../../../db/schema";
+
+/**
+ * Let a relation field name its target Base by **slug** instead of the raw
+ * `bse_...` id: agents rarely know the id but always know the slug they just chose.
+ * Given a field's `options`, if `targetBaseSlug` is present, resolve it to
+ * `targetBaseId` (scoped to the active space, active bases only) and drop the slug
+ * so what persists is always the canonical id.
+ *
+ * Idempotent and safe to run on every field: a no-op when there's no
+ * `targetBaseSlug`, and an explicit `targetBaseId` always wins (the slug is just an
+ * alias). Run at the point user input is first accepted so downstream commits,
+ * merges, and relation links only ever see a real id.
+ *
+ * Takes the `db` handle explicitly (rather than calling `getDb()`) so it can run
+ * both outside a transaction (create paths) and INSIDE the merge transaction via
+ * `ctx.db` — re-acquiring the getDb() singleton mid-transaction deadlocks pglite.
+ */
+export const resolveRelationFieldOptions = async <T extends Record<string, unknown>>(
+  db: Awaited<ReturnType<typeof getDb>>,
+  options: T,
+): Promise<T> => {
+  const slug = options.targetBaseSlug;
+  if (typeof slug !== "string" || slug.length === 0) {
+    return options;
+  }
+
+  const resolved: Record<string, unknown> = { ...options };
+  delete resolved.targetBaseSlug;
+
+  // An explicit id wins — the slug was a convenience alias, so just drop it.
+  if (typeof options.targetBaseId === "string" && options.targetBaseId.length > 0) {
+    return resolved as T;
+  }
+
+  const [target] = await db
+    .select({ id: busabaseBases.id })
+    .from(busabaseBases)
+    .where(
+      and(
+        eq(busabaseBases.slug, slug),
+        eq(busabaseBases.spaceId, getContextSpaceId()),
+        isNull(busabaseBases.archivedAt),
+      ),
+    )
+    .limit(1);
+  if (!target) {
+    throw new ORPCError("BAD_REQUEST", {
+      message: `Relation target base not found by slug "${slug}". Pass an existing active Base slug, or its targetBaseId.`,
+      data: { targetBaseSlug: slug },
+    });
+  }
+  resolved.targetBaseId = target.id;
+  return resolved as T;
+};

--- a/packages/busabase-core/src/domains/dashboard/hooks/use-live-sync.ts
+++ b/packages/busabase-core/src/domains/dashboard/hooks/use-live-sync.ts
@@ -1,0 +1,143 @@
+"use client";
+
+import { consumeEventIterator } from "@orpc/client";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
+import type { liveEventSchema } from "busabase-contract/contract/busabase";
+import { useEffect, useMemo } from "react";
+import type { z } from "zod";
+
+type BusabaseLiveEvent = z.infer<typeof liveEventSchema>;
+
+interface UseBusabaseLiveSyncOptions {
+  actorId?: string | null;
+  activeBaseId?: string | null;
+  listKeys: {
+    archivedBases: QueryKey;
+    archivedNodes: QueryKey;
+    auditEvents: QueryKey;
+    bases: QueryKey;
+    changeRequests: QueryKey;
+    nodes: QueryKey;
+    records: QueryKey;
+  };
+  orpc: BusabaseQueryUtils;
+  queryClient: QueryClient;
+}
+
+export function useBusabaseLiveSync({
+  actorId,
+  activeBaseId,
+  listKeys,
+  orpc,
+  queryClient,
+}: UseBusabaseLiveSyncOptions) {
+  const stableListKeys = useMemo(
+    () => listKeys,
+    [
+      listKeys.archivedBases,
+      listKeys.archivedNodes,
+      listKeys.auditEvents,
+      listKeys.bases,
+      listKeys.changeRequests,
+      listKeys.nodes,
+      listKeys.records,
+      listKeys,
+    ],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    let unsubscribe: (() => Promise<void>) | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const invalidateBaseScope = (baseId: string) => {
+      void queryClient.invalidateQueries({
+        queryKey: orpc.bases.listViews.queryOptions({ input: { baseId } }).queryKey,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: orpc.bases.listArchivedViews.queryOptions({ input: { baseId } }).queryKey,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: orpc.bases.listArchivedRecords.queryOptions({ input: { baseId } }).queryKey,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: orpc.bases.listDeletedFields.queryOptions({ input: { baseId } }).queryKey,
+      });
+    };
+
+    const invalidateWorkspace = () => {
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.nodes });
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.archivedNodes });
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.bases });
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.archivedBases });
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.records });
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.changeRequests });
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.auditEvents });
+      if (activeBaseId) {
+        invalidateBaseScope(activeBaseId);
+      }
+    };
+
+    const handleEvent = (event: BusabaseLiveEvent) => {
+      // Local mutations already invalidate their own queries in mutation handlers.
+      // Skipping same-actor live events avoids an immediate duplicate refresh while
+      // still letting other collaborators' merged CRs update this tab.
+      if (actorId && event.actorId === actorId) {
+        return;
+      }
+
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.changeRequests });
+      void queryClient.invalidateQueries({ queryKey: stableListKeys.auditEvents });
+
+      if (event.nodeIds.length > 0) {
+        void queryClient.invalidateQueries({ queryKey: stableListKeys.nodes });
+        void queryClient.invalidateQueries({ queryKey: stableListKeys.archivedNodes });
+        void queryClient.invalidateQueries({ queryKey: stableListKeys.bases });
+        void queryClient.invalidateQueries({ queryKey: stableListKeys.archivedBases });
+      }
+
+      if (event.recordIds.length > 0 || event.viewIds.length > 0 || event.baseId) {
+        void queryClient.invalidateQueries({ queryKey: stableListKeys.records });
+        void queryClient.invalidateQueries({ queryKey: stableListKeys.bases });
+        void queryClient.invalidateQueries({ queryKey: stableListKeys.archivedBases });
+        if (event.baseId) {
+          invalidateBaseScope(event.baseId);
+        }
+      }
+    };
+
+    const connect = () => {
+      if (cancelled) {
+        return;
+      }
+
+      // Redis pub/sub does not retain history. Refresh on every reconnect so a
+      // temporarily disconnected tab still converges to the latest workspace state.
+      invalidateWorkspace();
+      unsubscribe = consumeEventIterator(orpc.live.subscribe.call(undefined), {
+        onEvent: handleEvent,
+        onError: () => {
+          if (!cancelled) {
+            retryTimer = setTimeout(connect, 3000);
+          }
+        },
+        onSuccess: () => {
+          if (!cancelled) {
+            retryTimer = setTimeout(connect, 3000);
+          }
+        },
+      });
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+      }
+      void unsubscribe?.();
+    };
+  }, [activeBaseId, actorId, orpc, queryClient, stableListKeys]);
+}

--- a/packages/busabase-core/src/domains/dashboard/index.tsx
+++ b/packages/busabase-core/src/domains/dashboard/index.tsx
@@ -58,6 +58,7 @@ import type {
 } from "./helpers/view-types";
 import { useAttachmentUpload } from "./hooks/use-attachment-upload";
 import { useDashboardRoutes } from "./hooks/use-dashboard-routes";
+import { useBusabaseLiveSync } from "./hooks/use-live-sync";
 import { getNodeDetail } from "./node-detail-registry";
 
 interface BusabaseDashboardProps {
@@ -134,6 +135,7 @@ function BusabaseDashboardContent({
   const archivedBasesList = orpc.bases.listArchived.queryOptions({});
   const archivedNodesList = orpc.nodes.listArchived.queryOptions({});
   const auditEventsList = orpc.auditEvents.list.queryOptions({ input: {} });
+  const authInfoQuery = useQuery(orpc.auth.verify.queryOptions({}));
   const changeRequestsQuery = useQuery({
     ...changeRequestsList,
     initialData: initialChangeRequests,
@@ -152,9 +154,12 @@ function BusabaseDashboardContent({
   // Stable query keys for cache writes/invalidation (orpc is memoized on apiBasePath).
   const listKeys = useMemo(
     () => ({
+      archivedBases: orpc.bases.listArchived.queryOptions({}).queryKey as QueryKey,
+      archivedNodes: orpc.nodes.listArchived.queryOptions({}).queryKey as QueryKey,
       changeRequests: orpc.changeRequests.list.queryOptions({ input: {} }).queryKey as QueryKey,
       records: orpc.records.list.queryOptions({ input: {} }).queryKey as QueryKey,
       bases: orpc.bases.list.queryOptions({}).queryKey as QueryKey,
+      nodes: orpc.nodes.list.queryOptions({}).queryKey as QueryKey,
       auditEvents: orpc.auditEvents.list.queryOptions({ input: {} }).queryKey as QueryKey,
     }),
     [orpc],
@@ -217,6 +222,13 @@ function BusabaseDashboardContent({
         : (bases[0] ?? null),
     [selectedBaseSlug, bases],
   );
+  useBusabaseLiveSync({
+    actorId: authInfoQuery.data?.user.id,
+    activeBaseId: activeBase?.id,
+    listKeys,
+    orpc,
+    queryClient,
+  });
   // Deleted fields scoped to the active base (for the Design tab).
   const deletedFieldsQuery = useQuery({
     ...orpc.bases.listDeletedFields.queryOptions({ input: { baseId: activeBase?.id ?? "" } }),

--- a/packages/busabase-core/src/domains/doc/handlers.ts
+++ b/packages/busabase-core/src/domains/doc/handlers.ts
@@ -9,7 +9,7 @@ import type { NodeVO } from "busabase-contract/types";
 import { and, asc, eq, isNull } from "drizzle-orm";
 import { storage } from "openlib/storage";
 import type { z } from "zod";
-import { getContextSpaceId } from "../../context";
+import { getContextSpaceId, resolveActorId } from "../../context";
 import { getDb } from "../../db";
 import {
   busabaseChangeRequests,
@@ -22,7 +22,7 @@ import {
 } from "../../db/schema";
 // Doc handlers consume the kernel substrate one-way (no cycle). Doc is storage-backed,
 // so it owns no DB tables — its body lives in object storage.
-import { id, now, rootNodeIdForSpace } from "../../logic/kernel";
+import { CURRENT_USER_ID, id, now, rootNodeIdForSpace } from "../../logic/kernel";
 import { type MaterializeArgs, registerMaterializer } from "../../logic/materialize";
 import {
   ensureReady,
@@ -30,6 +30,8 @@ import {
   insertAuditEvent,
   loadNodesByIds,
   type MergeCtx,
+  recordMergedNodeCreate,
+  recordMergedOperation,
   toNodeVO,
 } from "../../logic/store";
 import { syncDocAssetUsages } from "../assets/handlers";
@@ -134,10 +136,17 @@ export const createDoc = async (input: z.input<typeof createDocInputSchema>): Pr
   if (!node) {
     throw new Error("Failed to create doc node");
   }
-  // Direct create (no change request) — record it so the audit trail is complete.
-  await insertAuditEvent(db, {
-    action: "doc.created",
-    metadata: { nodeId, slug: node.slug, name: node.name },
+  // Record the create as an auto-merged structural ChangeRequest (audit + history
+  // + rollback), replacing the old bespoke `doc.created` audit action.
+  await recordMergedNodeCreate({
+    nodeId,
+    nodeType: "doc",
+    slug: node.slug,
+    name: node.name,
+    description: node.description,
+    parentNodeId: parentNode.id,
+    message: `Create doc ${node.name}`,
+    submittedBy: resolveActorId(CURRENT_USER_ID),
   });
   return toDocVO(node);
 };
@@ -173,9 +182,18 @@ export const updateDocBody = async (
   }
   const parsed = updateDocInputSchema.parse(input);
   await writeDocBody(node.id, parsed.body);
-  // Direct edit (no change request) — record it so the audit trail is complete.
-  const db = await getDb();
-  await insertAuditEvent(db, { action: "doc.updated", metadata: { nodeId: node.id } });
+  // Record the body edit as an auto-merged doc_update ChangeRequest (audit +
+  // history + rollback), replacing the old bespoke `doc.updated` audit action —
+  // the same doc_update op shape the reviewed `createDocChangeRequest` path uses.
+  await recordMergedOperation({
+    operation: "doc_update",
+    targetType: "node",
+    nodeId: node.id,
+    fields: { body: parsed.body },
+    message: `Update doc ${node.name}`,
+    submittedBy: resolveActorId(CURRENT_USER_ID),
+    sourceMeta: { subject: "doc", nodeId: node.id },
+  });
   return toDocVO(node);
 };
 

--- a/packages/busabase-core/src/domains/skill/handlers.ts
+++ b/packages/busabase-core/src/domains/skill/handlers.ts
@@ -7,7 +7,7 @@ import {
 import type { SkillVO } from "busabase-contract/types";
 import { and, asc, eq, isNull } from "drizzle-orm";
 import type { z } from "zod";
-import { getContextSpaceId } from "../../context";
+import { getContextSpaceId, resolveActorId } from "../../context";
 import { getDb } from "../../db";
 import {
   busabaseChangeRequests,
@@ -22,7 +22,7 @@ import {
 // helpers + id/now) from the kernel residue. This is a one-way import — the kernel
 // never imports skill handlers — so there is no cycle. The kernel keeps the skill
 // storage helpers because the seed + merge dispatcher also use them.
-import { hashText, id, now, rootNodeIdForSpace } from "../../logic/kernel";
+import { CURRENT_USER_ID, hashText, id, now, rootNodeIdForSpace } from "../../logic/kernel";
 import { type MaterializeArgs, registerMaterializer } from "../../logic/materialize";
 import {
   ensureReady,
@@ -30,6 +30,7 @@ import {
   insertAuditEvent,
   loadNodesByIds,
   type MergeCtx,
+  recordMergedNodeCreate,
   toNodeVO,
 } from "../../logic/store";
 import {
@@ -112,10 +113,17 @@ export const createSkill = async (input: z.input<typeof createSkillInputSchema>)
     await writeSkillTextFile(node, file.path, file.content);
   }
 
-  // Direct create (no change request) — record it so the audit trail is complete.
-  await insertAuditEvent(db, {
-    action: "skill.created",
-    metadata: { nodeId, slug: parsed.slug, name: parsed.name },
+  // Record the create as an auto-merged structural ChangeRequest (audit + history
+  // + rollback), replacing the old bespoke `skill.created` audit action.
+  await recordMergedNodeCreate({
+    nodeId,
+    nodeType: "skill",
+    slug: parsed.slug,
+    name: parsed.name,
+    description: parsed.description,
+    parentNodeId: parentNode.id,
+    message: `Create skill ${parsed.name}`,
+    submittedBy: resolveActorId(CURRENT_USER_ID),
   });
   return getSkill(nodeId);
 };

--- a/packages/busabase-core/src/logic/base-schemas.ts
+++ b/packages/busabase-core/src/logic/base-schemas.ts
@@ -71,6 +71,9 @@ const fieldOptionsSchema = z
       })
       .optional(),
     targetBaseId: z.string().optional(),
+    // Convenience alias for `targetBaseId`: name the relation target by Base slug.
+    // Resolved to `targetBaseId` on write; never persisted.
+    targetBaseSlug: z.string().optional(),
   })
   .default({});
 

--- a/packages/busabase-core/src/logic/cr-lifecycle.ts
+++ b/packages/busabase-core/src/logic/cr-lifecycle.ts
@@ -62,6 +62,7 @@ import {
   requireBaseId,
   rootNodeIdForSpace,
 } from "./kernel";
+import { publishBusabaseLiveEvent } from "./live-events";
 import { getMaterializer, type MaterializeArgs, type NodeCreateFields } from "./materialize";
 import { loadNodesByIds } from "./nodes";
 import { ensureReady, loadBasesByIds } from "./seed";
@@ -832,6 +833,16 @@ export const reviewChangeRequest = async (
   if (!changeRequest) {
     throw new Error(`ChangeRequest not found: ${changeRequestId}`);
   }
+  // Idempotent for already-merged CRs: structural CRs auto-merge on create, so a
+  // caller still following the old create→review→merge flow (e.g. the CLI/skills)
+  // must not error here — return the merged CR unchanged.
+  if (changeRequest.status === "merged") {
+    const already = await getChangeRequest(changeRequest.id);
+    if (!already) {
+      throw new Error("Failed to load merged changeRequest");
+    }
+    return already;
+  }
   if (changeRequest.status !== "in_review" && changeRequest.status !== "changes_requested") {
     throw new Error(`ChangeRequest is not reviewable: ${changeRequest.status}`);
   }
@@ -894,6 +905,252 @@ export const reviewChangeRequest = async (
   }
   return updated;
 };
+
+// ── Auto-merge (structural ops) ─────────────────────────────────────────────
+//
+// Every content-tree mutation flows through a ChangeRequest so it is auditable,
+// reviewable, and revertable. STRUCTURAL / administrative ops (folder / base /
+// doc / skill scaffolding, schema convenience, destructive admin) don't need a
+// human in the loop — they auto-merge here, but still leave a first-class merged
+// CR. CONTENT ops (record_*) — the reviewable material busabase exists to gate —
+// never take this path; they keep the human review loop.
+
+/**
+ * Reviewer id stamped on the auto-approval row so history is honest that the
+ * merge was machine-driven, not a human approval. Not a real user — `reviewerId`
+ * is a plain text column (no FK), and the one-vote-per-CR unique index is keyed
+ * by reviewer, so this never collides with a later human vote.
+ */
+export const AUTO_MERGE_REVIEWER_ID = "system:auto-merge";
+
+/** True when any operation is reviewable content (a record change). */
+const changeRequestHasContentOps = (operations: OperationPO[]): boolean =>
+  operations.some((op) => op.operation.startsWith("record_"));
+
+/**
+ * Approve `changeRequestId` as the system reviewer and merge it in one step — the
+ * structural-op fast path that keeps `createBase` / `createDoc` / … feeling
+ * instant while still recording a merged CR. Refuses to touch a CR that carries
+ * any content (record) operation, so content review can never be bypassed here.
+ * Returns the same `_mergeChangeRequest` result (CR now `merged`, plus any
+ * materialized record/view), so callers can hydrate the created VO.
+ */
+export const autoApproveAndMerge = async (
+  changeRequestId: string,
+  reason = "Auto-merged: structural change",
+) => {
+  await ensureReady();
+  const db = await getDb();
+  const [changeRequest] = await db
+    .select()
+    .from(busabaseChangeRequests)
+    .where(eq(busabaseChangeRequests.id, changeRequestId))
+    .limit(1);
+  if (!changeRequest) {
+    throw new Error(`ChangeRequest not found: ${changeRequestId}`);
+  }
+  if (changeRequest.status !== "in_review" && changeRequest.status !== "changes_requested") {
+    throw new Error(`ChangeRequest is not auto-mergeable: ${changeRequest.status}`);
+  }
+
+  const operations = await db
+    .select()
+    .from(busabaseOperations)
+    .where(eq(busabaseOperations.changeRequestId, changeRequest.id));
+  if (operations.length === 0) {
+    throw new Error(`ChangeRequest has no operations: ${changeRequest.id}`);
+  }
+  // Safety net for F2: a content CR must never auto-merge, whatever the caller.
+  if (changeRequestHasContentOps(operations)) {
+    throw new Error("Refusing to auto-merge a content (record) change request");
+  }
+
+  const timestamp = now();
+  await db
+    .insert(busabaseReviews)
+    .values({
+      id: id("rev"),
+      changeRequestId: changeRequest.id,
+      reviewerId: AUTO_MERGE_REVIEWER_ID,
+      verdict: "approved",
+      reason,
+      visibleOperationHeads: {},
+      createdAt: timestamp,
+    })
+    .onConflictDoUpdate({
+      target: [busabaseReviews.changeRequestId, busabaseReviews.reviewerId],
+      set: { verdict: "approved", reason, createdAt: timestamp },
+    });
+  await db
+    .update(busabaseChangeRequests)
+    .set({
+      status: "approved",
+      rejectedReason: null,
+      reviewedAt: timestamp,
+      updatedAt: timestamp,
+    })
+    .where(eq(busabaseChangeRequests.id, changeRequest.id));
+  await insertAuditEvent(db, {
+    action: "change_request.reviewed",
+    actorId: CURRENT_USER_ID,
+    baseId: changeRequest.baseId,
+    changeRequestId: changeRequest.id,
+    metadata: { verdict: "approved", auto: true },
+  });
+
+  return mergeChangeRequest(changeRequest.id);
+};
+
+/**
+ * Record an already-performed structural mutation as a **merged** ChangeRequest —
+ * so a direct write (`createBase`/`createDoc`/`createSkill`, `createBaseField`,
+ * `updateDocBody`) still leaves a first-class, auditable, history-visible CR
+ * without re-running the merge (the rows already exist; the per-type materializers
+ * are NOT input-parity with the direct writes — a doc's body / a base's exact
+ * fields would be lost). Writes the same ledger shape the create→auto-merge path
+ * produces (CR + commit + merged operation + system review + the three CR audit
+ * events), so history/UI render it identically. This is what replaces the old
+ * bespoke `base.created` / `doc.created` / `skill.created` / `field.created` /
+ * `doc.updated` audit actions.
+ */
+export const recordMergedOperation = async (args: {
+  operation: OperationPO["operation"];
+  targetType: "node" | "base";
+  nodeId?: string | null;
+  baseId?: string | null;
+  fields: Record<string, unknown>;
+  message: string;
+  submittedBy: string;
+  sourceMeta?: Record<string, unknown>;
+  reviewPolicySnapshot?: Record<string, unknown>;
+  mergeSummary?: Record<string, unknown>;
+  auditMetadata?: Record<string, unknown>;
+}): Promise<string> => {
+  const db = await getDb();
+  const timestamp = now();
+  const changeRequestId = id("crq");
+  const operationId = id("opr");
+  const commitId = id("cmt");
+  const nodeId = args.nodeId ?? null;
+  const baseId = args.baseId ?? null;
+  const mergeSummary = args.mergeSummary ?? {};
+
+  await db.insert(busabaseChangeRequests).values({
+    id: changeRequestId,
+    baseId,
+    targetType: args.targetType,
+    nodeId,
+    status: "merged",
+    submittedBy: args.submittedBy,
+    sourceMeta: { ...(args.sourceMeta ?? {}), autoMerged: true },
+    reviewPolicySnapshot: args.reviewPolicySnapshot ?? { kind: "single", requiredApprovals: 1 },
+    mergeSummary,
+    rejectedReason: null,
+    reviewedAt: timestamp,
+    mergedAt: timestamp,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  await db.insert(busabaseCommits).values({
+    id: commitId,
+    baseId,
+    targetType: args.targetType,
+    nodeId,
+    operationId,
+    parentCommitId: null,
+    fields: args.fields,
+    operation: args.operation,
+    message: args.message,
+    author: args.submittedBy,
+    createdAt: timestamp,
+  });
+  await db.insert(busabaseOperations).values({
+    id: operationId,
+    changeRequestId,
+    baseId,
+    targetType: args.targetType,
+    nodeId,
+    operation: args.operation,
+    status: "merged",
+    targetRecordId: null,
+    targetViewId: null,
+    filePath: null,
+    sourceRecordId: null,
+    sourceCommitId: null,
+    baseCommitId: null,
+    headCommitId: commitId,
+    deleteMode: "archive",
+    mergedRecordId: null,
+    mergedViewId: null,
+    position: 0,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  await db.insert(busabaseReviews).values({
+    id: id("rev"),
+    changeRequestId,
+    reviewerId: AUTO_MERGE_REVIEWER_ID,
+    verdict: "approved",
+    reason: "Auto-merged: structural change",
+    visibleOperationHeads: {},
+    createdAt: timestamp,
+  });
+
+  await insertAuditEvent(db, {
+    action: "change_request.created",
+    actorId: args.submittedBy,
+    baseId,
+    changeRequestId,
+    metadata: { operation: args.operation, autoMerged: true, ...(args.auditMetadata ?? {}) },
+  });
+  await insertAuditEvent(db, {
+    action: "change_request.reviewed",
+    actorId: CURRENT_USER_ID,
+    baseId,
+    changeRequestId,
+    metadata: { verdict: "approved", auto: true },
+  });
+  await insertAuditEvent(db, {
+    action: "change_request.merged",
+    actorId: CURRENT_USER_ID,
+    baseId,
+    changeRequestId,
+    metadata: { operation: args.operation, ...mergeSummary },
+  });
+  return changeRequestId;
+};
+
+/** `recordMergedOperation` specialized to a node_create (base/doc/skill/folder). */
+export const recordMergedNodeCreate = async (args: {
+  nodeId: string;
+  baseId?: string | null;
+  nodeType: string;
+  slug: string;
+  name: string;
+  description?: string;
+  parentNodeId: string;
+  message: string;
+  submittedBy: string;
+}): Promise<string> =>
+  recordMergedOperation({
+    operation: "node_create",
+    targetType: "node",
+    nodeId: args.nodeId,
+    baseId: args.baseId ?? null,
+    fields: {
+      kind: "create",
+      nodeType: args.nodeType,
+      parentNodeId: args.parentNodeId,
+      slug: args.slug,
+      name: args.name,
+      description: args.description ?? "",
+    },
+    message: args.message,
+    submittedBy: args.submittedBy,
+    sourceMeta: { subject: "node_tree" },
+    mergeSummary: { mergedNodeIds: [args.nodeId] },
+    auditMetadata: { nodeType: args.nodeType },
+  });
 
 export const closeChangeRequest = async (changeRequestId: string, reason?: string) => {
   await ensureReady();
@@ -1062,6 +1319,15 @@ const _mergeChangeRequest = async (changeRequestId: string) => {
   if (!changeRequest) {
     throw new Error(`ChangeRequest not found: ${changeRequestId}`);
   }
+  // Idempotent for already-merged CRs (structural CRs auto-merge on create): a
+  // caller re-merging via the old flow gets the merged CR back, not an error.
+  if (changeRequest.status === "merged") {
+    const already = await getChangeRequest(changeRequest.id);
+    if (!already) {
+      throw new Error("Failed to load merged changeRequest");
+    }
+    return { changeRequest: already, record: null, view: null };
+  }
   if (changeRequest.status !== "approved") {
     throw new Error("ChangeRequest must be approved before merge");
   }
@@ -1179,6 +1445,17 @@ const _mergeChangeRequest = async (changeRequestId: string) => {
       baseId: null,
       changeRequestId: changeRequest.id,
       metadata: { mergedNodeIds: [...new Set(mergedNodeIds)] },
+    });
+    await publishBusabaseLiveEvent({
+      kind: "change_request.merged",
+      spaceId: getContextSpaceId(),
+      actorId: changeRequest.submittedBy,
+      changeRequestId: changeRequest.id,
+      baseId: null,
+      nodeIds: [...new Set(mergedNodeIds)],
+      recordIds: [],
+      viewIds: [],
+      operationCount: operationKinds.length,
     });
     const updated = await getChangeRequest(changeRequest.id);
     if (!updated) {
@@ -1445,6 +1722,17 @@ const _mergeChangeRequest = async (changeRequestId: string) => {
       recordIds: mergedRecordIds,
       viewIds: mergedViewIds,
     },
+  });
+  await publishBusabaseLiveEvent({
+    kind: "change_request.merged",
+    spaceId: getContextSpaceId(),
+    actorId: changeRequest.submittedBy,
+    changeRequestId: changeRequest.id,
+    baseId: changeRequest.baseId,
+    nodeIds: [],
+    recordIds: [...new Set(mergedRecordIds)],
+    viewIds: [...new Set(mergedViewIds)],
+    operationCount: operationKinds.length,
   });
 
   const updatedChangeRequest = await getChangeRequest(changeRequest.id);

--- a/packages/busabase-core/src/logic/live-events.ts
+++ b/packages/busabase-core/src/logic/live-events.ts
@@ -1,0 +1,46 @@
+import type { liveEventSchema } from "busabase-contract/contract/busabase";
+import { publishRealtimeMessage, subscribeRealtimeMessages } from "openlib/realtime";
+import type { z } from "zod";
+
+export type BusabaseLiveEvent = z.infer<typeof liveEventSchema>;
+
+const channelForSpace = (spaceId: string) => `busabase:live:${spaceId}`;
+
+export const publishBusabaseLiveEvent = async (event: BusabaseLiveEvent) => {
+  await publishRealtimeMessage(channelForSpace(event.spaceId), event);
+};
+
+export async function* subscribeBusabaseLiveEvents(
+  spaceId: string,
+  signal?: AbortSignal,
+): AsyncGenerator<BusabaseLiveEvent> {
+  const queue: BusabaseLiveEvent[] = [];
+  let wake: (() => void) | null = null;
+
+  const unsubscribe = subscribeRealtimeMessages<BusabaseLiveEvent>(
+    channelForSpace(spaceId),
+    (event) => {
+      queue.push(event);
+      wake?.();
+      wake = null;
+    },
+    signal,
+  );
+
+  try {
+    while (!signal?.aborted) {
+      const next = queue.shift();
+      if (next) {
+        yield next;
+        continue;
+      }
+
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+        signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+    }
+  } finally {
+    unsubscribe();
+  }
+}

--- a/packages/busabase-core/src/logic/nodes.ts
+++ b/packages/busabase-core/src/logic/nodes.ts
@@ -366,10 +366,10 @@ export const createNodeChangeRequest = async (
     metadata: { operation: "node_tree_update" },
   });
 
-  const { getChangeRequest } = await import("./cr-lifecycle");
-  const changeRequest = await getChangeRequest(changeRequestId);
-  if (!changeRequest) {
-    throw new Error("Failed to create node change request");
-  }
-  return changeRequest;
+  // Structural node ops auto-merge: the CR is recorded (audit/history/rollback)
+  // but doesn't wait on a human, so folder/base/skill/doc scaffolding feels
+  // instant. Content (record) CRs never reach this path — see autoApproveAndMerge.
+  const { autoApproveAndMerge } = await import("./cr-lifecycle");
+  const merged = await autoApproveAndMerge(changeRequestId);
+  return merged.changeRequest;
 };

--- a/packages/busabase-core/src/openapi/spec.ts
+++ b/packages/busabase-core/src/openapi/spec.ts
@@ -8,6 +8,7 @@ const openApiGenerator = new OpenAPIGenerator({
 
 export async function getBusabaseOpenApiSpec() {
   const spec = await openApiGenerator.generate(busabaseContract, {
+    exclude: (_contract, path) => path[0] === "live",
     info: {
       title: "Busabase API",
       version: process.env.VERSION || "0.0.0",

--- a/packages/busabase-core/src/router-demo.ts
+++ b/packages/busabase-core/src/router-demo.ts
@@ -41,6 +41,8 @@ const demoUnsupported = (action: string) =>
     message: `"${action}" is disabled in the Busabase demo. Run Busabase locally to make persistent changes.`,
   });
 
+const shouldEmitDemoLiveEvent = () => false;
+
 export const busabaseDemoRouter = os.router({
   auth: {
     verify: os.auth.verify.handler(() => demoGetAuthInfo()),
@@ -66,6 +68,14 @@ export const busabaseDemoRouter = os.router({
   },
   agent: {
     listTasks: os.agent.listTasks.handler(() => demoListAgentTasks()),
+  },
+  live: {
+    subscribe: os.live.subscribe.handler(async function* () {
+      if (shouldEmitDemoLiveEvent()) {
+        yield undefined as never;
+      }
+      return undefined;
+    }),
   },
   bases: {
     list: os.bases.list.handler(() => demoListBases()),

--- a/packages/busabase-core/src/router.ts
+++ b/packages/busabase-core/src/router.ts
@@ -1,11 +1,13 @@
 import { implement } from "@orpc/server";
 import { busabaseContract } from "busabase-contract/contract/busabase";
+import { getContextSpaceId } from "./context";
 import { assetsRouter } from "./domains/assets/router";
 import { attachmentsRouter } from "./domains/attachments/router";
 import { baseRouter, recordRouter, viewRouter } from "./domains/base/router";
 import { docRouter } from "./domains/doc/router";
 import { folderRouter } from "./domains/folder/router";
 import { skillRouter } from "./domains/skill/router";
+import { subscribeBusabaseLiveEvents } from "./logic/live-events";
 import {
   closeChangeRequest,
   createAuditEvent,
@@ -55,6 +57,11 @@ export const busabaseRouter = busabase.router({
   },
   agent: {
     listTasks: busabase.agent.listTasks.handler(async () => listAgentTasks()),
+  },
+  live: {
+    subscribe: busabase.live.subscribe.handler(({ signal }) =>
+      subscribeBusabaseLiveEvents(getContextSpaceId(), signal),
+    ),
   },
   bases: baseRouter,
   skills: skillRouter,

--- a/packages/busabase-core/src/skill-doc.ts
+++ b/packages/busabase-core/src/skill-doc.ts
@@ -65,9 +65,10 @@ export function buildSkillMarkdown(origin: string, ctx?: SkillMarkdownContext): 
 
   // Cloud mode: the API key is USER-scoped (works across every space the user
   // belongs to), so each request must name its target space explicitly via the
-  // `x-busabase-space` header — otherwise the server silently falls back to the
-  // user's default space. Every cloud example carries the header so a wrong or
-  // unreplaced space id fails loudly instead of writing into the wrong space.
+  // `x-busabase-space` header. With one space the server can use it automatically;
+  // with several, a write missing the header is rejected 400 (the server refuses to
+  // guess). Every cloud example carries the header so a wrong or unreplaced space
+  // id fails loudly, not into the wrong space.
   const spaceHeader = isLocal ? null : `x-busabase-space: ${spaceId}`;
   const headerList = [authHeader, spaceHeader].filter((h): h is string => Boolean(h));
 
@@ -126,8 +127,10 @@ ${
 
 Your API key belongs to the **user**, not to a space: it works across **every space the
 user is a member of**. Each request targets exactly one space via the
-\`x-busabase-space\` header — **without the header the server silently falls back to the
-user's default space**, which may not be the one the user means.
+\`x-busabase-space\` header. With exactly one space the header is optional; **when the
+key spans multiple spaces, a write with no \`x-busabase-space\` header is rejected
+with \`400\`** (it lists your spaces) rather than silently guessing. Always set the
+header once you know the target.
 
 Before the first write of a session:
 
@@ -145,7 +148,7 @@ curl ${base}/api/v1/auth${HAuthOnly}
    assume the default is the one they mean.
 3. Send the chosen ID as \`x-busabase-space\` on **every** call. The examples below
    already carry it (current target: \`${spaceId}\`). A space you're not a member of
-   returns 403.`
+   returns 403; a missing header with multiple spaces returns 400.`
 }
 
 ## API Surface
@@ -157,13 +160,16 @@ Quick reference — every path is relative to the base URL above; worked example
 | List Bases | \`GET /api/v1/bases\` | tables in this workspace |
 | List Nodes | \`GET /api/v1/nodes\` | folders, Bases, Skills |
 | List ChangeRequests | \`GET /api/v1/change-requests\` | the review queue |
-| Create record CR | \`POST /api/v1/bases/:baseId/change-requests\` | propose a record change |
-| Create node CR | \`POST /api/v1/nodes/change-requests\` | propose folder / Skill structure changes |
+| Create record CR | \`POST /api/v1/bases/:baseId/change-requests\` | propose one record change |
+| Bulk create records CR | \`POST /api/v1/bases/:baseId/records/bulk-change-request\` | propose many records (≤1000) as ONE CR |
+| Create node CR | \`POST /api/v1/nodes/change-requests\` | propose folder / Skill structure changes (supports in-CR \`ref\`/\`parentNodeRef\`) |
 | Read Skill files | \`GET /api/v1/skills/:nodeId/files/:filePath\` | read a Skill file |
 | Create Skill file CR | \`POST /api/v1/skills/:nodeId/change-requests\` | propose a Skill file edit |
 | Review (approve / request changes) | \`POST /api/v1/change-requests/:id/reviews\` | approve or request revision |
+| Review many | \`POST /api/v1/change-requests/reviews\` | approve/reject many CRs in one call |
 | Close / abandon ChangeRequest | \`POST /api/v1/change-requests/:id/close\` | terminally close a bad proposal |
 | Merge | \`POST /api/v1/change-requests/:id/merge\` | apply an approved CR |
+| Merge many | \`POST /api/v1/change-requests/merge\` | merge many approved CRs in one call |
 | Read records | \`GET /api/v1/records\` | merged canonical records |
 | Agent work queue | \`GET /api/v1/agent/tasks\` | CRs awaiting your revision |
 | Revise an operation | \`POST /api/v1/operations/:operationId/revisions\` | answer requested changes |
@@ -202,14 +208,78 @@ ${authLine}  -H 'content-type: application/json' \\
   }'
 \`\`\`
 
-Create a node ChangeRequest (folder / Skill structure changes — use
-\`node_create\`, \`node_rename\`, \`node_move\`, or \`node_delete\` semantics):
+Bulk-create many records as ONE ChangeRequest (up to 1000 — one review, one merge,
+instead of a CR per row). Prefer this whenever seeding / importing multiple records:
 
 \`\`\`bash
+curl -X POST ${base}/api/v1/bases/:baseId/records/bulk-change-request \\
+${authLine}  -H 'content-type: application/json' \\
+  --data '{
+    "records": [
+      { "title": "Acme Corp", "channel": "blog" },
+      { "title": "Globex", "channel": "blog" },
+      { "title": "Initech", "channel": "blog" }
+    ],
+    "message": "Import 3 launch-week leads",
+    "submittedBy": "agent"
+  }'
+\`\`\`
+
+Create a node ChangeRequest (folder / Skill structure changes — use
+\`create\`, \`rename\`, \`move\`, \`delete\`, or \`restore\`). \`operations\` is an ordered
+array — one CR can carry many operations, and a create op can declare a temp \`ref\`
+that a later op references via \`parentNodeRef\`, so you can create a folder and fill
+it in a single CR without merging the folder first to learn its real id.
+
+| \`kind\` | Required fields | Does |
+| --- | --- | --- |
+| \`create\` | \`nodeType\` (\`folder\`/\`base\`/\`skill\`/\`doc\`), \`slug\`, \`name\`; optional \`ref\`, \`parentNodeId\`, \`parentNodeRef\`, \`description\`, \`fields\` | create a node (omit parent → root; use \`ref\` for later ops) |
+| \`rename\` | \`nodeId\`; any of \`slug\`, \`name\`, \`description\` | rename / re-slug a node |
+| \`move\` | \`nodeId\`; \`parentNodeId\` or \`parentNodeRef\`; optional \`position\` | move a node under another folder |
+| \`delete\` | \`nodeId\` | archive a node |
+| \`restore\` | \`nodeId\` | un-archive a node |
+
+\`\`\`bash
+# Create a folder, create a base inside it by temp ref, and move an existing node into it:
 curl -X POST ${base}/api/v1/nodes/change-requests \\
 ${authLine}  -H 'content-type: application/json' \\
-  --data '{ "message": "Create a Campaigns folder for Q3 marketing docs", "submittedBy": "agent" }'
+  --data '{
+    "message": "Set up the Growth workspace",
+    "submittedBy": "agent",
+    "operations": [
+      { "kind": "create", "ref": "growth", "nodeType": "folder", "slug": "growth", "name": "Growth" },
+      { "kind": "create", "parentNodeRef": "growth", "nodeType": "base", "slug": "campaigns", "name": "Campaigns",
+        "fields": [{ "slug": "title", "name": "Title", "type": "text", "required": true }] },
+      { "kind": "move", "nodeId": ":existingNodeId", "parentNodeRef": "growth" }
+    ]
+  }'
+
+# Rename a node:
+curl -X POST ${base}/api/v1/nodes/change-requests \\
+${authLine}  -H 'content-type: application/json' \\
+  --data '{
+    "message": "Rename Campaigns → Q3 Campaigns",
+    "submittedBy": "agent",
+    "operations": [
+      { "kind": "rename", "nodeId": "<NODE_ID>", "name": "Q3 Campaigns", "slug": "q3-campaigns" }
+    ]
+  }'
+
+# Move a node into a folder (parentNodeId = the destination folder's node id):
+curl -X POST ${base}/api/v1/nodes/change-requests \\
+${authLine}  -H 'content-type: application/json' \\
+  --data '{
+    "message": "Move the Blog Posts base into Campaigns",
+    "submittedBy": "agent",
+    "operations": [
+      { "kind": "move", "nodeId": "<NODE_ID>", "parentNodeId": "<FOLDER_NODE_ID>" }
+    ]
+  }'
 \`\`\`
+
+> A newly created folder's real \`nodeId\` only exists **after the CR is merged**.
+> Within the same CR, use a temp \`ref\` on the create op and \`parentNodeRef\` on later
+> create/move ops that should target it.
 
 Read Skill files:
 
@@ -266,6 +336,21 @@ Merge an approved ChangeRequest:
 
 \`\`\`bash
 curl -X POST ${base}/api/v1/change-requests/:changeRequestId/merge${H}
+\`\`\`
+
+Review or merge MANY ChangeRequests in one call (for "approve/merge all of these" —
+failures are isolated and reported per id, so one bad id never aborts the rest):
+
+\`\`\`bash
+# Approve several at once
+curl -X POST ${base}/api/v1/change-requests/reviews \\
+${authLine}  -H 'content-type: application/json' \\
+  --data '{ "changeRequestIds": ["crq_1", "crq_2", "crq_3"], "verdict": "approved" }'
+
+# Merge several at once → { "results": [{ "changeRequestId", "ok", "status?", "error?" }] }
+curl -X POST ${base}/api/v1/change-requests/merge \\
+${authLine}  -H 'content-type: application/json' \\
+  --data '{ "changeRequestIds": ["crq_1", "crq_2", "crq_3"] }'
 \`\`\`
 
 Read canonical records:
@@ -410,8 +495,8 @@ function buildBootstrapMarkdown(origin: string, ctx?: SkillMarkdownContext): str
   const isCloud = ctx?.mode === "cloud";
 
   // Base URL + auth fragments woven into the shared Step 3 curl examples. Cloud
-  // calls always carry `x-busabase-space` — the API key is user-scoped, and without
-  // the header writes silently land in the user's default space (Step 0 picks the
+  // calls always carry `x-busabase-space` — the API key is user-scoped, and with
+  // multiple spaces a write without the header is rejected 400 (Step 0 picks the
   // space and exports $BUSABASE_SPACE_ID before any of these run).
   const api = isCloud ? "$BUSABASE_BASE_URL" : local;
   const H = isCloud
@@ -491,7 +576,8 @@ connection to \`~/.busabase/.env\` **for you** — base URL, a login session tok
 space (it even asks which space when the user belongs to more than one):
 
 \`\`\`bash
-npx -y busabase-cli login    # opens the browser; prints a URL to paste if it can't
+npm exec -y --package busabase-cli@latest -- busabase-cli login
+# opens the browser; prints a URL to paste if it can't
 \`\`\`
 
 When it prints **"Signed in"**, the connection is saved — just read it back and continue:
@@ -528,8 +614,9 @@ curl -fsS "$BUSABASE_BASE_URL/api/v1/users/me" -H "Authorization: Bearer $BUSABA
 
 **Then pick the target space — the key is user-scoped, not space-scoped.** The key works
 across every space the user is a member of, and each request targets one space via the
-\`x-busabase-space\` header; without it, writes silently land in the user's *default* space —
-which may not be the one the user means. So look before you write:
+\`x-busabase-space\` header. If the user has **more than one space**, a write without the
+header is **rejected with \`400\`** (the server refuses to guess and lists the candidates);
+with exactly one space the header is optional. Either way, look before you write:
 
 \`\`\`bash
 curl -fsS "$BUSABASE_BASE_URL/api/v1/auth" -H "Authorization: Bearer $BUSABASE_API_KEY"
@@ -589,8 +676,9 @@ printf 'BUSABASE_BASE_URL=%s\\n' "${local}" > ~/.busabase/.env
   const step1 = isCloud
     ? `## Step 1 — Get credentials (only if you don't have any)
 
-**Easiest: \`npx -y busabase-cli login\`** — browser sign-in that saves everything to
-\`~/.busabase/.env\`, no key to copy. Use the manual key below only when there's no browser.
+**Easiest: \`npm exec -y --package busabase-cli@latest -- busabase-cli login\`** — browser
+sign-in that saves everything to \`~/.busabase/.env\`, no key to copy. Use the manual key below
+only when there's no browser.
 
 Manual API key: tell the user in plain words to sign in at \`${site}/dashboard\`, open
 **Settings → API Keys**, and **Create key** — copy it (it is shown only once). Then save it so
@@ -725,7 +813,7 @@ until curl -fsS ${local}/api/v1/bases >/dev/null 2>&1; do sleep 2; done && echo 
 \`\`\``;
 
   const spaceNote = isCloud
-    ? "(Every call carries `x-busabase-space: $BUSABASE_SPACE_ID` — the space picked in Step 0. The API key is user-scoped, so a call without the header silently lands in the user's default space.)"
+    ? "(Every call carries `x-busabase-space: $BUSABASE_SPACE_ID` — the space picked in Step 0. The API key is user-scoped; with multiple spaces a write without the header is rejected 400.)"
     : "(No `spaceId` in local mode.)";
 
   const step4 = `## Step 4 — The last setup step: install the permanent skill
@@ -862,9 +950,11 @@ fold in any edits, and only create on their go-ahead. A sketch worth showing:
 Once they approve, build folder-first so the user never lands in a flat root full of tables:
 
 - Folder / node-tree edits **do require** a Node ChangeRequest: \`POST /api/v1/nodes/change-requests\`,
-  then approve + merge it.
-- Base creation can be direct through \`POST /api/v1/bases\`; pass \`parentNodeId\` when placing the
-  Base under a folder. Omitting \`parentNodeId\` creates a root-level Base node.
+  then approve + merge it. One CR can hold MANY operations — a create op can declare a temp \`ref\`
+  that a later op targets via \`parentNodeRef\`, so **you can create the folder AND the Bases/Docs
+  inside it in a single CR** (no need to merge the folder first to learn its id).
+- Base creation can also be direct through \`POST /api/v1/bases\`; pass \`parentNodeId\` when placing the
+  Base under an already-merged folder. Omitting \`parentNodeId\` creates a root-level Base node.
 
 Worked example for blueprint #1:
 
@@ -878,7 +968,9 @@ ${authLine}  -H 'content-type: application/json' \\
     ],
     "submittedBy": "agent"
   }'
-# Approve + merge the returned folder ChangeRequest, then use the new folder node id as parentNodeId.
+# Approve + merge, then use the new folder node id as parentNodeId below — OR skip the round-trip
+# and add the Base to the SAME CR with { "kind": "create", "parentNodeRef": "content", ... } after
+# giving the folder op a "ref": "content" (see the node ChangeRequest example in API Surface).
 \`\`\`
 
 \`\`\`bash
@@ -925,7 +1017,8 @@ write records directly. **Write for the reviewer:** the Base's PRIMARY field (it
 e.g. \`title\`) becomes the record's display name and the ChangeRequest title — always give it a
 short, human-readable value — and \`message\` is your commit message, shown under the title in the
 review inbox: write a conventional-commit style subject (imperative verb + what + why), never
-\`"update"\` or a bare default. One call per record (there is no bulk endpoint):
+\`"update"\` or a bare default. Seed one record per CR when you want each reviewed individually, or
+propose them all at once with the **bulk** endpoint below (one review, one merge):
 
 \`\`\`bash
 curl -X POST "${api}/api/v1/bases/<BASE_ID>/change-requests" \\
@@ -938,6 +1031,22 @@ ${authLine}  -H 'content-type: application/json' \\
       "status": "draft"
     },
     "message": "Seed: first content draft for review",
+    "submittedBy": "agent"
+  }'
+\`\`\`
+
+To seed several rows in one reviewable unit, use the bulk endpoint instead of N calls:
+
+\`\`\`bash
+curl -X POST "${api}/api/v1/bases/<BASE_ID>/records/bulk-change-request" \\
+${authLine}  -H 'content-type: application/json' \\
+  --data '{
+    "records": [
+      { "title": "Launch announcement blog post", "channel": "blog", "status": "draft" },
+      { "title": "Feature deep-dive", "channel": "blog", "status": "idea" },
+      { "title": "Launch week recap thread", "channel": "social", "status": "idea" }
+    ],
+    "message": "Seed: 3 sample content drafts for review",
     "submittedBy": "agent"
   }'
 \`\`\`

--- a/packages/busabase-core/tests/audit-direct-mutations.test.ts
+++ b/packages/busabase-core/tests/audit-direct-mutations.test.ts
@@ -8,8 +8,10 @@ import { seedScenario } from "../src/logic/store";
 import { busabaseRouter } from "../src/router";
 
 /**
- * Direct (non-change-request) mutations must still leave an audit-log entry, so the
- * product stays fully auditable even for operations that bypass propose → review → merge.
+ * Every content-tree mutation is recorded as an auto-merged ChangeRequest (so it's
+ * in history + rollback, not just an audit line): base / doc / skill create, field
+ * add, and doc body update. Destructive maintenance ops with no content-operation
+ * semantics (node purge, asset delete) stay audit-only — they satisfy "audit OR CR".
  */
 
 const MIGRATIONS_CWD = path.resolve(__dirname, "../../../apps/busabase");
@@ -41,15 +43,21 @@ describe("audit trail for direct mutations", () => {
     if (storageDir) await rm(storageDir, { recursive: true, force: true });
   });
 
-  const approveAndMerge = (changeRequestId: string) =>
-    client.changeRequests
-      .review({ changeRequestId, verdict: "approved" })
-      .then(() => client.changeRequests.merge({ changeRequestId }));
+  // A merged CR of a given operation whose predicate matches (how a structural
+  // mutation is now recorded).
+  const hasMergedCR = async (
+    operation: string,
+    match: (cr: {
+      baseId: string | null;
+      nodeId: string | null;
+      node: { slug: string } | null;
+    }) => boolean,
+  ) =>
+    (await client.changeRequests.list()).some(
+      (cr) => cr.status === "merged" && cr.primaryOperation?.operation === operation && match(cr),
+    );
 
-  const auditActions = async () =>
-    (await client.auditEvents.list({ limit: 100 })).map((e) => e.action);
-
-  it("audits base + field direct creation", async () => {
+  it("records merged ChangeRequests for a base create + field add", async () => {
     const base = await client.bases.create({
       slug: "audit-base",
       name: "Audit Base",
@@ -61,44 +69,35 @@ describe("audit trail for direct mutations", () => {
       name: "Extra",
       type: "text",
     });
-    const actions = await auditActions();
-    expect(actions).toContain("base.created");
-    expect(actions).toContain("field.created");
+    expect(await hasMergedCR("node_create", (cr) => cr.node?.slug === "audit-base")).toBe(true);
+    expect(await hasMergedCR("base_add_field", (cr) => cr.baseId === base.id)).toBe(true);
   });
 
-  it("audits doc create + direct body update", async () => {
+  it("records merged ChangeRequests for a doc create + body update", async () => {
     const doc = await client.docs.create({ slug: "audit-doc", name: "Audit Doc", body: "v1" });
     await client.docs.updateBody({ nodeId: doc.node.id, body: "v2" });
-    const actions = await auditActions();
-    expect(actions).toContain("doc.created");
-    expect(actions).toContain("doc.updated");
+    expect(await hasMergedCR("node_create", (cr) => cr.node?.slug === "audit-doc")).toBe(true);
+    expect(await hasMergedCR("doc_update", (cr) => cr.nodeId === doc.node.id)).toBe(true);
   });
 
-  it("audits skill direct creation", async () => {
+  it("records a merged ChangeRequest for a skill create", async () => {
     await client.skills.create({ slug: "audit-skill", name: "Audit Skill" });
-    expect(await auditActions()).toContain("skill.created");
+    expect(await hasMergedCR("node_create", (cr) => cr.node?.slug === "audit-skill")).toBe(true);
   });
 
   it("audits permanent node purge", async () => {
     const folderBySlug = async (slug: string) =>
       (await client.folders.list()).find((f) => f.node.slug === slug);
 
-    await approveAndMerge(
-      (
-        await client.nodes.createChangeRequest({
-          operations: [{ kind: "create", nodeType: "folder", slug: "audit-purge", name: "Purge" }],
-        })
-      ).id,
-    );
+    // Structural node CRs auto-merge — no manual review/merge needed.
+    await client.nodes.createChangeRequest({
+      operations: [{ kind: "create", nodeType: "folder", slug: "audit-purge", name: "Purge" }],
+    });
     const folderId = (await folderBySlug("audit-purge"))!.node.id;
     // Archive it (delete), then permanently purge.
-    await approveAndMerge(
-      (
-        await client.nodes.createChangeRequest({
-          operations: [{ kind: "delete", nodeId: folderId }],
-        })
-      ).id,
-    );
+    await client.nodes.createChangeRequest({
+      operations: [{ kind: "delete", nodeId: folderId }],
+    });
     await client.nodes.purge({ nodeId: folderId });
 
     const events = await client.auditEvents.list({ limit: 100 });

--- a/packages/busabase-core/tests/boundary-p16.test.ts
+++ b/packages/busabase-core/tests/boundary-p16.test.ts
@@ -34,14 +34,13 @@ describe("Boundary P16 — node/view merge state guards", () => {
       ).id,
     );
 
-    // A rename CR targeting the now-archived node must not merge.
-    const renameCr = await raw.nodes.createChangeRequest({
-      operations: [{ kind: "rename", nodeId: doc.node.id, name: "Renamed" }],
-    });
-    await raw.changeRequests.review({ changeRequestId: renameCr.id, verdict: "approved" });
-    await expect(raw.changeRequests.merge({ changeRequestId: renameCr.id })).rejects.toThrow(
-      /archived node/i,
-    );
+    // A rename CR targeting the now-archived node must not merge. Structural CRs
+    // auto-merge on create, so the guard rejects at the create call.
+    await expect(
+      raw.nodes.createChangeRequest({
+        operations: [{ kind: "rename", nodeId: doc.node.id, name: "Renamed" }],
+      }),
+    ).rejects.toThrow(/archived node/i);
   });
 
   it("Fix 2: restoring a view that is not archived is rejected", async () => {

--- a/packages/busabase-core/tests/merge-atomicity.test.ts
+++ b/packages/busabase-core/tests/merge-atomicity.test.ts
@@ -72,13 +72,15 @@ describe("merge atomicity", () => {
     const bId = (await folderBySlug("atom-b"))!.node.id;
 
     // One CR: rename A (valid) THEN restore B (invalid — B is not archived → throws).
-    const cr = await client.nodes.createChangeRequest({
-      operations: [
-        { kind: "rename", nodeId: aId, name: "A Renamed" },
-        { kind: "restore", nodeId: bId },
-      ],
-    });
-    await expect(approveAndMerge(cr.id)).rejects.toThrow();
+    // Structural CRs auto-merge on create, so the atomic failure surfaces here.
+    await expect(
+      client.nodes.createChangeRequest({
+        operations: [
+          { kind: "rename", nodeId: aId, name: "A Renamed" },
+          { kind: "restore", nodeId: bId },
+        ],
+      }),
+    ).rejects.toThrow();
 
     // The rename must have rolled back — A keeps its original name.
     expect((await folderBySlug("atom-a"))!.node.name).toBe("A");
@@ -95,7 +97,8 @@ describe("merge atomicity", () => {
     const cId = (await folderBySlug("atom-c"))!.node.id;
 
     // Two valid ops in one CR: rename C, then create a child folder under it.
-    const cr = await client.nodes.createChangeRequest({
+    // Auto-merges on create — both ops commit together.
+    await client.nodes.createChangeRequest({
       operations: [
         { kind: "rename", nodeId: cId, name: "C Renamed" },
         {
@@ -107,7 +110,6 @@ describe("merge atomicity", () => {
         },
       ],
     });
-    await approveAndMerge(cr.id);
 
     expect((await folderBySlug("atom-c"))!.node.name).toBe("C Renamed");
     expect(await folderBySlug("atom-c-child")).toBeDefined();

--- a/packages/busabase-core/tests/node-temp-refs-orpc.test.ts
+++ b/packages/busabase-core/tests/node-temp-refs-orpc.test.ts
@@ -72,11 +72,9 @@ describe("Node CR temp refs — oRPC integration", () => {
         },
       ],
     });
-    expect(cr.status).toBe("in_review");
+    // Structural node CRs auto-merge — already applied, no manual merge needed.
+    expect(cr.status).toBe("merged");
     expect(cr.operationCount).toBe(3);
-
-    await client.changeRequests.review({ changeRequestId: cr.id, verdict: "approved" });
-    await client.changeRequests.merge({ changeRequestId: cr.id });
 
     const tree = (await client.nodes.list()) as Array<{ slug: string; children?: unknown[] }>;
     const growth = findNode(tree, "growth");
@@ -99,8 +97,7 @@ describe("Node CR temp refs — oRPC integration", () => {
         { kind: "move", nodeId: orphan.id, parentNodeRef: "archive" },
       ],
     });
-    await client.changeRequests.review({ changeRequestId: cr.id, verdict: "approved" });
-    await client.changeRequests.merge({ changeRequestId: cr.id });
+    expect(cr.status).toBe("merged"); // auto-merged
 
     const after = (await client.nodes.list()) as Array<{ slug: string; children?: unknown[] }>;
     const archive = findNode(after, "archive");

--- a/packages/busabase-core/tests/node-tree.test.ts
+++ b/packages/busabase-core/tests/node-tree.test.ts
@@ -129,12 +129,13 @@ describe("Node tree + Doc lifecycle — oRPC", () => {
     const folderSlug = async (slug: string) =>
       (await client.folders.list()).find((f) => f.node.slug === slug);
 
-    it("creates, renames, and deletes a folder through merged node CRs", async () => {
-      // Create.
+    it("creates, renames, and deletes a folder through auto-merged node CRs", async () => {
+      // Structural node CRs auto-merge: the returned CR is already `merged`, so
+      // no separate review/merge is needed (but a merged CR is still recorded).
       const createCr = await client.nodes.createChangeRequest({
         operations: [{ kind: "create", nodeType: "folder", slug: "lc-tree", name: "Tree" }],
       });
-      await approveAndMerge(createCr.id);
+      expect(createCr.status).toBe("merged");
       const created = await folderSlug("lc-tree");
       expect(created).toBeDefined();
       const nodeId = created?.node.id ?? "";
@@ -143,18 +144,18 @@ describe("Node tree + Doc lifecycle — oRPC", () => {
       const renameCr = await client.nodes.createChangeRequest({
         operations: [{ kind: "rename", nodeId, name: "Tree Renamed" }],
       });
-      await approveAndMerge(renameCr.id);
+      expect(renameCr.status).toBe("merged");
       expect((await folderSlug("lc-tree"))?.node.name).toBe("Tree Renamed");
 
       // Delete.
       const deleteCr = await client.nodes.createChangeRequest({
         operations: [{ kind: "delete", nodeId }],
       });
-      await approveAndMerge(deleteCr.id);
+      expect(deleteCr.status).toBe("merged");
       expect(await folderSlug("lc-tree")).toBeUndefined();
     });
 
-    it("materializes a Base node created through a node CR", async () => {
+    it("materializes a Base node created through an auto-merged node CR", async () => {
       const cr = await client.nodes.createChangeRequest({
         operations: [
           {
@@ -166,9 +167,48 @@ describe("Node tree + Doc lifecycle — oRPC", () => {
           },
         ],
       });
-      await approveAndMerge(cr.id);
+      expect(cr.status).toBe("merged");
       const bases = await client.bases.list();
       expect(bases.some((b) => b.slug === "lc-node-base")).toBe(true);
+    });
+
+    it("creates a folder and moves a node into it in ONE CR via temp-id", async () => {
+      // A movable folder at the root.
+      const movableCr = await client.nodes.createChangeRequest({
+        operations: [{ kind: "create", nodeType: "folder", slug: "lc-movable", name: "Movable" }],
+      });
+      expect(movableCr.status).toBe("merged");
+      const movableId = (await folderSlug("lc-movable"))?.node.id ?? "";
+      expect(movableId).not.toBe("");
+
+      // One CR: create a destination folder (ref "dest") + move Movable under it.
+      // The move references the not-yet-materialized folder by its in-CR ref.
+      const combo = await client.nodes.createChangeRequest({
+        message: "Create Archive folder and move Movable into it",
+        operations: [
+          {
+            kind: "create",
+            ref: "dest",
+            nodeType: "folder",
+            slug: "lc-archive",
+            name: "Archive",
+          },
+          { kind: "move", nodeId: movableId, parentNodeRef: "dest" },
+        ],
+      });
+      expect(combo.status).toBe("merged");
+
+      const archiveId = (await folderSlug("lc-archive"))?.node.id;
+      expect(archiveId).toBeDefined();
+      expect((await folderSlug("lc-movable"))?.node.parentId).toBe(archiveId);
+    });
+
+    it("rejects a move that references an undeclared parentNodeRef", async () => {
+      await expect(
+        client.nodes.createChangeRequest({
+          operations: [{ kind: "move", nodeId: "nod_whatever", parentNodeRef: "ghost" }],
+        }),
+      ).rejects.toThrow(/no earlier operation declares/);
     });
   });
 });

--- a/packages/busabase-core/tests/relation-slug-orpc.test.ts
+++ b/packages/busabase-core/tests/relation-slug-orpc.test.ts
@@ -1,0 +1,221 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createRouterClient } from "@orpc/server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { busabaseRouter } from "../src/router";
+
+/**
+ * Relation fields can name their target Base by **slug** (`targetBaseSlug`) instead
+ * of the raw `bse_...` id — resolved to `targetBaseId` on write, comprehensively,
+ * across EVERY field-creation path: direct add-field, add-field CR (→ merge), field
+ * options update CR (→ merge), create-base-with-fields, and node-CR base create
+ * (→ merge). Exercised through the real oRPC router.
+ */
+
+type Client = ReturnType<typeof createRouterClient<typeof busabaseRouter, Record<never, never>>>;
+const MIGRATIONS_CWD = path.resolve(__dirname, "../../../apps/busabase");
+
+const findNode = (tree: Array<{ slug: string; children?: unknown[] }>, slug: string): any => {
+  for (const node of tree) {
+    if (node.slug === slug) return node;
+    const nested = node.children ? findNode(node.children as typeof tree, slug) : undefined;
+    if (nested) return nested;
+  }
+  return undefined;
+};
+
+describe("Relation field target by slug — oRPC integration", () => {
+  let dataDir = "";
+  let storageDir = "";
+  let originalCwd = "";
+  let client: Client;
+  let companiesId = "";
+
+  const optionsFor = async (baseId: string, fieldSlug: string) => {
+    const base = await client.bases.get({ baseId });
+    const field = base?.fields.find((f) => f.slug === fieldSlug);
+    return field?.options as { targetBaseId?: string; targetBaseSlug?: string } | undefined;
+  };
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    process.chdir(MIGRATIONS_CWD);
+    dataDir = await mkdtemp(path.join(os.tmpdir(), "busabase-relslug-db-"));
+    storageDir = await mkdtemp(path.join(os.tmpdir(), "busabase-relslug-storage-"));
+    process.env.PG_DATABASE_URL = `pglite://${dataDir}`;
+    process.env.STORAGE_URL = `local:${storageDir}?base_url=/api/test/storage`;
+    client = createRouterClient(busabaseRouter);
+    // The relation target every test points at.
+    const companies = await client.bases.create({
+      slug: "companies",
+      name: "Companies",
+      fields: [{ slug: "name", name: "Name", type: "text", required: true, options: {} }],
+    });
+    companiesId = companies.id;
+  });
+
+  afterAll(async () => {
+    delete process.env.PG_DATABASE_URL;
+    delete process.env.STORAGE_URL;
+    if (originalCwd) process.chdir(originalCwd);
+    for (const dir of [dataDir, storageDir]) {
+      if (dir) await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  const approveMerge = async (changeRequestId: string) => {
+    await client.changeRequests.review({ changeRequestId, verdict: "approved" });
+    await client.changeRequests.merge({ changeRequestId });
+  };
+
+  it("resolves the slug on a direct add-field (bases.createField)", async () => {
+    const base = await client.bases.create({
+      slug: "contacts-a",
+      name: "Contacts A",
+      fields: [{ slug: "name", name: "Name", type: "text", required: true, options: {} }],
+    });
+    await client.bases.createField({
+      baseId: base.id,
+      slug: "company",
+      name: "Company",
+      type: "relation",
+      options: { targetBaseSlug: "companies" },
+    });
+    const opts = await optionsFor(base.id, "company");
+    expect(opts?.targetBaseId).toBe(companiesId);
+    expect(opts?.targetBaseSlug).toBeUndefined();
+  });
+
+  it("resolves the slug in create-base-with-fields (bases.create)", async () => {
+    const base = await client.bases.create({
+      slug: "contacts-b",
+      name: "Contacts B",
+      fields: [
+        { slug: "name", name: "Name", type: "text", required: true, options: {} },
+        {
+          slug: "company",
+          name: "Company",
+          type: "relation",
+          required: false,
+          options: { targetBaseSlug: "companies" },
+        },
+      ],
+    });
+    const opts = await optionsFor(base.id, "company");
+    expect(opts?.targetBaseId).toBe(companiesId);
+  });
+
+  it("resolves the slug through an add-field ChangeRequest → merge", async () => {
+    const base = await client.bases.create({
+      slug: "contacts-c",
+      name: "Contacts C",
+      fields: [{ slug: "name", name: "Name", type: "text", required: true, options: {} }],
+    });
+    const cr = await client.bases.createFieldChangeRequest({
+      baseId: base.id,
+      slug: "company",
+      name: "Company",
+      type: "relation",
+      options: { targetBaseSlug: "companies" },
+    });
+    await approveMerge(cr.id);
+    const opts = await optionsFor(base.id, "company");
+    expect(opts?.targetBaseId).toBe(companiesId);
+    expect(opts?.targetBaseSlug).toBeUndefined();
+  });
+
+  it("resolves the slug through a field-options update ChangeRequest → merge", async () => {
+    const base = await client.bases.create({
+      slug: "contacts-d",
+      name: "Contacts D",
+      fields: [
+        { slug: "name", name: "Name", type: "text", required: true, options: {} },
+        {
+          slug: "company",
+          name: "Company",
+          type: "relation",
+          required: false,
+          options: { targetBaseId: companiesId },
+        },
+      ],
+    });
+    const field = (await client.bases.get({ baseId: base.id }))?.fields.find(
+      (f) => f.slug === "company",
+    );
+    const cr = await client.bases.updateFieldChangeRequest({
+      baseId: base.id,
+      fieldId: field?.id as string,
+      patch: { options: { targetBaseSlug: "companies" } },
+    });
+    await approveMerge(cr.id);
+    const opts = await optionsFor(base.id, "company");
+    expect(opts?.targetBaseId).toBe(companiesId);
+  });
+
+  it("resolves the slug in a node-CR base create → merge (materialize path)", async () => {
+    const cr = await client.nodes.createChangeRequest({
+      message: "Create a Deals base linked to Companies",
+      operations: [
+        {
+          kind: "create",
+          nodeType: "base",
+          slug: "deals",
+          name: "Deals",
+          fields: [
+            { slug: "title", name: "Title", type: "text", required: true },
+            {
+              slug: "company",
+              name: "Company",
+              type: "relation",
+              options: { targetBaseSlug: "companies" },
+            },
+          ],
+        },
+      ],
+    });
+    await approveMerge(cr.id);
+    const deals = findNode(
+      (await client.nodes.list()) as Array<{ slug: string; children?: unknown[] }>,
+      "deals",
+    );
+    const dealsBaseId = deals?.baseId as string;
+    const opts = await optionsFor(dealsBaseId, "company");
+    expect(opts?.targetBaseId).toBe(companiesId);
+  });
+
+  it("prefers an explicit targetBaseId when both are given, dropping the slug", async () => {
+    const base = await client.bases.create({
+      slug: "contacts-e",
+      name: "Contacts E",
+      fields: [{ slug: "name", name: "Name", type: "text", required: true, options: {} }],
+    });
+    await client.bases.createField({
+      baseId: base.id,
+      slug: "company",
+      name: "Company",
+      type: "relation",
+      options: { targetBaseId: companiesId, targetBaseSlug: "does-not-exist" },
+    });
+    const opts = await optionsFor(base.id, "company");
+    expect(opts?.targetBaseId).toBe(companiesId);
+    expect(opts?.targetBaseSlug).toBeUndefined();
+  });
+
+  it("rejects an unknown target base slug", async () => {
+    const base = await client.bases.create({
+      slug: "contacts-f",
+      name: "Contacts F",
+      fields: [{ slug: "name", name: "Name", type: "text", required: true, options: {} }],
+    });
+    await expect(
+      client.bases.createField({
+        baseId: base.id,
+        slug: "company",
+        name: "Company",
+        type: "relation",
+        options: { targetBaseSlug: "no-such-base" },
+      }),
+    ).rejects.toThrow(/not found by slug/i);
+  });
+});

--- a/packages/busabase-core/tests/skill-doc.test.ts
+++ b/packages/busabase-core/tests/skill-doc.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildSkillMarkdown } from "../src/skill-doc";
+
+/**
+ * The skill doc is the agent-facing contract for the HTTP API. It previously told
+ * agents to loop one change request per record and to merge a folder before
+ * referencing it — both now false. These assertions pin that the doc advertises the
+ * bulk / batch / temp-ref capabilities and never reintroduces the stale guidance.
+ */
+
+const cloud = buildSkillMarkdown("https://busabase.com", { mode: "cloud", spaceId: "spc_x" });
+const local = buildSkillMarkdown("http://localhost:15419", { mode: "local" });
+
+describe("buildSkillMarkdown advertises the batch/bulk/temp-ref surface", () => {
+  it("documents the bulk record change-request endpoint", () => {
+    for (const doc of [cloud, local]) {
+      expect(doc).toContain("/records/bulk-change-request");
+      expect(doc).toContain('"records"');
+    }
+  });
+
+  it("documents batch review and merge", () => {
+    expect(cloud).toContain("/change-requests/reviews");
+    expect(cloud).toContain("/change-requests/merge");
+    expect(cloud).toContain('"changeRequestIds"');
+  });
+
+  it("documents in-CR node temp references", () => {
+    expect(cloud).toContain("parentNodeRef");
+    expect(cloud).toContain('"ref"');
+  });
+
+  it("no longer claims there is no bulk endpoint", () => {
+    for (const doc of [cloud, local]) {
+      expect(doc).not.toContain("there is no bulk endpoint");
+    }
+  });
+
+  it("describes the multi-space guard as a rejection, not a silent fallback", () => {
+    // Cloud space-targeting section must reflect the 400-on-ambiguity behavior.
+    expect(cloud).toMatch(/rejected|400/);
+    expect(cloud).not.toContain("silently falls back to the\nuser's default space");
+  });
+});

--- a/packages/openlib/package.json
+++ b/packages/openlib/package.json
@@ -25,6 +25,10 @@
       "types": "./nanoid/index.ts",
       "default": "./nanoid/index.ts"
     },
+    "./realtime": {
+      "types": "./realtime/index.ts",
+      "default": "./realtime/index.ts"
+    },
     "./storage": {
       "types": "./storage/index.ts",
       "default": "./storage/index.ts"
@@ -87,6 +91,7 @@
     "nanoid": "^5.1.5",
     "negotiator": "^0.6.3",
     "nprogress": "^0.2.0",
+    "redis": "^5.10.0",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/packages/openlib/realtime/index.ts
+++ b/packages/openlib/realtime/index.ts
@@ -1,0 +1,116 @@
+type RealtimeMessageHandler<T> = (message: T) => void;
+type Unsubscribe = () => void;
+
+type RedisClient = {
+  connect: () => Promise<unknown>;
+  duplicate: () => RedisClient;
+  on: (event: "error", listener: (error: unknown) => void) => RedisClient;
+  publish: (channel: string, message: string) => Promise<unknown>;
+  subscribe: (channel: string, listener: (message: string) => void) => Promise<unknown>;
+  unsubscribe: (channel: string, listener?: (message: string) => void) => Promise<unknown>;
+};
+
+const localSubscribers = new Map<string, Set<(message: string) => void>>();
+
+let redisSubscriber: RedisClient | null = null;
+let redisReady: Promise<{ publisher: RedisClient; subscriber: RedisClient }> | null = null;
+
+const localPublish = (channel: string, message: string) => {
+  for (const handler of localSubscribers.get(channel) ?? []) {
+    handler(message);
+  }
+};
+
+const localSubscribe = (channel: string, handler: (message: string) => void): Unsubscribe => {
+  let subscribers = localSubscribers.get(channel);
+  if (!subscribers) {
+    subscribers = new Set();
+    localSubscribers.set(channel, subscribers);
+  }
+  subscribers.add(handler);
+
+  return () => {
+    subscribers.delete(handler);
+    if (subscribers.size === 0) {
+      localSubscribers.delete(channel);
+    }
+  };
+};
+
+const getRedisUrl = () => {
+  const url = process.env.REDIS_URL ?? "";
+  return url.startsWith("redis://") || url.startsWith("rediss://") ? url : null;
+};
+
+const ensureRedis = async () => {
+  if (!redisReady) {
+    redisReady = (async () => {
+      const redisUrl = getRedisUrl();
+      if (!redisUrl) {
+        throw new Error("REDIS_URL is not a redis:// or rediss:// URL");
+      }
+      const { createClient } = (await import("redis")) as {
+        createClient: (options: { url: string }) => RedisClient;
+      };
+      const publisher = createClient({ url: redisUrl });
+      const subscriber = publisher.duplicate();
+      publisher.on("error", (error) => console.warn("[openlib/realtime] Redis publisher", error));
+      subscriber.on("error", (error) => console.warn("[openlib/realtime] Redis subscriber", error));
+      await Promise.all([publisher.connect(), subscriber.connect()]);
+      redisSubscriber = subscriber;
+      return { publisher, subscriber };
+    })();
+  }
+
+  return redisReady;
+};
+
+export const publishRealtimeMessage = async (channel: string, payload: unknown) => {
+  const message = JSON.stringify(payload);
+
+  if (!getRedisUrl()) {
+    localPublish(channel, message);
+    return;
+  }
+
+  const { publisher } = await ensureRedis();
+  await publisher.publish(channel, message);
+};
+
+export const subscribeRealtimeMessages = <T>(
+  channel: string,
+  onMessage: RealtimeMessageHandler<T>,
+  signal?: AbortSignal,
+): Unsubscribe => {
+  const handler = (message: string) => onMessage(JSON.parse(message) as T);
+
+  if (!getRedisUrl()) {
+    const unsubscribe = localSubscribe(channel, handler);
+    signal?.addEventListener("abort", unsubscribe, { once: true });
+    return unsubscribe;
+  }
+
+  let active = true;
+  let unsubscribe: Unsubscribe = () => {
+    active = false;
+  };
+
+  ensureRedis()
+    .then(({ subscriber }) => {
+      if (!active) {
+        return;
+      }
+      void subscriber.subscribe(channel, handler);
+      unsubscribe = () => {
+        active = false;
+        void (redisSubscriber ?? subscriber).unsubscribe(channel, handler);
+      };
+      signal?.addEventListener("abort", unsubscribe, { once: true });
+    })
+    .catch((error) => {
+      active = false;
+      console.warn("[openlib/realtime] Redis subscribe failed", error);
+    });
+
+  return () => unsubscribe();
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.7(react@19.2.7)
+      redis:
+        specifier: ^5.10.0
+        version: 5.10.0
       wouter:
         specifier: ^3.9.0
         version: 3.9.0(react@19.2.7)
@@ -1088,16 +1091,8 @@ packages:
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -1392,10 +1387,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -3678,6 +3669,34 @@ packages:
   '@react-navigation/routers@7.5.3':
     resolution: {integrity: sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==}
 
+  '@redis/bloom@5.10.0':
+    resolution: {integrity: sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.10.0
+
+  '@redis/client@5.10.0':
+    resolution: {integrity: sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==}
+    engines: {node: '>= 18'}
+
+  '@redis/json@5.10.0':
+    resolution: {integrity: sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.10.0
+
+  '@redis/search@5.10.0':
+    resolution: {integrity: sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.10.0
+
+  '@redis/time-series@5.10.0':
+    resolution: {integrity: sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.10.0
+
   '@rive-app/react-webgl2@4.26.2':
     resolution: {integrity: sha512-AwJ7wzx6jzfTD2rrQ8Tt5u5W7b9B4ctnQQnHfIs4ldUM5DV3tE11d81sHOeYNrW9GishgOvU9jsMdHsSnozNzg==}
     peerDependencies:
@@ -5064,6 +5083,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
     peerDependencies:
@@ -6247,9 +6270,9 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@13.0.3:
-    resolution: {integrity: sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==}
-    engines: {node: 20 || >=22}
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -7299,8 +7322,8 @@ packages:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mitt@3.0.1:
@@ -7627,9 +7650,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -8105,6 +8128,10 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redis@5.10.0:
+    resolution: {integrity: sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==}
+    engines: {node: '>= 18'}
 
   refractor@3.6.0:
     resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
@@ -9936,11 +9963,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -10283,11 +10306,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -10754,7 +10772,7 @@ snapshots:
       expo-server: 56.0.5
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       lan-network: 0.2.1
       multitars: 1.0.0
       node-forge: 1.3.3
@@ -10831,7 +10849,7 @@ snapshots:
       expo-server: 56.0.5
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       lan-network: 0.2.1
       multitars: 1.0.0
       node-forge: 1.3.3
@@ -10907,7 +10925,7 @@ snapshots:
       expo-server: 56.0.5
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       lan-network: 0.2.1
       multitars: 1.0.0
       node-forge: 1.3.3
@@ -10959,7 +10977,7 @@ snapshots:
       chalk: 4.1.2
       debug: 4.4.3
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       semver: 7.8.4
       slugify: 1.6.6
       xcode: 3.0.1
@@ -10979,7 +10997,7 @@ snapshots:
       chalk: 4.1.2
       debug: 4.4.3
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       semver: 7.8.4
       slugify: 1.6.6
       xcode: 3.0.1
@@ -10998,7 +11016,7 @@ snapshots:
       '@expo/require-utils': 56.1.3(typescript@5.9.3)
       deepmerge: 4.3.1
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       resolve-workspace-root: 2.0.1
       semver: 7.8.4
       slugify: 1.6.6
@@ -11015,7 +11033,7 @@ snapshots:
       '@expo/require-utils': 56.1.3(typescript@6.0.3)
       deepmerge: 4.3.1
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       resolve-workspace-root: 2.0.1
       semver: 7.8.4
       slugify: 1.6.6
@@ -11091,7 +11109,7 @@ snapshots:
       chalk: 4.1.2
       debug: 4.4.3
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       ignore: 5.3.2
       minimatch: 10.2.4
       resolve-from: 5.0.0
@@ -11210,7 +11228,7 @@ snapshots:
       chalk: 4.1.2
       debug: 4.4.3
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       hermes-parser: 0.33.3
       jsc-safe-url: 0.2.4
       lightningcss: 1.31.1
@@ -11244,7 +11262,7 @@ snapshots:
       chalk: 4.1.2
       debug: 4.4.3
       getenv: 2.0.0
-      glob: 13.0.3
+      glob: 13.0.6
       hermes-parser: 0.33.3
       jsc-safe-url: 0.2.4
       lightningcss: 1.31.1
@@ -11699,7 +11717,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -13424,6 +13442,26 @@ snapshots:
     dependencies:
       nanoid: 3.3.12
 
+  '@redis/bloom@5.10.0(@redis/client@5.10.0)':
+    dependencies:
+      '@redis/client': 5.10.0
+
+  '@redis/client@5.10.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@5.10.0(@redis/client@5.10.0)':
+    dependencies:
+      '@redis/client': 5.10.0
+
+  '@redis/search@5.10.0(@redis/client@5.10.0)':
+    dependencies:
+      '@redis/client': 5.10.0
+
+  '@redis/time-series@5.10.0(@redis/client@5.10.0)':
+    dependencies:
+      '@redis/client': 5.10.0
+
   '@rive-app/react-webgl2@4.26.2(react@19.2.7)':
     dependencies:
       '@rive-app/webgl2': 2.34.2
@@ -14636,7 +14674,7 @@ snapshots:
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   babel-plugin-react-native-web@0.21.2: {}
 
@@ -14908,7 +14946,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -14917,7 +14955,7 @@ snapshots:
 
   chromium-edge-launcher@0.3.0:
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -14975,6 +15013,8 @@ snapshots:
   clone@1.0.4: {}
 
   clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -16680,15 +16720,15 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.9
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@13.0.3:
+  glob@13.0.6:
     dependencies:
       minimatch: 10.2.4
-      minipass: 7.1.2
-      path-scurry: 2.0.1
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   gopd@1.2.0: {}
 
@@ -17092,7 +17132,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -17109,7 +17149,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 25.2.3
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -18151,7 +18191,7 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.1
 
-  minipass@7.1.2: {}
+  minipass@7.1.3: {}
 
   mitt@3.0.1: {}
 
@@ -18508,12 +18548,12 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
-  path-scurry@2.0.1:
+  path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.6
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-to-regexp@6.3.0:
     optional: true
@@ -19359,6 +19399,14 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redis@5.10.0:
+    dependencies:
+      '@redis/bloom': 5.10.0(@redis/client@5.10.0)
+      '@redis/client': 5.10.0
+      '@redis/json': 5.10.0(@redis/client@5.10.0)
+      '@redis/search': 5.10.0(@redis/client@5.10.0)
+      '@redis/time-series': 5.10.0(@redis/client@5.10.0)
 
   refractor@3.6.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add RPC-only `live.subscribe` event iterator for Busabase dashboard realtime convergence
- add local in-memory pub/sub with Redis fanout support for cloud/multi-instance deployments
- publish dashboard live sync invalidation, write-model change-request unification docs, relation option handling, and related tests
- keep live streaming out of OpenAPI/MCP discovery and refresh the OSS lockfile

## Validation
- `pnpm install`
- `pnpm typecheck`
- `pnpm lint`
- security scan for real `.env*` and common secret patterns
- README relative link check
