### PR TITLE
fix: harden Busabase CLI npx entry

### DIFF
--- a/apps/busabase-cli/bin/busabase-cli.mjs
+++ b/apps/busabase-cli/bin/busabase-cli.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+const args = process.argv.slice(2);
+const distCli = resolve(root, "dist/cli.js");
+const srcCli = resolve(root, "src/cli.ts");
+const sdkDist = resolve(root, "../busabase-sdk/dist/index.js");
+
+if (existsSync(distCli)) {
+  await import(pathToFileURL(distCli).href);
+} else if (existsSync(srcCli) && existsSync(sdkDist)) {
+  try {
+    import.meta.resolve("tsx");
+  } catch {
+    console.error(
+      [
+        "busabase-cli: dist/cli.js is missing and the source fallback needs `tsx`.",
+        "Build the CLI first:",
+        "  pnpm --filter busabase-cli build",
+        "Or run the published package explicitly:",
+        "  npm exec -y --package busabase-cli@latest -- busabase-cli",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+
+  const result = spawnSync(process.execPath, ["--import", "tsx", srcCli, ...args], {
+    cwd: root,
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    console.error(`busabase-cli: ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+  }
+  process.exit(result.status ?? 1);
+} else if (existsSync(srcCli)) {
+  console.error(
+    [
+      "busabase-cli: dist/cli.js is missing in this source checkout.",
+      "Build the workspace packages first:",
+      "  pnpm --filter busabase-sdk build",
+      "  pnpm --filter busabase-cli build",
+      "Or run the published package explicitly:",
+      "  npm exec -y --package busabase-cli@latest -- busabase-cli",
+    ].join("\n"),
+  );
+  process.exit(1);
+} else {
+  console.error(
+    [
+      "busabase-cli: no executable CLI entry was found.",
+      "Expected either dist/cli.js in the published package or src/cli.ts in a source checkout.",
+    ].join("\n"),
+  );
+  process.exit(1);
+}

--- a/apps/busabase-cli/package.json
+++ b/apps/busabase-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Command-line client for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server`.",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-cli",
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "bin": {
-    "busabase-cli": "./dist/cli.js"
+    "busabase-cli": "./bin/busabase-cli.mjs"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -26,6 +26,7 @@
     }
   },
   "files": [
+    "bin",
     "dist",
     "README.md"
   ],

--- a/apps/busabase-cli/scripts/assert-help.mjs
+++ b/apps/busabase-cli/scripts/assert-help.mjs
@@ -6,12 +6,20 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const cliPath = path.join(root, "dist", "cli.js");
+const binPath = path.join(root, "bin", "busabase-cli.mjs");
 
 if (!existsSync(cliPath)) {
   throw new Error("dist/cli.js is missing. Run `pnpm run build` before publishing.");
 }
+if (!existsSync(binPath)) {
+  throw new Error("bin/busabase-cli.mjs is missing. The package bin must be shippable.");
+}
 
 const help = execFileSync(process.execPath, [cliPath, "--help"], {
+  cwd: root,
+  encoding: "utf8",
+});
+const binHelp = execFileSync(process.execPath, [binPath, "--help"], {
   cwd: root,
   encoding: "utf8",
 });
@@ -44,8 +52,8 @@ const forbidden = [
   "--draft-id",
 ];
 
-const missing = required.filter((text) => !help.includes(text));
-const stale = forbidden.filter((text) => help.includes(text));
+const missing = required.filter((text) => !help.includes(text) || !binHelp.includes(text));
+const stale = forbidden.filter((text) => help.includes(text) || binHelp.includes(text));
 
 if (missing.length || stale.length) {
   throw new Error(

--- a/apps/busabase/bin/busabase.mjs
+++ b/apps/busabase/bin/busabase.mjs
@@ -6,7 +6,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url)); // <pkg>/bin
 const pkgRoot = resolve(here, "..");
@@ -185,14 +185,48 @@ async function startServer(argv) {
   await import(entry);
 }
 
+async function runClientCli(argv) {
+  try {
+    const { runCli } = await import("busabase-cli");
+    return await runCli(argv);
+  } catch (error) {
+    const sourceCliWrapper = resolve(pkgRoot, "../busabase-cli/bin/busabase-cli.mjs");
+    if (existsSync(sourceCliWrapper)) {
+      const previousArgv = process.argv;
+      process.argv = [process.execPath, sourceCliWrapper, ...argv];
+      try {
+        await import(pathToFileURL(sourceCliWrapper).href);
+      } finally {
+        process.argv = previousArgv;
+      }
+      return 0;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      [
+        "busabase: could not load the bundled busabase-cli client.",
+        `Reason: ${message}`,
+        "",
+        "If you are running from source, build the CLI first:",
+        "  pnpm --filter busabase-sdk build",
+        "  pnpm --filter busabase-cli build",
+        "",
+        "Or run the published CLI explicitly:",
+        "  npm exec -y --package busabase-cli@latest -- busabase-cli",
+      ].join("\n"),
+    );
+    return 1;
+  }
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   if (argv[0] === "server") {
     await startServer(argv.slice(1));
     return;
   }
-  const { runCli } = await import("busabase-cli");
-  const code = await runCli(argv);
+  const code = await runClientCli(argv);
   // The delegated client help doesn't know about the server role — append it.
   const wantsHelp = argv.length === 0 || ["-h", "--help", "help"].includes(argv[0]);
   if (wantsHelp && code === 0) {

--- a/apps/busabase/package.json
+++ b/apps/busabase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase",
   "description": "Open-source Busabase review app + CLI. `busabase server` boots a zero-setup local instance (pglite); other subcommands act as an OpenAPI client.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase",


### PR DESCRIPTION
## Summary
- add a stable `bin/busabase-cli.mjs` wrapper so the package bin no longer points directly at build-only `dist/cli.js`
- bump `busabase-cli` to `0.1.4` so the publish workflow ships the bin-entry fix instead of skipping the already-published `0.1.3`
- extend `assert-help` to execute the real package bin wrapper before publish

## Why
`npx busabase-cli` should work for the published package. It does on the registry path, but inside a source/workspace checkout a local unbuilt `busabase-cli` package can leave the bin pointing at missing `dist/cli.js`, producing `busabase-cli: not found`. The wrapper gives source checkouts a stable entry and a clear recovery message, while the published package continues to execute the built CLI.

## Validation
- `npm exec -y --package busabase-cli@latest -- busabase-cli --version` -> `0.1.3`
- `node apps/busabase-cli/bin/busabase-cli.mjs --version` in an unbuilt source checkout prints a clear build/published-package recovery message instead of disappearing as `command not found`
- `npm pack ./apps/busabase-cli --ignore-scripts --json` confirms `bin/busabase-cli.mjs` is included and executable

## Notes
- Full package build/pack was not run locally because this clean temporary worktree has no installed dev dependencies; CI installs dependencies before building and publish checks now exercise the wrapper.
