### PR TITLE
fix: harden Busabase app CLI delegation

### DIFF
--- a/apps/busabase/bin/busabase.mjs
+++ b/apps/busabase/bin/busabase.mjs
@@ -6,7 +6,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url)); // <pkg>/bin
 const pkgRoot = resolve(here, "..");
@@ -185,14 +185,48 @@ async function startServer(argv) {
   await import(entry);
 }
 
+async function runClientCli(argv) {
+  try {
+    const { runCli } = await import("busabase-cli");
+    return await runCli(argv);
+  } catch (error) {
+    const sourceCliWrapper = resolve(pkgRoot, "../busabase-cli/bin/busabase-cli.mjs");
+    if (existsSync(sourceCliWrapper)) {
+      const previousArgv = process.argv;
+      process.argv = [process.execPath, sourceCliWrapper, ...argv];
+      try {
+        await import(pathToFileURL(sourceCliWrapper).href);
+      } finally {
+        process.argv = previousArgv;
+      }
+      return 0;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      [
+        "busabase: could not load the bundled busabase-cli client.",
+        `Reason: ${message}`,
+        "",
+        "If you are running from source, build the CLI first:",
+        "  pnpm --filter busabase-sdk build",
+        "  pnpm --filter busabase-cli build",
+        "",
+        "Or run the published CLI explicitly:",
+        "  npm exec -y --package busabase-cli@latest -- busabase-cli",
+      ].join("\n"),
+    );
+    return 1;
+  }
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   if (argv[0] === "server") {
     await startServer(argv.slice(1));
     return;
   }
-  const { runCli } = await import("busabase-cli");
-  const code = await runCli(argv);
+  const code = await runClientCli(argv);
   // The delegated client help doesn't know about the server role — append it.
   const wantsHelp = argv.length === 0 || ["-h", "--help", "help"].includes(argv[0]);
   if (wantsHelp && code === 0) {

--- a/apps/busabase/package.json
+++ b/apps/busabase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase",
   "description": "Open-source Busabase review app + CLI. `busabase server` boots a zero-setup local instance (pglite); other subcommands act as an OpenAPI client.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase",


### PR DESCRIPTION
## Summary
- add guarded client delegation in `busabase` so non-server commands don't fail with a raw module error when `busabase-cli` is unavailable or unbuilt
- fall back to the sibling source CLI wrapper when running from a source/workspace checkout
- bump `busabase` to `0.1.4` so the npm publish workflow ships the bin hardening instead of skipping the already-published `0.1.3`

## Why
`apps/busabase` already has a stable bin file (`bin/busabase.mjs`), so it does not have the same direct `dist/cli.js` bin problem as `busabase-cli`. The remaining weak spot is delegation: every non-`server` command imports `busabase-cli`. In a source checkout where the CLI package is not built, that import can fail unclearly. This PR catches that case and either runs the sibling CLI wrapper or prints actionable build / published-package commands.

## Validation
- `node apps/busabase/bin/busabase.mjs server --help`
- `node apps/busabase/bin/busabase.mjs --version` in an unbuilt source checkout prints the sibling CLI wrapper's clear build/published-package recovery message
- `npm pack ./apps/busabase --ignore-scripts --json` confirms `bin/busabase.mjs` is included in the package

## Stacking
- Stacked on #4 because it uses the `busabase-cli` source wrapper added there.
