### PR TITLE
ci: dispatch deploy after docker publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,8 @@
 #
 # Required secrets: DOCKERHUB_TOKEN (a Docker Hub access token for the `busabase`
 # org with push rights). GHCR uses the built-in GITHUB_TOKEN.
-# Required for deploy dispatch: CR_PAT plus DEPLOY_REPOSITORY (for example,
-# vikadata/ops-manager).
+# Required for deploy dispatch: CR_PAT, DEPLOY_REPOSITORY (for example,
+# vikadata/ops-manager), and DEPLOY_EVENT_TYPE (for example, deploy-bika).
 name: Docker
 
 on:
@@ -82,6 +82,7 @@ jobs:
         env:
           DEPLOY_TOKEN: ${{ secrets.CR_PAT }}
           DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}
+          DEPLOY_EVENT_TYPE: ${{ secrets.DEPLOY_EVENT_TYPE }}
         run: |
           set -euo pipefail
           if [ -z "${DEPLOY_TOKEN:-}" ]; then
@@ -92,6 +93,10 @@ jobs:
             echo "DEPLOY_REPOSITORY is not configured; skipping deploy dispatch."
             exit 0
           fi
+          if [ -z "${DEPLOY_EVENT_TYPE:-}" ]; then
+            echo "DEPLOY_EVENT_TYPE is not configured; skipping deploy dispatch."
+            exit 0
+          fi
 
           short_sha="${GITHUB_SHA::7}"
           version="sha-${short_sha}"
@@ -99,9 +104,10 @@ jobs:
           echo "Dispatching deploy for busabase @ ${version}"
           PAYLOAD=$(jq -nc \
             --arg semver "${version}" \
+            --arg event_type "${DEPLOY_EVENT_TYPE}" \
             --arg image "ghcr.io/${{ github.repository_owner }}/busabase:${version}" \
             --arg arch "$(uname -m)" \
-            '{event_type:"deploy-bika",client_payload:{SEMVER_FULL:$semver,edition:"busabase",app:"busabase",containerName:"busabase",image:$image,arch:$arch}}')
+            '{event_type:$event_type,client_payload:{SEMVER_FULL:$semver,edition:"busabase",app:"busabase",containerName:"busabase",image:$image,arch:$arch}}')
           curl --fail -sS -X POST "https://api.github.com/repos/${DEPLOY_REPOSITORY}/dispatches" \
             -H "Authorization: token ${DEPLOY_TOKEN}" \
             -H "Accept: application/vnd.github.everest-preview+json" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,10 +3,11 @@
 #
 # Builds the Busabase image from apps/busabase/Dockerfile and pushes multi-arch
 # (amd64 + arm64) to GHCR and Docker Hub, on GitHub's official ubuntu-latest
-# runner. No internal deploy — that stays in the private infra repo.
+# runner. After publishing, it can dispatch the private deploy workflow.
 #
 # Required secrets: DOCKERHUB_TOKEN (a Docker Hub access token for the `busabase`
 # org with push rights). GHCR uses the built-in GITHUB_TOKEN.
+# Required for deploy dispatch: CR_PAT with access to DEPLOY_REPOSITORY.
 name: Docker
 
 on:
@@ -22,6 +23,9 @@ on:
       - "!apps/busabase/docs/**"
       - "!apps/busabase/public/assets/**"
   workflow_dispatch:
+
+env:
+  DEPLOY_REPOSITORY: vikadata/ops-manager
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -75,3 +79,29 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Dispatch internal deploy
+        env:
+          DEPLOY_TOKEN: ${{ secrets.CR_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_TOKEN:-}" ]; then
+            echo "CR_PAT is not configured; skipping deploy dispatch."
+            exit 0
+          fi
+
+          short_sha="${GITHUB_SHA::7}"
+          version="sha-${short_sha}"
+
+          echo "Dispatching deploy for busabase @ ${version}"
+          PAYLOAD=$(jq -nc \
+            --arg semver "${version}" \
+            --arg image "ghcr.io/${{ github.repository_owner }}/busabase:${version}" \
+            --arg arch "$(uname -m)" \
+            '{event_type:"deploy-bika",client_payload:{SEMVER_FULL:$semver,edition:"busabase",app:"busabase",containerName:"busabase",image:$image,arch:$arch}}')
+          curl --fail -sS -X POST "https://api.github.com/repos/${DEPLOY_REPOSITORY}/dispatches" \
+            -H "Authorization: token ${DEPLOY_TOKEN}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" \
+            --data "${PAYLOAD}"
+          echo "Deploy dispatch sent."

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,8 @@
 #
 # Required secrets: DOCKERHUB_TOKEN (a Docker Hub access token for the `busabase`
 # org with push rights). GHCR uses the built-in GITHUB_TOKEN.
-# Required for deploy dispatch: CR_PAT with access to DEPLOY_REPOSITORY.
+# Required for deploy dispatch: CR_PAT plus DEPLOY_REPOSITORY (for example,
+# vikadata/ops-manager).
 name: Docker
 
 on:
@@ -23,9 +24,6 @@ on:
       - "!apps/busabase/docs/**"
       - "!apps/busabase/public/assets/**"
   workflow_dispatch:
-
-env:
-  DEPLOY_REPOSITORY: vikadata/ops-manager
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -83,10 +81,15 @@ jobs:
       - name: Dispatch internal deploy
         env:
           DEPLOY_TOKEN: ${{ secrets.CR_PAT }}
+          DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}
         run: |
           set -euo pipefail
           if [ -z "${DEPLOY_TOKEN:-}" ]; then
             echo "CR_PAT is not configured; skipping deploy dispatch."
+            exit 0
+          fi
+          if [ -z "${DEPLOY_REPOSITORY:-}" ]; then
+            echo "DEPLOY_REPOSITORY is not configured; skipping deploy dispatch."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- Add a Docker version job that mirrors the kapps `compute-version` semver scheme.
- Publish Busabase Docker images with semver-based tags instead of only `latest` and `sha-*`.
- Dispatch deploy using the same semver tag that was pushed.
- Keep deploy repository and event type configurable via secrets.

## Tag Scheme

Matches the kapps docker version format:

- `${packageVersion}-release.${runNumber}.${shortSha}` on `main`
- `${packageVersion}-alpha.${runNumber}.${shortSha}` on non-main refs
- Also tags `v${semver}`, `${packageVersion}`, `${refSlug}`, `${refSlug}-${shortSha}`
- Adds `latest` on `main`

## Deploy Details

- Secret: `CR_PAT` as `DEPLOY_TOKEN`.
- Secret: `DEPLOY_REPOSITORY`, for example `vikadata/ops-manager`.
- Secret: `DEPLOY_EVENT_TYPE`, for example `deploy-bika`.
- Image dispatched: `ghcr.io/${{ github.repository_owner }}/busabase:${semver}`.
- Payload app fields: `edition`, `app`, and `containerName` are all `busabase`.
- If `CR_PAT`, `DEPLOY_REPOSITORY`, or `DEPLOY_EVENT_TYPE` is not configured, the deploy dispatch step skips cleanly so public Docker publishing still succeeds.

## Validation

- `git diff --check`
