### PR TITLE
ci: derive docker tags from package version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,20 +43,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          package_version=$(jq -r '.version' apps/busabase/package.json)
+          package_version=$(node -p "require('./apps/busabase/package.json').version")
           short_sha="${GITHUB_SHA::7}"
           ref_slug=$(printf '%s' "${GITHUB_REF_NAME}" | sed 's#[^A-Za-z0-9_.-]#-#g')
 
-          if [ "${GITHUB_REF_NAME}" = "main" ]; then
-            build_meta="release.${GITHUB_RUN_NUMBER}.${short_sha}"
-          else
-            build_meta="alpha.${GITHUB_RUN_NUMBER}.${short_sha}"
+          if ! [[ "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "apps/busabase/package.json version is not SemVer: ${package_version}" >&2
+            exit 1
           fi
-          semver="${package_version}-${build_meta}"
 
-          tags="${semver}
-          v${semver}
-          ${package_version}
+          docker_version="${package_version%%+*}"
+          major_minor=$(printf '%s' "${docker_version}" | cut -d. -f1,2)
+          major=$(printf '%s' "${docker_version}" | cut -d. -f1)
+
+          tags="${docker_version}
+          ${major_minor}
+          ${major}
           ${ref_slug}
           ${ref_slug}-${short_sha}"
           if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
@@ -66,13 +68,13 @@ jobs:
           tags=$(printf '%s\n' "${tags}" | sed 's/^[[:space:]]*//')
 
           {
-            echo "version=${semver}"
+            echo "version=${docker_version}"
             echo "tag_values<<__TAGS_EOF__"
             echo "${tags}"
             echo "__TAGS_EOF__"
           } >> "$GITHUB_OUTPUT"
 
-          echo "Version: ${semver}"
+          echo "Version: ${docker_version}"
           echo "Tags:"
           echo "${tags}"
 


### PR DESCRIPTION
## Summary

This updates the Docker workflow so image tags come directly from `apps/busabase/package.json` instead of inventing a run-specific semver suffix.

The workflow now reads the Busabase app package version with Node, validates that it is SemVer, strips any SemVer build metadata that Docker tags cannot represent, and publishes tags derived from that version. For the current package version, a main build will publish `0.1.4`, `0.1`, `0`, `main`, `main-<shortSha>`, and `latest`.

## Why

The previous workflow generated tags like `${packageVersion}-release.${runNumber}.${shortSha}` and used that synthetic value for the deploy dispatch payload. That made the pushed image unique per workflow run, but it also meant the Docker image version was not the same version recorded in `package.json`.

Reading `apps/busabase/package.json` keeps Docker publishing aligned with the app release version. The existing branch and SHA tags still provide traceability for a specific build, while the package-derived SemVer tags provide stable release tags for consumers.

## Validation

- Parsed `.github/workflows/docker.yml` as YAML.
- Ran `bash -n .github/workflows/docker.yml`.
- Simulated the version/tag computation locally with the current `apps/busabase/package.json` version.
- Ran `git diff --check`.
