### PR TITLE
chore(release): align Busabase packages to 0.9.3

### DIFF
--- a/apps/busabase-cli/package.json
+++ b/apps/busabase-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-cli",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Command-line client for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server`.",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-cli",

--- a/apps/busabase-desktop/package.json
+++ b/apps/busabase-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@busabase/desktop",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "scripts": {
     "dev": "next dev --port 3064",

--- a/apps/busabase-desktop/src-tauri/Cargo.lock
+++ b/apps/busabase-desktop/src-tauri/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "busabase_desktop"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "semver",
  "serde",

--- a/apps/busabase-desktop/src-tauri/Cargo.toml
+++ b/apps/busabase-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busabase_desktop"
-version = "0.9.2"
+version = "0.9.3"
 description = "Busabase Desktop - private local-first Busabase knowledge base shell"
 authors = ["Busabase Team"]
 edition = "2021"

--- a/apps/busabase-desktop/src-tauri/tauri.conf.json
+++ b/apps/busabase-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Busabase Desktop",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "identifier": "com.busabase.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/busabase-mobile/app.json
+++ b/apps/busabase-mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Busabase",
     "slug": "busabase-mobile",
     "scheme": "busabase",
-    "version": "0.9.2",
+    "version": "0.9.3",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/busabase-mobile/package.json
+++ b/apps/busabase-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-mobile",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "main": "expo-router/entry",
   "private": true,
   "scripts": {

--- a/apps/busabase-sdk/package.json
+++ b/apps/busabase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-sdk",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Typed TypeScript/JavaScript SDK for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server` (or Busabase Cloud).",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-sdk",

--- a/apps/busabase/package.json
+++ b/apps/busabase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase",
   "description": "Open-source Busabase review app + CLI. `busabase server` boots a zero-setup local instance (pglite); other subcommands act as an OpenAPI client.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-repo",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "packageManager": "pnpm@10.15.1",
   "workspaces": [
     "apps/*",

--- a/packages/busabase-contract/package.json
+++ b/packages/busabase-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-contract",
   "description": "Client-safe Busabase surface: oRPC contracts (OSS + cloud), node-type kernel, VO types, and the oRPC client factories. Pure leaf — no db/logic/server deps. Consumed by busabase-cli, busabase-mobile, busabase-core, busabase, and busabase-cloud.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/busabase-core/package.json
+++ b/packages/busabase-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-core",
   "description": "Shared Busabase open-core protocol, local store, API helpers, and dashboard components.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump the Busabase OSS workspace from 0.9.2 to 0.9.3 across the server, CLI, SDK, desktop, mobile, contract, and core packages.
- Align the standalone root package version generated by the OSS sync.
- Update native app metadata versions for Tauri desktop and Expo mobile.

## Verification
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true make typecheck` in kapps
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm lint:err` in kapps
- `pnpm install` in `~/Documents/busabase`
- `pnpm --filter busabase typecheck` in `~/Documents/busabase`
- `pnpm --filter busabase build` in `~/Documents/busabase`
- README relative link check passed
- Secret scan found only `.env.example` and benign text matches; no app `content/` diff was included

## Notes
- Public npm latest for `busabase`, `busabase-cli`, and `busabase-sdk` was 0.9.2 before this bump.
- The sync was rerun after fetching LFS assets so the public repo keeps real image binaries rather than LFS pointer text files.