### PR TITLE
fix: change-request detail uses uncapped data + e2e assertion fixes

### DIFF
--- a/apps/busabase/tests/e2e/busabase-smoke.spec.ts
+++ b/apps/busabase/tests/e2e/busabase-smoke.spec.ts
@@ -55,7 +55,11 @@ test("dashboard routes render the review-first seeded experience", async ({ page
 
   await page.goto("/dashboard/activity");
   await expect(page.getByText("Workspace activity")).toBeVisible();
-  await expect(page.getByText(/change requests · \d+ operations · \d+ records/)).toBeVisible();
+  // The activity feed no longer renders a "N change requests · M operations ·
+  // K records" summary line (messages.activity.activityStats is defined in
+  // i18n but unused by the component — dead copy from a past redesign); the
+  // per-entry feed itself is what actually proves the seed's activity shows
+  // up, same as the assertion right below.
   await expect(
     page.getByRole("link", { name: /Change request|operation|Record/i }).first(),
   ).toBeVisible();

--- a/apps/busabase/tests/e2e/demo-mode.spec.ts
+++ b/apps/busabase/tests/e2e/demo-mode.spec.ts
@@ -47,7 +47,16 @@ test("?demo={use-case} focuses the seed (blog excludes other bases)", async ({ r
     await request.get("/api/v1/change-requests?demo=blog"),
   );
   expect(changeRequests.length).toBeGreaterThan(0);
-  expect(changeRequests.every((cr) => cr.baseId === bases[0].id)).toBe(true);
+  // Base-scoped CRs must all belong to the blog base — that's the actual
+  // "excludes other bases" guarantee. Doc-level CRs (baseId: null, e.g. the
+  // seeded Agent Operating Guide update) are deliberately NOT use-case-scoped
+  // — they're general knowledge-base content the demo shows regardless of
+  // which base-focused scenario is selected (confirmed: the same doc CR
+  // appears identically under every ?demo={use-case}), so they're excluded
+  // from this check rather than asserted to have blog's baseId.
+  const baseScoped = changeRequests.filter((cr) => cr.baseId !== null);
+  expect(baseScoped.length).toBeGreaterThan(0);
+  expect(baseScoped.every((cr) => cr.baseId === bases[0].id)).toBe(true);
 
   const records = await json<RecordVO[]>(await request.get("/api/v1/records?demo=blog"));
   expect(records.every((record) => record.base.slug === "blog")).toBe(true);

--- a/apps/busabase/tests/e2e/new-user-journey.spec.ts
+++ b/apps/busabase/tests/e2e/new-user-journey.spec.ts
@@ -83,6 +83,13 @@ test("a new user tours the approval-first knowledge base", async ({ page }) => {
   await test.step("checks the workspace activity feed", async () => {
     await page.goto("/dashboard/activity");
     await expect(page.getByText("Workspace activity")).toBeVisible();
-    await expect(page.getByText(/change requests · \d+ operations · \d+ records/)).toBeVisible();
+    // No "N change requests · M operations · K records" summary line is
+    // rendered anymore (messages.activity.activityStats is defined in i18n
+    // but unused by the component — dead copy from a past redesign); assert
+    // the per-entry feed itself instead, which is what actually proves the
+    // seed's activity shows up.
+    await expect(
+      page.getByRole("link", { name: /Change request|operation|Record/i }).first(),
+    ).toBeVisible();
   });
 });

--- a/apps/busabase/tests/e2e/review-experience.spec.ts
+++ b/apps/busabase/tests/e2e/review-experience.spec.ts
@@ -170,7 +170,11 @@ test("same-field merge conflict stays visible and recoverable", async ({ page, r
   await expect(page.getByText("Approved · ready to merge")).toBeVisible();
   await page.getByRole("button", { name: "Merge into Base" }).click();
   await expect(page.getByText("Merge needs review")).toBeVisible();
-  await expect(page.getByText(/Conflicting field.*title/)).toBeVisible();
+  // The conflict is surfaced twice by design: the raw backend message (in the
+  // ReviewConflictPanel banner) embeds "Conflicting field(s): title", and the
+  // ConflictDiffPanel below it restates the same fields as a styled pill list —
+  // match either, .first() avoids a strict-mode multi-match failure.
+  await expect(page.getByText(/Conflicting field.*title/).first()).toBeVisible();
   await expect(page.getByText("The change request is still safe here")).toBeVisible();
   await expect(page.getByRole("heading", { name: `${title} B` })).toBeVisible();
 });

--- a/packages/busabase-core/src/domains/dashboard/index.tsx
+++ b/packages/busabase-core/src/domains/dashboard/index.tsx
@@ -185,6 +185,7 @@ function BusabaseDashboardContent({
       changeRequests: orpc.changeRequests.list.queryOptions({ input: {} }).queryKey as QueryKey,
       changeRequestsPaged: orpc.changeRequests.listPaged.key() as QueryKey,
       changeRequestCounts: orpc.changeRequests.counts.key() as QueryKey,
+      changeRequestDetail: orpc.changeRequests.get.key() as QueryKey,
       records: orpc.records.listPaged.key() as QueryKey,
       recordsCount: orpc.records.count.key() as QueryKey,
       bases: orpc.bases.list.queryOptions({}).queryKey as QueryKey,
@@ -512,20 +513,23 @@ function BusabaseDashboardContent({
       setRelationRecordIds((previous) => [...previous, ...fresh]);
     }
   }, [missingRelationRecordIds, relationRecordIds]);
-  // A change request opened by direct link may not be in the list query (e.g. a
-  // merged/closed CR); fetch it on demand via React Query and fall back to it.
+  // The list query caps each CR's `operations` (see LIST_MAX_OPERATIONS_PER_CHANGE_REQUEST)
+  // and strips `reviews[].visibleOperationHeads` for payload size — fine for inbox
+  // rows, but the single-CR detail view needs the uncapped, un-stripped shape
+  // (full diffs past 5 operations; `changedSinceReview` staleness detection).
+  // It also covers a change request opened by direct link that isn't in the
+  // list query at all (e.g. a merged/closed CR).
+  const isChangeRequestDetailRoute = isChangeRequestRoute || isOperationRoute;
   const fallbackChangeRequestQuery = useQuery({
     ...orpc.changeRequests.get.queryOptions({
       input: { changeRequestId: selectedChangeRequestId ?? "" },
     }),
-    enabled:
-      Boolean(selectedChangeRequestId) &&
-      !allChangeRequests.some((changeRequest) => changeRequest.id === selectedChangeRequestId),
+    enabled: Boolean(selectedChangeRequestId) && isChangeRequestDetailRoute,
   });
   const selectedChangeRequest = useMemo(
     () =>
-      allChangeRequests.find((changeRequest) => changeRequest.id === selectedChangeRequestId) ??
       fallbackChangeRequestQuery.data ??
+      allChangeRequests.find((changeRequest) => changeRequest.id === selectedChangeRequestId) ??
       null,
     [allChangeRequests, selectedChangeRequestId, fallbackChangeRequestQuery.data],
   );
@@ -766,6 +770,7 @@ function BusabaseDashboardContent({
       queryClient.invalidateQueries({ queryKey: listKeys.changeRequests }),
       queryClient.invalidateQueries({ queryKey: listKeys.changeRequestsPaged }),
       queryClient.invalidateQueries({ queryKey: listKeys.changeRequestCounts }),
+      queryClient.invalidateQueries({ queryKey: listKeys.changeRequestDetail }),
       queryClient.invalidateQueries({ queryKey: listKeys.records }),
       queryClient.invalidateQueries({ queryKey: listKeys.recordsCount }),
       queryClient.invalidateQueries({ queryKey: listKeys.bases }),


### PR DESCRIPTION
## Problem
The single change-request review page could silently show stale/truncated information: an agent's revision after a human requested changes never showed the "changed since review" indicator, and a bulk change request proposing more than 5 records only showed diffs for the first 5.

## Root cause
The detail page read the change request from the same `changeRequests.list` query used for inbox rows. That list query intentionally caps `operations` at 5 and strips `reviews[].visibleOperationHeads` to keep list payloads small — correct for a row preview, wrong for the detail view. A fallback query to the uncapped `changeRequests.get` endpoint existed but was only enabled when the CR was *missing* from the list, so it effectively never fired.

Found via the new CI e2e job (first time e2e ever ran in this repo) — 4 other pre-existing e2e failures surfaced alongside it, all root-caused individually rather than papered over:
- `demo-mode.spec.ts`: asserted every change request under `?demo=blog` belonged to the blog base, but a doc-level CR (`baseId: null`) is intentionally global across every use-case scope (confirmed via direct API comparison across blog/social/newsletter/crm).
- `busabase-smoke.spec.ts` / `new-user-journey.spec.ts`: both asserted on an activity-feed summary line that no longer renders (dead i18n copy from a past redesign).
- `review-experience.spec.ts`: a conflict-resolution regex now legitimately matches two elements (the raw backend message + the styled conflict panel).

## Fix
- `packages/busabase-core/src/domains/dashboard/index.tsx`: detail route always fetches the uncapped `changeRequests.get` query and prefers it over the capped list entry; wired into the existing post-review cache invalidation.
- 4 e2e spec assertion fixes, each with an explanatory comment.

## Validation
- `pnpm --filter busabase-core --filter busabase run typecheck` — clean.
- Full local e2e suite, run serially (`--workers=1`, matching CI): **40/40 passing**.
- The `changeRequests.get` network response was inspected directly (not inferred) before/after the fix to confirm `visibleOperationHeads` actually reaches the browser populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)