### PR TITLE
fix(ci): connect CMS example deployment to public demo

### DIFF
--- a/.github/workflows/vercel-cms-example.yml
+++ b/.github/workflows/vercel-cms-example.yml
@@ -47,6 +47,10 @@ env:
   NODE_VERSION: 24.18.0
   EXAMPLE_DIRECTORY: packages/busabase-example-nextjs-fumadocs
   DEPLOY_ENVIRONMENT: ${{ (github.event_name == 'push' || inputs.environment == 'production') && 'production' || 'preview' }}
+  BUSABASE_BASE_URL: https://demo.busabase.com
+  BUSABASE_CMS_FOLDER_ID: nodmru0gtq2tdiukii
+  BUSABASE_CMS_DEFAULT_LOCALE: en
+  BUSABASE_CMS_LOCALES: en,zh-CN
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -125,10 +129,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          cms_runtime_env=(
+            --env "BUSABASE_BASE_URL=${BUSABASE_BASE_URL}"
+            --env "BUSABASE_CMS_FOLDER_ID=${BUSABASE_CMS_FOLDER_ID}"
+            --env "BUSABASE_CMS_DEFAULT_LOCALE=${BUSABASE_CMS_DEFAULT_LOCALE}"
+            --env "BUSABASE_CMS_LOCALES=${BUSABASE_CMS_LOCALES}"
+          )
           if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
-            deployment_url=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+            deployment_url=$(vercel deploy --prebuilt --prod "${cms_runtime_env[@]}" --token="$VERCEL_TOKEN")
           else
-            deployment_url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+            deployment_url=$(vercel deploy --prebuilt "${cms_runtime_env[@]}" --token="$VERCEL_TOKEN")
           fi
           echo "url=${deployment_url}" >> "$GITHUB_OUTPUT"
 
@@ -143,4 +153,6 @@ jobs:
             echo
             echo "- Environment: **${DEPLOY_ENVIRONMENT}**"
             echo "- URL: [${DEPLOYMENT_URL}](${DEPLOYMENT_URL})"
+            echo "- CMS endpoint: [${BUSABASE_BASE_URL}](${BUSABASE_BASE_URL})"
+            echo "- CMS folder: \`${BUSABASE_CMS_FOLDER_ID}\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The Vercel CMS example workflow deployed the application without a defined Busabase content source. A deployment could therefore start in the unconfigured empty state unless the same variables were manually duplicated in the Vercel project.

## Fix

- Configure the public anonymous Busabase instance at `https://demo.busabase.com` for the CMS example build.
- Point the example to the dedicated `Next.js Fumadocs Demo CMS` Folder (`nodmru0gtq2tdiukii`).
- Keep the setup credential-free: no `BUSABASE_API_KEY` or `BUSABASE_SPACE_ID` is used.
- Inject the public CMS values into both Preview and Production Server Function runtimes when deploying the prebuilt output.
- Report the CMS endpoint and Folder ID in the GitHub Actions job summary.

The dedicated Folder has already been provisioned with the standard Posts, Pages, Categories, and Tags Bases by `busabase-cms` lazy setup.

## Validation

- Parsed the workflow successfully with Ruby YAML.
- Checked all seven workflow shell blocks with `bash -n`.
- Confirmed Vercel CLI 50.22.1 supports `--env` with `deploy --prebuilt`.
- Verified `https://demo.busabase.com/api/v1/bases` is anonymously accessible.
- Verified the configured Folder and all four standard Bases through the live anonymous API.
- Ran the Next.js + Fumadocs example against the live Demo instance without credentials; `/`, `/blog`, `/pages`, and `/sitemap.xml` all returned HTTP 200 with no schema errors after provisioning completed.
- `git diff --check` passed.

## Confidence

High for the workflow configuration and anonymous Busabase integration. Both YAML/shell structure and the real application-to-Demo HTTP path were exercised.

## Known Limitation

The repository still needs `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` secrets before the workflow can perform an actual Vercel deployment. Without them, the existing guard intentionally reports a warning and skips deploy steps.
