### PR TITLE
fix(ci): deploy CMS example from workspace root

### DIFF
--- a/.github/workflows/vercel-cms-example.yml
+++ b/.github/workflows/vercel-cms-example.yml
@@ -45,7 +45,6 @@ concurrency:
 
 env:
   NODE_VERSION: 24.18.0
-  EXAMPLE_DIRECTORY: packages/busabase-example-nextjs-fumadocs
   DEPLOY_ENVIRONMENT: ${{ (github.event_name == 'push' || inputs.environment == 'production') && 'production' || 'preview' }}
   BUSABASE_BASE_URL: https://demo.busabase.com
   BUSABASE_CMS_FOLDER_ID: nodmru0gtq2tdiukii
@@ -107,12 +106,10 @@ jobs:
 
       - name: Pull Vercel environment
         if: steps.vercel_config.outputs.ready == 'true'
-        working-directory: ${{ env.EXAMPLE_DIRECTORY }}
         run: vercel pull --yes --environment="$DEPLOY_ENVIRONMENT" --token="$VERCEL_TOKEN"
 
       - name: Build Vercel project
         if: steps.vercel_config.outputs.ready == 'true'
-        working-directory: ${{ env.EXAMPLE_DIRECTORY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -125,7 +122,6 @@ jobs:
       - name: Deploy prebuilt output
         if: steps.vercel_config.outputs.ready == 'true'
         id: deploy
-        working-directory: ${{ env.EXAMPLE_DIRECTORY }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/vercel-cms-example.yml
+++ b/.github/workflows/vercel-cms-example.yml
@@ -97,9 +97,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
-      - name: Install example and workspace dependencies
+      - name: Install workspace dependencies
         if: steps.vercel_config.outputs.ready == 'true'
-        run: pnpm install --frozen-lockfile --filter "busabase-example-nextjs-fumadocs..."
+        run: pnpm install --frozen-lockfile
 
       - name: Install Vercel CLI
         if: steps.vercel_config.outputs.ready == 'true'

--- a/.github/workflows/vercel-cms-example.yml
+++ b/.github/workflows/vercel-cms-example.yml
@@ -50,6 +50,7 @@ env:
   BUSABASE_CMS_FOLDER_ID: nodmru0gtq2tdiukii
   BUSABASE_CMS_DEFAULT_LOCALE: en
   BUSABASE_CMS_LOCALES: en,zh-CN
+  NEXT_PUBLIC_SITE_URL: https://busabase-cms-example.vercel.app
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -130,6 +131,7 @@ jobs:
             --env "BUSABASE_CMS_FOLDER_ID=${BUSABASE_CMS_FOLDER_ID}"
             --env "BUSABASE_CMS_DEFAULT_LOCALE=${BUSABASE_CMS_DEFAULT_LOCALE}"
             --env "BUSABASE_CMS_LOCALES=${BUSABASE_CMS_LOCALES}"
+            --env "NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL}"
           )
           if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
             deployment_url=$(vercel deploy --prebuilt --prod "${cms_runtime_env[@]}" --token="$VERCEL_TOKEN")

--- a/packages/busabase-core/tests/webhook-orpc.test.ts
+++ b/packages/busabase-core/tests/webhook-orpc.test.ts
@@ -302,6 +302,11 @@ describe("Webhook automation domain — oRPC", () => {
       const expectedSig = createHmac("sha256", "s3cr3t").update(hit!.body).digest("hex");
       expect(hit!.signature).toBe(expectedSig);
 
+      await waitFor(async () => {
+        const deliveries = await client.webhooks.deliveries({ ruleId: rule.id, limit: 10 });
+        return deliveries.length > 0;
+      }, 2000);
+
       const deliveries = await client.webhooks.deliveries({ ruleId: rule.id, limit: 10 });
       expect(deliveries[0]?.status).toBe("success");
     });


### PR DESCRIPTION
## Summary

- install the complete pnpm workspace before building the CMS example
- run `vercel pull`, `vercel build`, and `vercel deploy --prebuilt` from the monorepo root
- rely on the Vercel project Root Directory to select `packages/busabase-example-nextjs-fumadocs`
- configure `NEXT_PUBLIC_SITE_URL` for canonical URLs and the generated sitemap
- wait for asynchronous webhook delivery persistence in the coverage test before asserting its status

## Why

Running Vercel from the package directory caused two deployment failures:

1. The configured Vercel Root Directory was appended twice.
2. Next.js traced the hoisted `@opentelemetry/api` peer from the workspace root, but `vercel deploy --prebuilt` looked for it under the package directory.

The workspace-root workflow matches Vercel monorepo semantics and keeps the traced dependency available.

The coverage job also exposed a pre-existing timing race in the webhook integration test: receiving the HTTP request does not guarantee that the fire-and-forget dispatcher has already persisted its delivery row. The test now polls for that row using its existing bounded `waitFor` helper before asserting the result. Production behavior is unchanged.

## Deployment configuration

- Vercel project: `busabase-cms-example`
- Project Root Directory: `packages/busabase-example-nextjs-fumadocs`
- CMS endpoint: `https://demo.busabase.com`
- CMS folder: `nodmru0gtq2tdiukii`
- Production URL: `https://busabase-cms-example.vercel.app`

## Verification

- Preview deployment: passed
- Production deployment: passed
- `/`: HTTP 200
- `/blog`: HTTP 200
- `/pages`: HTTP 200
- `/sitemap.xml`: HTTP 200 with `application/xml`
- sitemap locations use `https://busabase-cms-example.vercel.app`
- focused webhook tests: 24/24 passed
- focused webhook tests with coverage: 24/24 passed
- complete `busabase-core` coverage suite: 992/992 passed
- `busabase-core` typecheck: passed
- `git diff --check`: passed

## Notes

Vercel Preview URLs are protected by the team deployment-protection policy. The production URL is publicly accessible.