### PR TITLE
fix(ci): stop ci-badge from crashing on shallow-clone merge-base lookup

### DIFF
--- a/.github/workflows/ci-badge.yml
+++ b/.github/workflows/ci-badge.yml
@@ -39,9 +39,17 @@ jobs:
         # Defence in depth: `paths` already scoped this workflow to the badge,
         # but that filter looks at the whole push. Diffing against the base
         # makes sure no code slipped through on a badge-labelled commit.
+        #
+        # Diff against the PR's exact base SHA with a plain two-dot diff, not
+        # `origin/<base_ref>...HEAD`. actions/checkout@v4 leaves both sides
+        # shallow (depth 1, no shared ancestor commit), so a three-dot diff
+        # — which needs a merge-base — fails with "no merge base" on any real
+        # release branch (more than one commit ahead of main). A two-dot diff
+        # just compares the two trees directly and needs no shared history,
+        # so fetching the single base commit by SHA is enough.
         run: |
-          git fetch --depth=1 origin '${{ github.base_ref }}'
-          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          git fetch --depth=1 origin '${{ github.event.pull_request.base.sha }}'
+          changed=$(git diff --name-only '${{ github.event.pull_request.base.sha }}' HEAD)
           echo "$changed"
           unexpected=$(echo "$changed" | grep -v '^apps/busabase/public/assets/readme/coverage.svg$' || true)
           if [ -n "$unexpected" ]; then


### PR DESCRIPTION
## Problem

`.github/workflows/ci-badge.yml`'s defence-in-depth check crashes on any real release branch:

```
git fetch --depth=1 origin '${{ github.base_ref }}'
changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
```

`actions/checkout@v4` leaves the workspace shallow (depth 1, no ancestor history). Fetching `main` with `--depth=1` is *also* shallow. Neither side shares a commit, so the three-dot diff (which needs a merge-base) fails with `fatal: ... no merge base`, and the job errors out instead of evaluating whether the PR is badge-only.

This is exactly what happened on `release/busabase-0.13.0` (#19): `ci-ok` from this workflow reported a stale FAILURE from the crash, while the real `checks / *` pipeline's own `ci-ok` run later reported SUCCESS. Branch protection saw two check-runs under the same required name and stayed `BLOCKED` until an admin merge overrode it.

## Fix

Fetch the PR's exact base commit by SHA (`github.event.pull_request.base.sha`) and diff it against `HEAD` with a plain two-dot diff. A two-dot diff compares the two trees directly and never needs a merge-base or shared history, so a depth-1 fetch of that one SHA is sufficient.

## Testing

- Reproduced the failure mode locally: a three-dot diff between two shallow, disconnected commit fetches fails with "no merge base"; a two-dot diff between the same two commits (even far apart, 560 changed files) succeeds cleanly.
- Not able to fully replicate `actions/checkout`'s exact shallow-fetch mechanics against a local `file://` remote (GitHub's server allows fetching arbitrary SHAs; a local git server needs extra config to allow it), but the two-dot-diff behavior that fixes the actual bug is verified.
- Will also serve as this PR's own real-world test: it changes a workflow file (not `coverage.svg`), so it runs through the full `CI (pull request)` pipeline rather than `ci-badge.yml` itself — the next *actual* badge-only commit (from this or the next release) is what will exercise the fixed path for real.