### PR TITLE
chore: release Busabase v0.14.0

### DIFF
--- a/.github/workflows/ci-badge.yml
+++ b/.github/workflows/ci-badge.yml
@@ -37,22 +37,31 @@ jobs:
       - uses: actions/checkout@v4
       - name: Confirm nothing but the coverage badge changed
         # Defence in depth: `paths` already scoped this workflow to the badge,
-        # but that filter looks at the whole push. Diffing against the base
-        # makes sure no code slipped through on a badge-labelled commit.
+        # but that filter looks at the whole push. Diffing makes sure no code
+        # slipped through disguised as a badge-labelled commit.
         #
-        # Diff against the PR's exact base SHA with a plain two-dot diff, not
-        # `origin/<base_ref>...HEAD`. actions/checkout@v4 leaves both sides
-        # shallow (depth 1, no shared ancestor commit), so a three-dot diff
-        # — which needs a merge-base — fails with "no merge base" on any real
-        # release branch (more than one commit ahead of main). A two-dot diff
-        # just compares the two trees directly and needs no shared history,
-        # so fetching the single base commit by SHA is enough.
+        # Diff against the PREVIOUS head of this push (`github.event.before`),
+        # not the PR's base SHA. A real release branch is never badge-only
+        # relative to main — it carries the actual release diff — so comparing
+        # against base would fail this check on every release, exactly the
+        # case ci-pr.yml's coverage job creates when it commits the refreshed
+        # badge onto a release/* branch. What must be badge-only is this one
+        # push, not the whole PR; `before` is only present on `synchronize`,
+        # so fall back to `base.sha` for a PR that opens with just the badge.
+        #
+        # Plain two-dot diff, not `before...HEAD`. actions/checkout@v4 leaves
+        # both sides shallow (depth 1, no shared ancestor commit), so a
+        # three-dot diff — which needs a merge-base — fails with "no merge
+        # base". A two-dot diff just compares the two trees directly and
+        # needs no shared history, so fetching the single base commit by SHA
+        # is enough.
         run: |
-          git fetch --depth=1 origin '${{ github.event.pull_request.base.sha }}'
-          changed=$(git diff --name-only '${{ github.event.pull_request.base.sha }}' HEAD)
+          base='${{ github.event.before || github.event.pull_request.base.sha }}'
+          git fetch --depth=1 origin "$base"
+          changed=$(git diff --name-only "$base" HEAD)
           echo "$changed"
           unexpected=$(echo "$changed" | grep -v '^apps/busabase/public/assets/readme/coverage.svg$' || true)
           if [ -n "$unexpected" ]; then
-            echo "::error::Not a badge-only pull request; refusing to wave it through."
+            echo "::error::Not a badge-only push; refusing to wave it through."
             exit 1
           fi

--- a/.github/workflows/ci-badge.yml
+++ b/.github/workflows/ci-badge.yml
@@ -10,8 +10,16 @@
 # what the previous commit already proved, so this waves it through instead. The
 # job name must stay exactly `ci-ok` — that string is the required check.
 #
-# The `paths` here and the `paths-ignore` in ci-pr.yml are complementary: every
-# commit must match exactly one of them. Change one and change the other.
+# Triggered on `push`, NOT `pull_request`. GitHub's `paths`/`paths-ignore`
+# filters for `pull_request` events match against the PR's *cumulative* diff
+# against its base branch, not the commits introduced by a given push. Once
+# the coverage job's bot commit lands once, coverage.svg stays part of that
+# cumulative diff for the rest of the PR's life, so a `pull_request`-triggered
+# version of this workflow (and `ci-pr.yml`'s paths-ignore) would keep
+# re-matching — and, worse, this workflow's own defence-in-depth check would
+# then fail every later push, since none of those pushes are themselves
+# badge-only. `push` path filters look only at the commits in that specific
+# push, which is what "was this commit a badge-only commit" actually needs.
 #
 # Owned by this open-source repo (busabase/busabase). The kapps sync
 # (scripts/publish-busabase-repo.ts) PRESERVES `.github`, so it never overwrites
@@ -19,8 +27,8 @@
 name: CI (badge only)
 
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches: ["release/**"]
     paths:
       - "apps/busabase/public/assets/readme/coverage.svg"
 
@@ -35,30 +43,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - name: Confirm nothing but the coverage badge changed
-        # Defence in depth: `paths` already scoped this workflow to the badge,
-        # but that filter looks at the whole push. Diffing makes sure no code
-        # slipped through disguised as a badge-labelled commit.
-        #
-        # Diff against the PREVIOUS head of this push (`github.event.before`),
-        # not the PR's base SHA. A real release branch is never badge-only
-        # relative to main — it carries the actual release diff — so comparing
-        # against base would fail this check on every release, exactly the
-        # case ci-pr.yml's coverage job creates when it commits the refreshed
-        # badge onto a release/* branch. What must be badge-only is this one
-        # push, not the whole PR; `before` is only present on `synchronize`,
-        # so fall back to `base.sha` for a PR that opens with just the badge.
-        #
-        # Plain two-dot diff, not `before...HEAD`. actions/checkout@v4 leaves
-        # both sides shallow (depth 1, no shared ancestor commit), so a
-        # three-dot diff — which needs a merge-base — fails with "no merge
-        # base". A two-dot diff just compares the two trees directly and
-        # needs no shared history, so fetching the single base commit by SHA
-        # is enough.
+        # Defence in depth: `paths` already scoped this workflow to pushes
+        # that touch the badge, but that filter looks at the whole push (all
+        # commits it contains). Diffing against the push's previous head
+        # (`github.event.before`) makes sure no code slipped through
+        # disguised as a badge-labelled push.
         run: |
-          base='${{ github.event.before || github.event.pull_request.base.sha }}'
-          git fetch --depth=1 origin "$base"
-          changed=$(git diff --name-only "$base" HEAD)
+          changed=$(git diff --name-only '${{ github.event.before }}' HEAD)
           echo "$changed"
           unexpected=$(echo "$changed" | grep -v '^apps/busabase/public/assets/readme/coverage.svg$' || true)
           if [ -n "$unexpected" ]; then

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -6,11 +6,15 @@
 # jobs instead would mean editing branch protection every time a job is added or
 # renamed, and — more importantly — it would deadlock the badge commit below.
 #
-# `paths-ignore` pairs with ci-badge.yml: a commit that only touches
-# coverage.svg skips this workflow and is waved through there instead. GitHub
+# `paths-ignore` pairs with ci-badge.yml: a PR that is *only* the coverage
+# badge (nothing else in its diff against `main`) skips this workflow and is
+# waved through by ci-badge.yml's `push`-triggered version instead. GitHub
 # never reports a required check for a workflow skipped by a path filter, so a
 # same-named `ci-ok` job has to exist on the other side or such a PR would sit
-# "Expected — waiting for status" forever.
+# "Expected — waiting for status" forever. Note `pull_request` path filters
+# match the PR's cumulative diff against `main`, not a single push, so once a
+# release branch has any real changes this condition never re-triggers a skip
+# — which is correct: every later push should get the full suite.
 #
 # Owned by this open-source repo (busabase/busabase). The kapps sync
 # (scripts/publish-busabase-repo.ts) PRESERVES `.github`, so it never overwrites

--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ Follow its onboarding to set me up, and never merge a ChangeRequest without my a
 
 </details>
 
-**→** [Bring Your Own Agent](./apps/busabase/docs/bring-your-agent.md) — the full flow, then
+**→** [Claude Code Guide](./apps/busabase/docs/claude-code.md) — install the local skill or Cloud plugin, verify
+the connection, and start with safe approval-first prompts.
+
+**→** [Bring Your Own Agent](./apps/busabase/docs/bring-your-agent.md) — the agent-neutral flow, then
 `npx skills add busabase/skills` installs a permanent skill so you never re-paste it.
 
 ### Where your data lives
@@ -412,10 +415,8 @@ CHANGE_REQUEST_ID=$(curl -s -X POST \
 echo "Review: http://localhost:15419/dashboard/local/inbox/$CHANGE_REQUEST_ID"
 
 # 4. Optional automation after a human approves: merge and read canonical records.
-curl -s -X POST "http://localhost:15419/api/v1/change-requests/merge" \
-  -H 'content-type: application/json' \
-  --data "{\"changeRequestIds\":[\"$CHANGE_REQUEST_ID\"]}" \
-  | jq '.results[0].record.id, .results[0].record.headCommit.fields.title'
+curl -s -X POST "http://localhost:15419/api/v1/change-requests/$CHANGE_REQUEST_ID/merge" \
+  | jq '.record.id, .record.headCommit.fields.title'
 curl -s "http://localhost:15419/api/v1/records?baseId=$BLOG_BASE_ID" \
   | jq '.[].headCommit.fields.title'
 ```
@@ -474,6 +475,22 @@ Use it when:
 - data should remain local, but certain approved records or endpoints should be reachable
 
 This is different from cloud-first tools like Notion or Airtable. Busabase can let data remain distributed with the people or teams who own it, while still offering controlled API access, review, automation, and audit trails.
+
+## Architecture
+
+<div align="center">
+  <img src="public/architecture-diagram.svg" alt="Busabase architecture diagram" width="100%">
+</div>
+
+Busabase's app package (`apps/busabase`) is a thin Next.js shell — it only owns `settings`,
+`vault`, and `webhook`. Everything else (the review primitives: Nodes, Commits, Change
+Requests, Operations, Reviews, Comments, Audit Events; and the content domains: base,
+assets, doc, drive, form, airapp/skill) lives in the shared `busabase-core` package, which
+is also what [Busabase Cloud](https://busabase.com) runs. `busabase-core` threads
+`{ db, actorId, spaceId }` through `AsyncLocalStorage` so the same engine can be reused by a
+multi-tenant host — but the open-source app never sets that context, so every getter falls
+back to local-mode defaults and there is no `spaceId` column on any table. That's what makes
+this edition single-tenant, local-only, and login-free by construction, not by omission.
 
 ## Open-Source Shape
 

--- a/apps/busabase-cli/package.json
+++ b/apps/busabase-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Command-line client for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server`.",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-cli",

--- a/apps/busabase-cli/src/login-device.test.ts
+++ b/apps/busabase-cli/src/login-device.test.ts
@@ -241,6 +241,51 @@ describe("runLogin --device-code", () => {
     expect(loadDotEnvFile()).not.toHaveProperty("BUSABASE_API_KEY");
   });
 
+  it("reassures the user after several pending polls instead of looking frozen", async () => {
+    let tokenPolls = 0;
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith("/api/auth/device/code")) {
+        return jsonResponse({
+          device_code: "private-device-code",
+          user_code: "ABCD2345",
+          verification_uri: `${CLOUD}/device`,
+          expires_in: 60,
+          interval: 1,
+        });
+      }
+      if (url.endsWith("/api/auth/device/token")) {
+        tokenPolls += 1;
+        return tokenPolls <= 5
+          ? jsonResponse({ error: "authorization_pending", error_description: "Pending" }, 400)
+          : jsonResponse({ access_token: ACCESS_TOKEN, expires_in: 3600 });
+      }
+      if (url.endsWith("/api/v1/device/finalize")) {
+        return jsonResponse({
+          apiKey: API_KEY,
+          apiKeyId: "apk_1",
+          expiresAt: null,
+          credentialType: "api_key",
+        });
+      }
+      if (url.endsWith("/api/v1/auth")) {
+        return jsonResponse({
+          user: { id: "usr_1", email: "dev@example.com" },
+          space: { id: "spc_1", name: "Space One" },
+          spaces: [{ id: "spc_1", name: "Space One" }],
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    }) as typeof fetch;
+
+    const login = runLogin({ baseUrl: CLOUD, deviceCode: true, browser: false });
+    await vi.advanceTimersByTimeAsync(6_000);
+    await expect(login).resolves.toMatchObject({ status: "signed in" });
+    expect(stderr.join("\n")).toContain(
+      "Still waiting… if you already approved in the browser, this can take a few extra seconds to register",
+    );
+  });
+
   it("fails clearly after repeated polling network errors", async () => {
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();

--- a/apps/busabase-cli/src/login.ts
+++ b/apps/busabase-cli/src/login.ts
@@ -346,6 +346,13 @@ async function deviceLogin(
   const deadline = Date.now() + expiresInSeconds * 1000;
   let intervalSeconds = Math.max(1, code.interval ?? 5);
   let consecutiveNetworkFailures = 0;
+  // The CLI's poll and the browser's approve are independent requests with no session
+  // affinity; a just-approved code can briefly still read back as pending. Purely
+  // cosmetic — the loop already keeps retrying regardless — but without this the CLI
+  // looks frozen right after someone approves in the browser, which reads as "stuck".
+  let pendingPollCount = 0;
+  let reassuredAfterApprovalHint = false;
+  const REASSURE_AFTER_POLLS = 4; // ~20s at the default 5s interval
 
   while (Date.now() < deadline) {
     await delay(intervalSeconds * 1000);
@@ -405,6 +412,13 @@ async function deviceLogin(
 
     switch (payload.error) {
       case "authorization_pending":
+        pendingPollCount += 1;
+        if (pendingPollCount >= REASSURE_AFTER_POLLS && !reassuredAfterApprovalHint) {
+          reassuredAfterApprovalHint = true;
+          say(
+            "Still waiting… if you already approved in the browser, this can take a few extra seconds to register — no need to retry.",
+          );
+        }
         continue;
       case "slow_down":
         intervalSeconds += 5;

--- a/apps/busabase-desktop/package.json
+++ b/apps/busabase-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@busabase/desktop",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --port 3064",

--- a/apps/busabase-desktop/src-tauri/Cargo.lock
+++ b/apps/busabase-desktop/src-tauri/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "busabase_desktop"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "semver",
  "serde",

--- a/apps/busabase-desktop/src-tauri/Cargo.toml
+++ b/apps/busabase-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busabase_desktop"
-version = "0.13.0"
+version = "0.14.0"
 description = "Busabase Desktop - private local-first Busabase knowledge base shell"
 authors = ["Busabase Team"]
 edition = "2021"

--- a/apps/busabase-desktop/src-tauri/tauri.conf.json
+++ b/apps/busabase-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Busabase Desktop",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "identifier": "com.busabase.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/busabase-mobile/app.json
+++ b/apps/busabase-mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Busabase",
     "slug": "busabase-mobile",
     "scheme": "busabase",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/busabase-mobile/package.json
+++ b/apps/busabase-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-mobile",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "expo-router/entry",
   "private": true,
   "scripts": {

--- a/apps/busabase-mobile/src/search/node-icons.ts
+++ b/apps/busabase-mobile/src/search/node-icons.ts
@@ -3,11 +3,11 @@ import { getNodeType } from "busabase-contract/domains";
 import {
   AppWindow,
   Bot,
-  ClipboardList,
   CodeXml,
   File,
   FileText,
   Folder,
+  Form,
   HardDrive,
   PenTool,
   Sparkles,
@@ -27,10 +27,10 @@ const NODE_ICONS: Record<string, typeof Folder> = {
   "hard-drive": HardDrive,
   "app-window": AppWindow,
   // The remaining registry icon ids. Without these the types they belong to
-  // (File, Form, Whiteboard, Workflow, HTML) all fell through to the FileText
+  // (File, Whiteboard, Workflow, HTML) all fell through to the FileText
   // fallback and looked identical in the tree and the create sheet.
   file: File,
-  "clipboard-list": ClipboardList,
+  form: Form,
   "pen-tool": PenTool,
   workflow: Workflow,
   "code-xml": CodeXml,

--- a/apps/busabase-sdk/package.json
+++ b/apps/busabase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-sdk",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Typed TypeScript/JavaScript SDK for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server` (or Busabase Cloud).",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-sdk",

--- a/apps/busabase/README.md
+++ b/apps/busabase/README.md
@@ -131,7 +131,10 @@ Follow its onboarding to set me up, and never merge a ChangeRequest without my a
 
 </details>
 
-**→** [Bring Your Own Agent](./docs/bring-your-agent.md) — the full flow, then
+**→** [Claude Code Guide](./docs/claude-code.md) — install the local skill or Cloud plugin, verify
+the connection, and start with safe approval-first prompts.
+
+**→** [Bring Your Own Agent](./docs/bring-your-agent.md) — the agent-neutral flow, then
 `npx skills add busabase/skills` installs a permanent skill so you never re-paste it.
 
 ### Where your data lives
@@ -412,10 +415,8 @@ CHANGE_REQUEST_ID=$(curl -s -X POST \
 echo "Review: http://localhost:15419/dashboard/local/inbox/$CHANGE_REQUEST_ID"
 
 # 4. Optional automation after a human approves: merge and read canonical records.
-curl -s -X POST "http://localhost:15419/api/v1/change-requests/merge" \
-  -H 'content-type: application/json' \
-  --data "{\"changeRequestIds\":[\"$CHANGE_REQUEST_ID\"]}" \
-  | jq '.results[0].record.id, .results[0].record.headCommit.fields.title'
+curl -s -X POST "http://localhost:15419/api/v1/change-requests/$CHANGE_REQUEST_ID/merge" \
+  | jq '.record.id, .record.headCommit.fields.title'
 curl -s "http://localhost:15419/api/v1/records?baseId=$BLOG_BASE_ID" \
   | jq '.[].headCommit.fields.title'
 ```
@@ -474,6 +475,22 @@ Use it when:
 - data should remain local, but certain approved records or endpoints should be reachable
 
 This is different from cloud-first tools like Notion or Airtable. Busabase can let data remain distributed with the people or teams who own it, while still offering controlled API access, review, automation, and audit trails.
+
+## Architecture
+
+<div align="center">
+  <img src="public/architecture-diagram.svg" alt="Busabase architecture diagram" width="100%">
+</div>
+
+Busabase's app package (`apps/busabase`) is a thin Next.js shell — it only owns `settings`,
+`vault`, and `webhook`. Everything else (the review primitives: Nodes, Commits, Change
+Requests, Operations, Reviews, Comments, Audit Events; and the content domains: base,
+assets, doc, drive, form, airapp/skill) lives in the shared `busabase-core` package, which
+is also what [Busabase Cloud](https://busabase.com) runs. `busabase-core` threads
+`{ db, actorId, spaceId }` through `AsyncLocalStorage` so the same engine can be reused by a
+multi-tenant host — but the open-source app never sets that context, so every getter falls
+back to local-mode defaults and there is no `spaceId` column on any table. That's what makes
+this edition single-tenant, local-only, and login-free by construction, not by omission.
 
 ## Open-Source Shape
 

--- a/apps/busabase/docs/claude-code.md
+++ b/apps/busabase/docs/claude-code.md
@@ -1,0 +1,229 @@
+# Use Busabase with Claude Code
+
+[← Back to the README](../README.md)
+
+Busabase gives Claude Code a structured knowledge base where it can search approved information,
+propose changes, and wait for your review before those changes become canonical.
+
+Choose the setup that matches where your workspace runs:
+
+| Your workspace | Recommended setup | Authentication |
+| --- | --- | --- |
+| **Busabase Desktop or local server** | Install the general Busabase skill | No account or API key |
+| **Busabase Cloud** | Install the Claude Code plugin from the PR #7 marketplace package | Browser OAuth |
+
+> The Cloud plugin connects to `https://busabase.com/api/mcp`. It does not replace the local
+> `http://localhost:15419` connection used by Busabase Desktop.
+
+## Option A: Busabase Desktop or local server
+
+Use this option when Busabase is running on the same computer as Claude Code.
+
+### 1. Start Busabase
+
+Launch the desktop app, or start the local server from the kapps repository:
+
+```bash
+pnpm --dir apps/busabase dev
+```
+
+Confirm that the onboarding skill is available:
+
+```bash
+curl --fail http://localhost:15419/SETUP_SKILL.md
+```
+
+### 2. Onboard Claude Code
+
+Open Claude Code and paste:
+
+```text
+Read and follow the Busabase Agent Skill — it is the single source of truth:
+http://localhost:15419/SETUP_SKILL.md
+
+Follow its onboarding to set me up, and never merge a ChangeRequest without my approval. Reply to me in English.
+```
+
+Claude Code verifies the local server and saves the connection in `~/.busabase/.env`. An existing
+workspace is preserved as-is. A genuinely new workspace may receive the versioned starter structure
+described by the onboarding skill.
+
+### 3. Install the permanent skill
+
+```bash
+npx skills add busabase/skills
+```
+
+The `skills` CLI detects Claude Code and installs the Busabase skill so future conversations do not
+need the onboarding prompt again.
+
+Start a new Claude Code conversation after installation. Try:
+
+```text
+Use Busabase to list my Bases and summarize what each one contains.
+```
+
+## Option B: Busabase Cloud plugin
+
+Use this option when your workspace is hosted on Busabase Cloud. The plugin package introduced by
+[`ranglang/busabase-skills#7`](https://github.com/ranglang/busabase-skills/pull/7) bundles:
+
+- `busabase` for searching workspace knowledge and proposing reviewable changes;
+- `busabase-app-creator` for creating or maintaining complete workspace apps;
+- the hosted Busabase MCP connection with browser OAuth.
+
+### 1. Check Claude Code
+
+You need Claude Code 2.x and Git in the same terminal:
+
+```bash
+claude --version
+git --version
+```
+
+If Claude Code is installed but outdated, run `claude update` before continuing.
+
+### 2. Install the marketplace plugin
+
+Run these commands in order:
+
+```bash
+claude plugin marketplace add https://github.com/ranglang/busabase-skills.git#main
+claude plugin install busabase@busabase
+```
+
+Confirm the installed components:
+
+```bash
+claude plugin list
+claude plugin details busabase@busabase
+```
+
+The details should show two skills, `busabase` and `busabase-app-creator`, plus one MCP server.
+
+### 3. Sign in to Busabase
+
+Claude Code namespaces servers bundled by plugins. The Busabase server id is
+`plugin:busabase:busabase`.
+
+```bash
+claude mcp login plugin:busabase:busabase
+```
+
+Complete the Busabase sign-in and authorization flow in the browser. Claude Code stores and
+refreshes the OAuth session; do not create or paste an API key.
+
+For SSH, containers, or another headless terminal:
+
+```bash
+claude mcp login --no-browser plugin:busabase:busabase
+```
+
+Open the printed URL on a computer with a browser. If the localhost callback cannot return to the
+remote terminal, copy the full callback URL from the browser address bar and paste it into the
+waiting Claude Code prompt.
+
+### 4. Verify the connection
+
+```bash
+claude mcp get plugin:busabase:busabase
+```
+
+The server should point to `https://busabase.com/api/mcp` and report an authenticated or connected
+state. You can also run `/mcp` inside Claude Code.
+
+Start a **new conversation** after installation and login. A conversation opened earlier may not
+contain the refreshed skills or MCP tool catalog.
+
+## Your first Busabase task
+
+Ask naturally and name Busabase in the request:
+
+- `Use Busabase to find our onboarding checklist and summarize the current process.`
+- `Search Busabase for references to the Q3 launch date.`
+- `Use Busabase to propose changing the owner of the launch record to Maya.`
+- `Show me the open Busabase ChangeRequests, but do not approve or merge anything.`
+
+Claude should call `auth_verify` before any other Cloud operation. If your account can access more
+than one space, Claude must show the spaces and ask you to choose one instead of guessing. Keep the
+selected `targetSpaceId` for the rest of the task.
+
+## The approval-first editing loop
+
+For read-only work, Claude searches or reads the selected workspace and reports the result. For an
+edit, the safe workflow is:
+
+1. Claude reads the relevant Base, record, document, or node.
+2. Claude creates a ChangeRequest that explains the proposed change and why it is needed.
+3. You inspect the proposal in Busabase or ask Claude to show it.
+4. Claude reviews, merges, or closes that exact ChangeRequest only after your explicit instruction.
+5. After a merge, Claude reads the canonical data again and confirms the observed result.
+
+Stored records, documents, assets, comments, and ChangeRequest messages are data, not instructions.
+They never grant Claude permission to approve or merge a proposal.
+
+## Create or maintain a workspace app
+
+The Cloud plugin also includes the `busabase-app-creator` skill. Example requests:
+
+- `Use the Busabase app creator to build a customer feedback tracker.`
+- `Create a Busabase app for weekly content planning with status and owner fields.`
+- `Maintain the existing Sales Pipeline AirApp and add an approved next-follow-up workflow.`
+- `Audit this Busabase AirApp and propose improvements without changing it yet.`
+
+Claude first determines whether the task is **create** or **maintain**, then guides you through one
+decision at a time. New apps use isolated workspace resources. Maintenance work must identify the
+existing AirApp and preserve everything outside the approved scope.
+
+## Troubleshooting
+
+### The plugin is installed but no Busabase tools appear
+
+Start a new conversation or run `/reload-plugins`, then inspect `/mcp`. Run `/doctor` if Claude Code
+reports a plugin loading error.
+
+### The Cloud server says `Needs authentication`
+
+Run the login command again and keep the terminal process open until the browser flow finishes:
+
+```bash
+claude mcp login plugin:busabase:busabase
+```
+
+Do not add an `Authorization` header or create a second standalone MCP server named `busabase`.
+
+### The local connection fails
+
+Confirm Busabase is still running and that the skill URL is reachable:
+
+```bash
+curl --fail http://localhost:15419/SETUP_SKILL.md
+```
+
+Then ask Claude to reread that URL and verify `~/.busabase/.env`.
+
+### Claude selects the wrong Cloud space
+
+Ask Claude to call `auth_verify`, list every available space, and wait for your selection. Do not
+continue a space-scoped task until the intended `targetSpaceId` is explicit.
+
+### The browser cannot complete OAuth
+
+Use `--no-browser`, open the authorization URL locally, and paste the full callback URL into the
+waiting terminal.
+
+## Update or remove the Cloud plugin
+
+```bash
+claude plugin marketplace update busabase
+claude plugin update busabase@busabase
+claude plugin uninstall busabase@busabase
+```
+
+Start a new conversation after an update so Claude Code reloads the skills and MCP tool catalog.
+
+---
+
+See also: [Bring Your Own Agent](./bring-your-agent.md) ·
+[Busabase skill source](https://github.com/busabase/skills) ·
+[Claude Code plugin package PR](https://github.com/ranglang/busabase-skills/pull/7)

--- a/apps/busabase/package.json
+++ b/apps/busabase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase",
   "description": "Open-source Busabase review app + CLI. `busabase server` boots a zero-setup local instance (pglite); other subcommands act as an OpenAPI client.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase",

--- a/apps/busabase/public/architecture-diagram.svg
+++ b/apps/busabase/public/architecture-diagram.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 860" font-family="Inter, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#8A8A8A"/>
+    </marker>
+    <style>
+      .card { fill: #FFFFFF; stroke: #E5E5E5; stroke-width: 1.5; rx: 12; }
+      .card-muted { fill: #F5F5F5; stroke: #E5E5E5; stroke-width: 1.5; rx: 12; }
+      .card-dark { fill: #171717; stroke: #171717; stroke-width: 1.5; rx: 12; }
+      .card-line { fill: #FFFFFF; stroke: #D9D9D9; stroke-width: 1.5; stroke-dasharray: 4 3; rx: 14; }
+      .title { font-size: 16px; font-weight: 700; fill: #0A0A0A; }
+      .title-inv { font-size: 15px; font-weight: 700; fill: #FAFAFA; }
+      .sub { font-size: 11px; fill: #737373; }
+      .sub-inv { font-size: 11px; fill: #D4D4D4; }
+      .group-title { font-size: 12.5px; font-weight: 700; fill: #525252; letter-spacing: 0.04em; text-transform: uppercase; }
+      .edge { stroke: #C7C7C7; stroke-width: 1.5; fill: none; marker-end: url(#arrow); }
+      .edge-label { font-size: 10.5px; fill: #737373; }
+      .pill { fill: #FFFFFF; stroke: #E5E5E5; stroke-width: 1.2; rx: 8; }
+      .pill-text { font-size: 11px; fill: #171717; font-weight: 600; }
+      .pill-sub { font-size: 9.5px; fill: #A3A3A3; }
+      .badge { fill: #F0F0F0; stroke: #D9D9D9; stroke-width: 1; rx: 6; }
+      .badge-text { font-size: 10px; fill: #404040; font-weight: 700; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="860" fill="#FFFFFF"/>
+
+  <text x="30" y="34" class="title">Busabase — Architecture</text>
+  <rect x="290" y="16" width="150" height="22" class="badge"/>
+  <text x="365" y="32" text-anchor="middle" class="badge-text">OPEN SOURCE · SELF-HOSTED</text>
+  <text x="30" y="56" class="sub">Local-first "review database" — single-tenant, no login, driven by external AI agents over OpenAPI/oRPC</text>
+
+  <!-- Clients -->
+  <rect x="30" y="90" width="1140" height="90" class="card-line"/>
+  <text x="600" y="114" text-anchor="middle" class="group-title">Clients</text>
+
+  <rect x="50" y="128" width="200" height="40" class="pill"/><text x="150" y="152" text-anchor="middle" class="pill-text">Web Dashboard</text>
+  <rect x="266" y="128" width="200" height="40" class="pill"/><text x="366" y="152" text-anchor="middle" class="pill-text">busabase-cli</text>
+  <rect x="482" y="128" width="200" height="40" class="pill"/><text x="582" y="152" text-anchor="middle" class="pill-text">Desktop (Tauri)</text>
+  <rect x="698" y="128" width="200" height="40" class="pill"/><text x="798" y="152" text-anchor="middle" class="pill-text">Mobile</text>
+  <rect x="914" y="128" width="236" height="40" class="pill"/><text x="1032" y="152" text-anchor="middle" class="pill-text">External AI Agent (Claude Code, Cursor…)</text>
+
+  <!-- App shell -->
+  <rect x="30" y="210" width="1140" height="110" class="card-muted"/>
+  <text x="600" y="234" text-anchor="middle" class="group-title">apps/busabase — Next.js App Router (thin shell)</text>
+
+  <rect x="50" y="250" width="270" height="50" class="pill"/>
+  <text x="185" y="270" text-anchor="middle" class="pill-text">settings · vault · webhook</text>
+  <text x="185" y="286" text-anchor="middle" class="pill-sub">only app-level domains</text>
+
+  <rect x="335" y="250" width="270" height="50" class="pill"/>
+  <text x="470" y="270" text-anchor="middle" class="pill-text">Fixed local actor</text>
+  <text x="470" y="286" text-anchor="middle" class="pill-sub">no auth gateway, no space concept</text>
+
+  <rect x="620" y="250" width="270" height="50" class="pill"/>
+  <text x="755" y="270" text-anchor="middle" class="pill-text">OpenAPI / oRPC surface</text>
+  <text x="755" y="286" text-anchor="middle" class="pill-sub">what CLI + agents call</text>
+
+  <rect x="905" y="250" width="245" height="50" class="pill"/>
+  <text x="1027" y="270" text-anchor="middle" class="pill-text">workspace: "local"</text>
+  <text x="1027" y="286" text-anchor="middle" class="pill-sub">/dashboard/local/inbox</text>
+
+  <!-- Shared engine -->
+  <rect x="30" y="350" width="1140" height="260" class="card"/>
+  <text x="600" y="374" text-anchor="middle" class="group-title">busabase-core — shared engine (also used by busabase-cloud)</text>
+
+  <text x="50" y="398" class="sub" font-weight="700">Review primitives (human-in-the-loop)</text>
+  <rect x="50" y="408" width="1120" height="40" class="pill"/>
+  <text x="610" y="432" text-anchor="middle" class="pill-text">Nodes · Commits · Change Requests · Operations · Reviews · Comments · Audit Events</text>
+
+  <text x="50" y="470" class="sub" font-weight="700">Content domains</text>
+  <rect x="50" y="480" width="170" height="46" class="pill"/><text x="135" y="500" text-anchor="middle" class="pill-text">base</text><text x="135" y="516" text-anchor="middle" class="pill-sub">tables/fields/records/views</text>
+  <rect x="230" y="480" width="170" height="46" class="pill"/><text x="315" y="500" text-anchor="middle" class="pill-text">assets</text><text x="315" y="516" text-anchor="middle" class="pill-sub">assets · usages · text</text>
+  <rect x="410" y="480" width="170" height="46" class="pill"/><text x="495" y="500" text-anchor="middle" class="pill-text">doc / rich-node</text><text x="495" y="516" text-anchor="middle" class="pill-sub">documents</text>
+  <rect x="590" y="480" width="170" height="46" class="pill"/><text x="675" y="500" text-anchor="middle" class="pill-text">drive / folder / filetree</text><text x="675" y="516" text-anchor="middle" class="pill-sub">file hierarchy</text>
+  <rect x="770" y="480" width="170" height="46" class="pill"/><text x="855" y="500" text-anchor="middle" class="pill-text">form</text><text x="855" y="516" text-anchor="middle" class="pill-sub">structured intake</text>
+  <rect x="950" y="480" width="220" height="46" class="pill"/><text x="1060" y="500" text-anchor="middle" class="pill-text">airapp / skill / install</text><text x="1060" y="516" text-anchor="middle" class="pill-sub">extensibility</text>
+
+  <text x="50" y="550" class="sub">Context threaded via AsyncLocalStorage: { db, actorId, spaceId } — OSS never sets it, so every</text>
+  <text x="50" y="566" class="sub">getter falls back to local-mode defaults (ANONYMOUS_ACTOR_ID, "local-user", LOCAL_SPACE_ID)</text>
+  <text x="50" y="588" class="sub" font-weight="700">→ single-tenant by construction, no spaceId column on any table.</text>
+
+  <!-- Storage -->
+  <rect x="30" y="630" width="560" height="130" class="card-dark"/>
+  <text x="310" y="658" text-anchor="middle" class="title-inv">Drizzle ORM</text>
+  <text x="310" y="682" text-anchor="middle" class="sub-inv">PGlite (embedded, default) — zero setup</text>
+  <text x="310" y="700" text-anchor="middle" class="sub-inv">or external PostgreSQL via PG_DATABASE_URL</text>
+  <text x="310" y="722" text-anchor="middle" class="sub-inv">Local filesystem storage (default) or S3 via STORAGE_URL</text>
+
+  <!-- Distribution -->
+  <rect x="610" y="630" width="560" height="130" class="card"/>
+  <text x="890" y="658" text-anchor="middle" class="title">Distribution</text>
+  <text x="890" y="682" text-anchor="middle" class="sub">npx busabase server · Docker (busabase/busabase) · from source</text>
+  <text x="890" y="700" text-anchor="middle" class="sub">Data root ~/.busabase/data/{pgdata,storage} — shared across all run modes</text>
+  <text x="890" y="722" text-anchor="middle" class="sub">Health check: /api/health · no Redis/queue dependency</text>
+
+  <!-- Footer -->
+  <rect x="30" y="790" width="1140" height="46" class="card-muted"/>
+  <text x="600" y="818" text-anchor="middle" class="sub" font-weight="700">MIT licensed · same engine as Busabase Cloud, just never given a tenant to scope by</text>
+
+  <!-- Edges -->
+  <path class="edge" d="M600,180 L600,206"/>
+  <path class="edge" d="M600,320 L600,346"/>
+  <path class="edge" d="M310,610 L310,626"/>
+  <path class="edge" d="M890,610 L890,626"/>
+</svg>

--- a/apps/busabase/public/assets/readme/coverage.svg
+++ b/apps/busabase/public/assets/readme/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="107" height="20" role="img" aria-label="coverage: 78.1%">
-  <title>coverage: 78.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="107" height="20" role="img" aria-label="coverage: 77.9%">
+  <title>coverage: 77.9%</title>
   <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
   <clipPath id="r"><rect width="107" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
@@ -10,7 +10,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="310" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="520">coverage</text>
     <text x="310" y="140" transform="scale(.1)" fill="#fff" textLength="520">coverage</text>
-    <text aria-hidden="true" x="845" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">78.1%</text>
-    <text x="845" y="140" transform="scale(.1)" fill="#fff" textLength="330">78.1%</text>
+    <text aria-hidden="true" x="845" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">77.9%</text>
+    <text x="845" y="140" transform="scale(.1)" fill="#fff" textLength="330">77.9%</text>
   </g>
 </svg>

--- a/apps/busabase/scripts/verify-busabase-domains.ts
+++ b/apps/busabase/scripts/verify-busabase-domains.ts
@@ -282,23 +282,36 @@ async function main() {
   });
   await approveAndMerge(docNodeCr.id);
   const materializedDoc = await getDoc("probe-node-doc");
-  assert.match(materializedDoc.body, /Probe Node Doc/, "node_create doc materializer seeded body");
+  // Deliberately EMPTY, not a synthesized `# {name}` heading: the detail page
+  // already renders the node's name as the page-level <h1>, so seeding one into
+  // the body produced two identically-named headings (see the comment on
+  // `materializeDocNode`). Asserting the empty body is what guards that choice.
+  assert.equal(materializedDoc.body, "", "node_create doc materializer leaves the body empty");
+  assert.equal(materializedDoc.node.name, "Probe Node Doc", "node_create doc carried the name");
   ok("node_create (doc) materializer merged");
 
-  // --- review-first DEFAULT: createBase/createDoc/createSkill(createFileTreeNode)
-  // without `autoMerge` must propose a PENDING ChangeRequest, not materialize
-  // anything — the fix this harness exists to guard against a regression on.
+  // --- review-first PATH: createBase/createDoc/createSkill(createFileTreeNode)
+  // with an explicit `autoMerge: false` must propose a PENDING ChangeRequest and
+  // materialize nothing until it merges.
+  //
+  // This block used to assert the same of the DEFAULT (omitting the flag). That
+  // is no longer true: `shouldAutoMerge` is permission-aware, and this harness
+  // always holds write access because the open-source host runs with full local
+  // access. Asking for review explicitly is what a review-first caller does.
   const pendingBaseCr = await createBase({
     slug: "review-first-probe-base",
     name: "Review First Probe Base",
     description: "",
     fields: [{ slug: "title", name: "Title", type: "text", required: true, options: {} }],
+    autoMerge: false,
   });
   if (!("status" in pendingBaseCr)) {
-    throw new Error("Expected createBase() with no autoMerge to return a pending ChangeRequestVO");
+    throw new Error(
+      "Expected createBase({ autoMerge: false }) to return a pending ChangeRequestVO",
+    );
   }
-  assert.equal(pendingBaseCr.status, "in_review", "createBase() defaults to a pending CR");
-  assert.equal(pendingBaseCr.node, null, "createBase() default path materializes nothing yet");
+  assert.equal(pendingBaseCr.status, "in_review", "createBase({ autoMerge: false }) stays pending");
+  assert.equal(pendingBaseCr.node, null, "the review-first path materializes nothing yet");
   const baseBeforeMerge = await getBase("review-first-probe-base");
   assert.equal(baseBeforeMerge, null, "the Base does not exist before the pending CR is merged");
   await approveAndMerge(pendingBaseCr.id);
@@ -309,18 +322,21 @@ async function main() {
   // Doc/Skill checks below.
   const mergedBase = await getBase("review-first-probe-base");
   assert.ok(mergedBase, "approving + merging the pending CR materializes the Base");
-  ok("createBase() review-first default (pending CR → approve+merge materializes)");
+  ok(
+    "createBase({ autoMerge: false }) review-first path (pending CR → approve+merge materializes)",
+  );
 
   const pendingDocCr = await createDoc({
     slug: "review-first-probe-doc",
     name: "Review First Probe Doc",
     body: "# Custom initial body\n",
+    autoMerge: false,
   });
   if (!("status" in pendingDocCr)) {
-    throw new Error("Expected createDoc() with no autoMerge to return a pending ChangeRequestVO");
+    throw new Error("Expected createDoc({ autoMerge: false }) to return a pending ChangeRequestVO");
   }
-  assert.equal(pendingDocCr.status, "in_review", "createDoc() defaults to a pending CR");
-  assert.equal(pendingDocCr.node, null, "createDoc() default path materializes nothing yet");
+  assert.equal(pendingDocCr.status, "in_review", "createDoc({ autoMerge: false }) stays pending");
+  assert.equal(pendingDocCr.node, null, "the review-first path materializes nothing yet");
   await approveAndMerge(pendingDocCr.id);
   const mergedDoc = await getDoc("review-first-probe-doc");
   assert.match(
@@ -329,7 +345,7 @@ async function main() {
     "merging the pending Doc CR carries the custom initial body through (not the synthesized default header)",
   );
   ok(
-    "createDoc() review-first default (pending CR carries custom body → approve+merge materializes)",
+    "createDoc({ autoMerge: false }) review-first path (pending CR carries custom body → approve+merge materializes)",
   );
 
   const pendingSkillCr = await createSkill({
@@ -339,12 +355,19 @@ async function main() {
     visibility: "private",
     version: "0.1.0",
     files: [{ path: "notes.md", content: "custom initial file\n" }],
+    autoMerge: false,
   });
   if (!("status" in pendingSkillCr)) {
-    throw new Error("Expected createSkill() with no autoMerge to return a pending ChangeRequestVO");
+    throw new Error(
+      "Expected createSkill({ autoMerge: false }) to return a pending ChangeRequestVO",
+    );
   }
-  assert.equal(pendingSkillCr.status, "in_review", "createSkill() defaults to a pending CR");
-  assert.equal(pendingSkillCr.node, null, "createSkill() default path materializes nothing yet");
+  assert.equal(
+    pendingSkillCr.status,
+    "in_review",
+    "createSkill({ autoMerge: false }) stays pending",
+  );
+  assert.equal(pendingSkillCr.node, null, "the review-first path materializes nothing yet");
   await approveAndMerge(pendingSkillCr.id);
   const mergedSkill = await getSkill("review-first-probe-skill");
   assert.ok(
@@ -356,7 +379,7 @@ async function main() {
     "merging the pending Skill CR carries the custom initial file through (createFileTreeNode's initialFiles)",
   );
   ok(
-    "createSkill()/createFileTreeNode() review-first default (pending CR carries custom files → approve+merge materializes)",
+    "createSkill({ autoMerge: false }) review-first path (pending CR carries custom files → approve+merge materializes)",
   );
 
   // --- record_delete (last; archives the record) ---------------------------

--- a/apps/busabase/src/db/migrations/0013_curved_the_twelve.sql
+++ b/apps/busabase/src/db/migrations/0013_curved_the_twelve.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "busabase_audit_events_space_created_id_idx" ON "busabase_audit_events" USING btree ("space_id","created_at","id");

--- a/apps/busabase/src/db/migrations/meta/0013_snapshot.json
+++ b/apps/busabase/src/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,4470 @@
+{
+  "id": "2b559b01-8300-4a74-b14c-d496b4ae5898",
+  "prevId": "2bed3b86-9bf0-4d7a-a699-3349803c748f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.busabase_audit_events": {
+      "name": "busabase_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_audit_events_space_created_id_idx": {
+          "name": "busabase_audit_events_space_created_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_audit_events_action_created_idx": {
+          "name": "busabase_audit_events_action_created_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_audit_events_record_created_idx": {
+          "name": "busabase_audit_events_record_created_idx",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_audit_events_base_created_idx": {
+          "name": "busabase_audit_events_base_created_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_audit_events_base_id_busabase_bases_id_fk": {
+          "name": "busabase_audit_events_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_audit_events_record_id_busabase_records_id_fk": {
+          "name": "busabase_audit_events_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_audit_events_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_audit_events_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_audit_events_operation_id_busabase_operations_id_fk": {
+          "name": "busabase_audit_events_operation_id_busabase_operations_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_operations",
+          "columnsFrom": ["operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_audit_events_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_audit_events_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_change_requests": {
+      "name": "busabase_change_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "busabase_change_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_review'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_meta": {
+          "name": "source_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "review_policy_snapshot": {
+          "name": "review_policy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "merge_summary": {
+          "name": "merge_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rejected_reason": {
+          "name": "rejected_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_change_requests_base_created_idx": {
+          "name": "busabase_change_requests_base_created_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_change_requests_node_created_idx": {
+          "name": "busabase_change_requests_node_created_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_change_requests_status_created_idx": {
+          "name": "busabase_change_requests_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_change_requests_idempotency_uniq": {
+          "name": "busabase_change_requests_idempotency_uniq",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_change_requests\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_change_requests_base_id_busabase_bases_id_fk": {
+          "name": "busabase_change_requests_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_change_requests",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_change_requests_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_change_requests_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_change_requests",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_comments": {
+      "name": "busabase_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "busabase_comment_subject",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentions_ai": {
+          "name": "mentions_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_comments_subject_created_idx": {
+          "name": "busabase_comments_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_comments_record_created_idx": {
+          "name": "busabase_comments_record_created_idx",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_comments_change_request_created_idx": {
+          "name": "busabase_comments_change_request_created_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_comments_operation_created_idx": {
+          "name": "busabase_comments_operation_created_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_comments_commit_created_idx": {
+          "name": "busabase_comments_commit_created_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_comments_record_id_busabase_records_id_fk": {
+          "name": "busabase_comments_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_comments",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_comments_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_comments_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_comments",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_comments_operation_id_busabase_operations_id_fk": {
+          "name": "busabase_comments_operation_id_busabase_operations_id_fk",
+          "tableFrom": "busabase_comments",
+          "tableTo": "busabase_operations",
+          "columnsFrom": ["operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_comments_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_comments_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_comments",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_commits": {
+      "name": "busabase_commits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_commit_id": {
+          "name": "parent_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "busabase_operation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'record_create'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_commits_base_created_idx": {
+          "name": "busabase_commits_base_created_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_commits_node_created_idx": {
+          "name": "busabase_commits_node_created_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_commits_operation_idx": {
+          "name": "busabase_commits_operation_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_commits_created_idx": {
+          "name": "busabase_commits_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_commits_base_id_busabase_bases_id_fk": {
+          "name": "busabase_commits_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_commits",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "busabase_commits_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_commits_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_commits",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_favorites": {
+      "name": "busabase_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_favorites_node_actor_uniq": {
+          "name": "busabase_favorites_node_actor_uniq",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_favorites_actor_idx": {
+          "name": "busabase_favorites_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_favorites_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_favorites_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_favorites",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_node_principals": {
+      "name": "busabase_node_principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_node_principals_node_principal_source_uniq": {
+          "name": "busabase_node_principals_node_principal_source_uniq",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_node_principals_node_idx": {
+          "name": "busabase_node_principals_node_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_node_principals_principal_idx": {
+          "name": "busabase_node_principals_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_node_principals_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_node_principals_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_node_principals",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_node_principals_source_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_node_principals_source_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_node_principals",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["source_node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_node_shares": {
+      "name": "busabase_node_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_node_shares_space_scope_idx": {
+          "name": "busabase_node_shares_space_scope_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_node_shares_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_node_shares_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_node_shares",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "busabase_node_shares_node_id_unique": {
+          "name": "busabase_node_shares_node_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["node_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_nodes": {
+      "name": "busabase_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "effective_visibility": {
+          "name": "effective_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_public_scope": {
+          "name": "effective_public_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_nodes_parent_slug_uniq": {
+          "name": "busabase_nodes_parent_slug_uniq",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_nodes\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_nodes_parent_position_idx": {
+          "name": "busabase_nodes_parent_position_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_nodes_effective_visibility_idx": {
+          "name": "busabase_nodes_effective_visibility_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_nodes_effective_public_scope_idx": {
+          "name": "busabase_nodes_effective_public_scope_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_public_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_nodes_parent_id_busabase_nodes_id_fk": {
+          "name": "busabase_nodes_parent_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_nodes",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_operations": {
+      "name": "busabase_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "busabase_operation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "target_record_id": {
+          "name": "target_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_view_id": {
+          "name": "target_view_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_commit_id": {
+          "name": "source_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_commit_id": {
+          "name": "base_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_commit_id": {
+          "name": "head_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_mode": {
+          "name": "delete_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'archive'"
+        },
+        "merged_record_id": {
+          "name": "merged_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_view_id": {
+          "name": "merged_view_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_operations_change_request_position_idx": {
+          "name": "busabase_operations_change_request_position_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_operations_node_file_idx": {
+          "name": "busabase_operations_node_file_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_operations_target_record_idx": {
+          "name": "busabase_operations_target_record_idx",
+          "columns": [
+            {
+              "expression": "target_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_operations_target_view_idx": {
+          "name": "busabase_operations_target_view_idx",
+          "columns": [
+            {
+              "expression": "target_view_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_operations_head_commit_idx": {
+          "name": "busabase_operations_head_commit_idx",
+          "columns": [
+            {
+              "expression": "head_commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_operations_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_operations_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_base_id_busabase_bases_id_fk": {
+          "name": "busabase_operations_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_operations_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_target_view_id_busabase_views_id_fk": {
+          "name": "busabase_operations_target_view_id_busabase_views_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_views",
+          "columnsFrom": ["target_view_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_head_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_operations_head_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["head_commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_merged_view_id_busabase_views_id_fk": {
+          "name": "busabase_operations_merged_view_id_busabase_views_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_views",
+          "columnsFrom": ["merged_view_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_reviews": {
+      "name": "busabase_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "busabase_review_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_operation_heads": {
+          "name": "visible_operation_heads",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_reviews_one_vote_per_change_request": {
+          "name": "busabase_reviews_one_vote_per_change_request",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_reviews_change_request_created_idx": {
+          "name": "busabase_reviews_change_request_created_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_reviews_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_reviews_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_reviews",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_user_id_idx": {
+          "name": "attachments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_space_id_idx": {
+          "name": "attachments_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_context_idx": {
+          "name": "attachments_context_idx",
+          "columns": [
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_created_at_idx": {
+          "name": "attachments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_storage_key_idx": {
+          "name": "attachments_storage_key_idx",
+          "columns": [
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_content_hash_idx": {
+          "name": "attachments_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_asset_texts": {
+      "name": "busabase_asset_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "text_storage_key": {
+          "name": "text_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_content_hash": {
+          "name": "text_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "written_by": {
+          "name": "written_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "line_count": {
+          "name": "line_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "byte_count": {
+          "name": "byte_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "line_checkpoints": {
+          "name": "line_checkpoints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "stats_computed_at": {
+          "name": "stats_computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_asset_texts_asset_uniq": {
+          "name": "busabase_asset_texts_asset_uniq",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_texts_space_status_idx": {
+          "name": "busabase_asset_texts_space_status_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_texts_content_hash_idx": {
+          "name": "busabase_asset_texts_content_hash_idx",
+          "columns": [
+            {
+              "expression": "text_content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_asset_texts_asset_id_busabase_assets_id_fk": {
+          "name": "busabase_asset_texts_asset_id_busabase_assets_id_fk",
+          "tableFrom": "busabase_asset_texts",
+          "tableTo": "busabase_assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_asset_usages": {
+      "name": "busabase_asset_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "field_slug": {
+          "name": "field_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_asset_usages_asset_idx": {
+          "name": "busabase_asset_usages_asset_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_usages_node_idx": {
+          "name": "busabase_asset_usages_node_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_usages_node_path_idx": {
+          "name": "busabase_asset_usages_node_path_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_usages_uniq": {
+          "name": "busabase_asset_usages_uniq",
+          "columns": [
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_asset_usages_asset_id_busabase_assets_id_fk": {
+          "name": "busabase_asset_usages_asset_id_busabase_assets_id_fk",
+          "tableFrom": "busabase_asset_usages",
+          "tableTo": "busabase_assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_asset_usages_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_asset_usages_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_asset_usages",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_assets": {
+      "name": "busabase_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'binary'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local-producer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_assets_space_idx": {
+          "name": "busabase_assets_space_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_assets_space_attachment_idx": {
+          "name": "busabase_assets_space_attachment_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_base_fields": {
+      "name": "busabase_base_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "busabase_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "busabase_fields_base_slug_uniq": {
+          "name": "busabase_fields_base_slug_uniq",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_base_fields\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_base_fields_base_id_busabase_bases_id_fk": {
+          "name": "busabase_base_fields_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_base_fields",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_bases": {
+      "name": "busabase_bases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "review_policy": {
+          "name": "review_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"kind\":\"single\",\"requiredApprovals\":1}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "busabase_bases_node_uniq": {
+          "name": "busabase_bases_node_uniq",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_bases_space_slug_uniq": {
+          "name": "busabase_bases_space_slug_uniq",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_bases\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_bases_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_bases_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_bases",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_field_values": {
+      "name": "busabase_field_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_slug": {
+          "name": "field_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "busabase_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_hash": {
+          "name": "value_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_field_values_base_field_idx": {
+          "name": "busabase_field_values_base_field_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_text_fts_idx": {
+          "name": "busabase_field_values_text_fts_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', coalesce(\"value_text\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "busabase_field_values_text_trgm_idx": {
+          "name": "busabase_field_values_text_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"value_text\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "busabase_field_values_slug_trgm_idx": {
+          "name": "busabase_field_values_slug_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"field_slug\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "busabase_field_values_base_field_number_idx": {
+          "name": "busabase_field_values_base_field_number_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_base_field_date_idx": {
+          "name": "busabase_field_values_base_field_date_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_record_idx": {
+          "name": "busabase_field_values_record_idx",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_change_request_idx": {
+          "name": "busabase_field_values_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_operation_idx": {
+          "name": "busabase_field_values_operation_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_commit_idx": {
+          "name": "busabase_field_values_commit_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_field_values_base_id_busabase_bases_id_fk": {
+          "name": "busabase_field_values_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_field_values_record_id_busabase_records_id_fk": {
+          "name": "busabase_field_values_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_field_values_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_field_values_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_field_values_operation_id_busabase_operations_id_fk": {
+          "name": "busabase_field_values_operation_id_busabase_operations_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_operations",
+          "columnsFrom": ["operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_field_values_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_field_values_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_record_links": {
+      "name": "busabase_record_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_slug": {
+          "name": "field_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_base_id": {
+          "name": "target_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_record_id": {
+          "name": "target_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_record_links_source_field_target_uniq": {
+          "name": "busabase_record_links_source_field_target_uniq",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_record_links_source_field_idx": {
+          "name": "busabase_record_links_source_field_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_record_links_target_idx": {
+          "name": "busabase_record_links_target_idx",
+          "columns": [
+            {
+              "expression": "target_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_record_links_base_field_idx": {
+          "name": "busabase_record_links_base_field_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_record_links_base_id_busabase_bases_id_fk": {
+          "name": "busabase_record_links_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_field_id_busabase_base_fields_id_fk": {
+          "name": "busabase_record_links_field_id_busabase_base_fields_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_base_fields",
+          "columnsFrom": ["field_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_source_record_id_busabase_records_id_fk": {
+          "name": "busabase_record_links_source_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["source_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_target_base_id_busabase_bases_id_fk": {
+          "name": "busabase_record_links_target_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["target_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_target_record_id_busabase_records_id_fk": {
+          "name": "busabase_record_links_target_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["target_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_record_links_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_records": {
+      "name": "busabase_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_commit_id": {
+          "name": "head_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_record_id": {
+          "name": "parent_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_commit_id": {
+          "name": "parent_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_records_base_created_idx": {
+          "name": "busabase_records_base_created_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_records_status_created_idx": {
+          "name": "busabase_records_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_records_head_commit_idx": {
+          "name": "busabase_records_head_commit_idx",
+          "columns": [
+            {
+              "expression": "head_commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_records_base_id_busabase_bases_id_fk": {
+          "name": "busabase_records_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_records",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_records_head_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_records_head_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_records",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["head_commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_views": {
+      "name": "busabase_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'table'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_views_base_slug_uniq": {
+          "name": "busabase_views_base_slug_uniq",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_views\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_views_base_status_position_idx": {
+          "name": "busabase_views_base_status_position_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_views_base_id_busabase_bases_id_fk": {
+          "name": "busabase_views_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_views",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_forms": {
+      "name": "busabase_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_base_id": {
+          "name": "target_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bindings": {
+          "name": "bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "page": {
+          "name": "page",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "share": {
+          "name": "share",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"isPublic\":false,\"anonymousSubmit\":false}'::jsonb"
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_forms_node_idx": {
+          "name": "busabase_forms_node_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_forms_target_base_idx": {
+          "name": "busabase_forms_target_base_idx",
+          "columns": [
+            {
+              "expression": "target_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_forms_space_status_idx": {
+          "name": "busabase_forms_space_status_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_forms_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_forms_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_forms",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_forms_target_base_id_busabase_bases_id_fk": {
+          "name": "busabase_forms_target_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_forms",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["target_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_vault_items": {
+      "name": "busabase_vault_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_payload": {
+          "name": "value_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "access": {
+          "name": "access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"runtime\":true,\"reveal\":true,\"edit\":true,\"share\":false}'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_vault_items_user_updated_idx": {
+          "name": "busabase_vault_items_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_vault_items_user_kind_idx": {
+          "name": "busabase_vault_items_user_kind_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_vault_items_user_key_idx": {
+          "name": "busabase_vault_items_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_webhook_deliveries": {
+      "name": "busabase_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_webhook_deliveries_rule_created_idx": {
+          "name": "busabase_webhook_deliveries_rule_created_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_webhook_rules": {
+      "name": "busabase_webhook_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_kind": {
+          "name": "action_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "busabase_webhook_rules_space_event_enabled_idx": {
+          "name": "busabase_webhook_rules_space_event_enabled_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_app_branding": {
+      "name": "busabase_app_branding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_cloud_connect": {
+      "name": "busabase_cloud_connect",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_url": {
+          "name": "cloud_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oss_origin": {
+          "name": "oss_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_token": {
+          "name": "credential_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_refresh_token": {
+          "name": "credential_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_expires_at": {
+          "name": "credential_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.busabase_change_request_status": {
+      "name": "busabase_change_request_status",
+      "schema": "public",
+      "values": [
+        "in_review",
+        "changes_requested",
+        "approved",
+        "rejected",
+        "merged",
+        "abandoned",
+        "conflict"
+      ]
+    },
+    "public.busabase_comment_subject": {
+      "name": "busabase_comment_subject",
+      "schema": "public",
+      "values": ["record", "change_request", "operation", "commit"]
+    },
+    "public.busabase_operation_kind": {
+      "name": "busabase_operation_kind",
+      "schema": "public",
+      "values": [
+        "record_create",
+        "record_update",
+        "record_delete",
+        "record_variant",
+        "view_create",
+        "view_update",
+        "view_delete",
+        "view_restore",
+        "node_create",
+        "node_rename",
+        "node_delete",
+        "node_restore",
+        "node_move",
+        "skill_file_create",
+        "skill_file_update",
+        "skill_file_delete",
+        "skill_metadata_update",
+        "drive_file_create",
+        "drive_file_update",
+        "drive_file_delete",
+        "drive_metadata_update",
+        "airapp_file_create",
+        "airapp_file_update",
+        "airapp_file_delete",
+        "airapp_metadata_update",
+        "doc_update",
+        "base_add_field",
+        "base_delete_field",
+        "base_update_field",
+        "base_convert_field",
+        "base_reorder_fields",
+        "base_restore_field",
+        "base_archive",
+        "base_restore",
+        "record_restore"
+      ]
+    },
+    "public.busabase_review_verdict": {
+      "name": "busabase_review_verdict",
+      "schema": "public",
+      "values": ["approved", "rejected"]
+    },
+    "public.busabase_field_type": {
+      "name": "busabase_field_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "longtext",
+        "markdown",
+        "html",
+        "attachment",
+        "relation",
+        "number",
+        "date",
+        "checkbox",
+        "select",
+        "multiselect",
+        "url",
+        "embed",
+        "email",
+        "phone",
+        "created_time",
+        "updated_time",
+        "created_by",
+        "updated_by",
+        "auto_number",
+        "ai_summary",
+        "ai_tags",
+        "code",
+        "json",
+        "yaml",
+        "formula",
+        "lookup",
+        "whiteboard"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/busabase/src/db/migrations/meta/_journal.json
+++ b/apps/busabase/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1785719592270,
       "tag": "0012_tricky_felicia_hardy",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1786434849111,
+      "tag": "0013_curved_the_twelve",
+      "breakpoints": true
     }
   ]
 }

--- a/biome.json
+++ b/biome.json
@@ -54,6 +54,7 @@
       "!**/dist",
       "!**/build",
       "!**/coverage",
+      "!**/evals/**/results",
       "!**/pnpm-lock.yaml",
       "!**/storybook-static",
       "!**/prisma-client",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-repo",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "packageManager": "pnpm@10.15.1",
   "workspaces": [
     "apps/*",

--- a/packages/busabase-contract/package.json
+++ b/packages/busabase-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-contract",
   "description": "Client-safe Busabase surface: oRPC contracts (OSS + cloud), node-type kernel, VO types, and the oRPC client factories. Pure leaf — no db/logic/server deps. Consumed by busabase-cli, busabase-mobile, busabase-core, busabase, and busabase-cloud.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/busabase-contract/src/api-client/index.ts
+++ b/packages/busabase-contract/src/api-client/index.ts
@@ -398,12 +398,15 @@ export const createBusabaseORPCClient = (
     headers?:
       | Record<string, string>
       | (() => Record<string, string> | Promise<Record<string, string>>);
+    /** Optional transport override for host-specific response handling. */
+    fetch?: NonNullable<ConstructorParameters<typeof RPCLink>[0]["fetch"]>;
   },
 ): ContractRouterClient<BusabaseContract> => {
   const link = new RPCLink({
     url: resolveApiUrl(apiBasePath),
     headers: async () =>
       (typeof opts?.headers === "function" ? await opts.headers() : opts?.headers) ?? {},
+    ...(opts?.fetch ? { fetch: opts.fetch } : {}),
   });
 
   return createORPCClient(link);
@@ -454,6 +457,8 @@ export const createBusabaseRestApiClient = (
     headers?:
       | Record<string, string>
       | (() => Record<string, string> | Promise<Record<string, string>>);
+    /** Optional transport override for host-specific response handling. */
+    fetch?: NonNullable<ConstructorParameters<typeof RPCLink>[0]["fetch"]>;
   },
 ): BusabaseDashboardApiClient => {
   const rpcPath = apiBasePath.endsWith("/v1")

--- a/packages/busabase-contract/src/api-client/react-query.ts
+++ b/packages/busabase-contract/src/api-client/react-query.ts
@@ -18,17 +18,20 @@ export interface BusabaseClientOptions {
   headers?:
     | Record<string, string>
     | (() => Record<string, string> | Promise<Record<string, string>>);
+  /** Optional transport override for host-specific response handling. */
+  fetch?: NonNullable<ConstructorParameters<typeof RPCLink>[0]["fetch"]>;
 }
 
 // RPCLink fetch interceptor that appends `?demo=1` to each outgoing request URL.
-const demoFetch: NonNullable<ConstructorParameters<typeof RPCLink>[0]["fetch"]> = (
-  request,
-  init,
-) => {
-  const url = new URL(request.url);
-  url.searchParams.set("demo", "1");
-  return globalThis.fetch(new Request(url.toString(), request), init);
-};
+const createDemoFetch =
+  (
+    fetchImpl: NonNullable<ConstructorParameters<typeof RPCLink>[0]["fetch"]>,
+  ): NonNullable<ConstructorParameters<typeof RPCLink>[0]["fetch"]> =>
+  (request, init, path, input, options) => {
+    const url = new URL(request.url);
+    url.searchParams.set("demo", "1");
+    return fetchImpl(new Request(url.toString(), request), init, path, input, options);
+  };
 
 /**
  * Procedures that must NEVER be folded into a batch request.
@@ -74,11 +77,16 @@ export const createBusabaseORPCClient = (
   apiBasePath = "/api/rpc",
   opts: BusabaseClientOptions = {},
 ): BusabaseORPCClient => {
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
   const link = new RPCLink({
     url: resolveApiUrl(apiBasePath),
     headers: async () =>
       (typeof opts.headers === "function" ? await opts.headers() : opts.headers) ?? {},
-    ...(opts.demo ? { fetch: demoFetch } : {}),
+    ...(opts.demo
+      ? { fetch: createDemoFetch(fetchImpl) }
+      : opts.fetch
+        ? { fetch: opts.fetch }
+        : {}),
     plugins: [batchPlugin()],
   });
   return createORPCClient<BusabaseORPCClient>(link);

--- a/packages/busabase-contract/src/domains/form/definition.ts
+++ b/packages/busabase-contract/src/domains/form/definition.ts
@@ -12,7 +12,7 @@ import type { NodeTypeDefinition } from "../types";
 export const formNodeType = {
   type: "form",
   label: "Form",
-  icon: "clipboard-list",
+  icon: "form",
   capabilities: { hasDetail: true, creatable: true },
   operations: [],
 } as const satisfies NodeTypeDefinition;

--- a/packages/busabase-contract/src/domains/form/types.ts
+++ b/packages/busabase-contract/src/domains/form/types.ts
@@ -1,6 +1,7 @@
 // Form-as-Node DTO/VO schemas. Pure zod leaf — no db, no server imports.
 // See apps/busabase/content/spec/form-as-node.md.
 import { z } from "zod";
+import { fieldNameSchema, fieldTypeSchema } from "../base/contract/base-schemas";
 
 /**
  * One input-to-field mapping. `inputName` is the name the agent-authored page
@@ -16,6 +17,25 @@ export const FormFieldBindingSchema = z.object({
   help: z.string().optional(),
 });
 export type FormFieldBindingVO = z.infer<typeof FormFieldBindingSchema>;
+
+/**
+ * Client-safe control metadata for one bound Base field. Public Forms expose
+ * only these curated fields, never the target Base or its records.
+ */
+export const FormBoundFieldSchema = z.object({
+  slug: z.string(),
+  name: fieldNameSchema,
+  type: fieldTypeSchema,
+  choices: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+      }),
+    )
+    .default([]),
+});
+export type FormBoundFieldVO = z.infer<typeof FormBoundFieldSchema>;
 
 /** Optional theme tokens layered over the agent-authored page. */
 export const FormThemeSchema = z.object({
@@ -59,6 +79,7 @@ export const FormVOSchema = z.object({
   name: z.string(),
   description: z.string(),
   bindings: z.array(FormFieldBindingSchema),
+  boundFields: z.array(FormBoundFieldSchema).default([]),
   page: FormPageSourceSchema,
   share: FormShareSchema,
   /** Accepted submissions so far — backs server-side `share.submitLimit`. */

--- a/packages/busabase-contract/src/types/index.ts
+++ b/packages/busabase-contract/src/types/index.ts
@@ -152,6 +152,7 @@ export { VIEW_FIELD_MAX_WIDTH, VIEW_FIELD_MIN_WIDTH } from "../domains/base/type
 
 export type {
   CreateFormDTO,
+  FormBoundFieldVO,
   FormFieldBindingVO,
   FormPageSourceVO,
   FormShareVO,

--- a/packages/busabase-core/package.json
+++ b/packages/busabase-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-core",
   "description": "Shared Busabase open-core protocol, local store, API helpers, and dashboard components.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/busabase-core/src/context.ts
+++ b/packages/busabase-core/src/context.ts
@@ -279,6 +279,67 @@ export function runWithAnonymousContext<T>(
   );
 }
 
+/**
+ * Run `fn` as a MEMBER — a signed-in session, or an API key (whose ceiling
+ * rides along as `credentialPermissionCeiling`; see the field's own doc
+ * comment for why a read-only key issued to an admin still sees what that
+ * admin can see, and is capped only on what it can DO).
+ *
+ * Unlike `runWithAnonymousContext` / `runWithEmbedContext`, a member's ACL
+ * signals are not pinned here — they are host-resolved from the actor's real
+ * workspace role and supplied by the caller. What this factory pins is
+ * `visitorKind`: it is never set, so a member request can never carry the
+ * anonymous downgrade by accident. Its value is a single named, documented
+ * construction point for the caller kind that today's twelve call sites hand-
+ * assemble independently (see caller-kinds-and-permission-context.md).
+ */
+export function runWithMemberContext<T>(
+  ctx: Omit<BusabaseContext, "visitorKind">,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return storage.run(ctx, fn);
+}
+
+/**
+ * Run `fn` as an EMBED visitor — an anonymous holder of an Embed Link (an
+ * AirApp embed, or a generic node embed).
+ *
+ * Distinct from `runWithAnonymousContext` ("guest"): a guest's authority
+ * comes from the NODE being explicitly publicly shared; an embed visitor's
+ * authority comes from possessing the LINK, and V1 links carry Space-scoped
+ * read (see caller-kinds-and-permission-context.md §5).
+ *
+ * `actorId` is supplied by the caller and is deliberately the link's
+ * CREATOR, not an anonymous sentinel — kept for attribution and for their
+ * own node-principal grants (§9.2 of the same doc), never for privilege
+ * LEVEL, which is why the two pins below cannot be overridden by the caller:
+ *
+ * - `isSpaceManager: false` — the creator is typically an owner/admin, and a
+ *   manager short-circuits every node-ACL check to full access; without this
+ *   pin every private node in the Space would be listed and readable through
+ *   the link. This was PR #5948's bug (there, for the AirApp bridge only).
+ * - `credentialPermissionCeiling: "read"` — the capability is a read-only
+ *   credential, so no node-principal grant can raise this request above
+ *   `read` even where the creator personally holds `manage`.
+ *
+ * Both are needed: the ceiling alone still leaves the manager bypass in the
+ * visibility SQL, and `isSpaceManager: false` alone still lets an explicit
+ * `manage` grant through.
+ */
+export function runWithEmbedContext<T>(
+  ctx: Omit<BusabaseContext, "isSpaceManager" | "credentialPermissionCeiling">,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return storage.run(
+    {
+      ...ctx,
+      isSpaceManager: false,
+      credentialPermissionCeiling: "read",
+    },
+    fn,
+  );
+}
+
 /** The injected host db for the current request, or undefined in local mode. */
 export function getContextDb(): BusabaseDatabase | undefined {
   return storage.getStore()?.db;

--- a/packages/busabase-core/src/db/schema.ts
+++ b/packages/busabase-core/src/db/schema.ts
@@ -485,6 +485,7 @@ export const busabaseAuditEvents = pgTable(
     createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
   },
   (base) => [
+    index("busabase_audit_events_space_created_id_idx").on(base.spaceId, base.createdAt, base.id),
     index("busabase_audit_events_action_created_idx").on(base.action, base.createdAt),
     index("busabase_audit_events_record_created_idx").on(base.recordId, base.createdAt),
     index("busabase_audit_events_base_created_idx").on(base.baseId, base.createdAt),

--- a/packages/busabase-core/src/domains/airapp/handlers.ts
+++ b/packages/busabase-core/src/domains/airapp/handlers.ts
@@ -207,6 +207,15 @@ export const createAirAppChangeRequest = (
   input: z.input<typeof createAirAppChangeRequestInputSchema>,
 ) => createFileTreeChangeRequest(airappFileTreeConfig, nodeIdOrSlug, input);
 
-export const materializeAirAppNode = makeMaterializer(airappFileTreeConfig);
+// Built on first use, not at module evaluation: `makeMaterializer` comes from
+// filetree/handlers, and calling it here would make this module's evaluation
+// order relative to that one load-bearing (see logic/materialize.ts).
+let materializeAirAppNodeImpl: ReturnType<typeof makeMaterializer> | undefined;
+export const materializeAirAppNode: ReturnType<typeof makeMaterializer> = (ctx, args) => {
+  if (!materializeAirAppNodeImpl) {
+    materializeAirAppNodeImpl = makeMaterializer(airappFileTreeConfig);
+  }
+  return materializeAirAppNodeImpl(ctx, args);
+};
 
 registerMaterializer("airapp", materializeAirAppNode);

--- a/packages/busabase-core/src/domains/base/logic/record-ops.ts
+++ b/packages/busabase-core/src/domains/base/logic/record-ops.ts
@@ -11,6 +11,7 @@ import {
   busabaseBases,
   busabaseChangeRequests,
   busabaseCommits,
+  busabaseForms,
   busabaseNodes,
   busabaseOperations,
   busabaseRecords,
@@ -19,6 +20,7 @@ import { insertAuditEvent } from "../../../logic/audit";
 import {
   finalizeChangeRequest,
   getChangeRequest,
+  hydrateChangeRequest,
   mergeChangeRequest,
   recordMergedNodeCreate,
   recordPendingNodeCreate,
@@ -42,6 +44,7 @@ import {
   createDeleteChangeRequestInputSchema,
   updateRecordChangeRequestInputSchema,
 } from "../../../logic/store";
+import { toBaseVO } from "../../../logic/vo";
 import { assertValidFormulaField, validateRecordFields } from "../field-rules";
 import type { FieldDef } from "../field-types";
 import { FormulaError } from "../formula";
@@ -325,22 +328,84 @@ export const createBase = async (input: z.input<typeof createBaseInputSchema>) =
   return { ...base, materialized: true as const };
 };
 
-export const createChangeRequest = async (
+type CreateChangeRequestInput = z.input<typeof createChangeRequestInputSchema>;
+
+type CreateChangeRequestAuthorization = { kind: "base" } | { kind: "form"; formNodeId: string };
+
+/**
+ * Resolve the private Base behind an already-authorized Form submission.
+ * The Form-to-Base relationship is checked again here so this narrow entry
+ * point cannot be used to target an arbitrary Base.
+ */
+const getFormSubmissionBase = async (formNodeId: string, baseId: string) => {
+  const db = await getDb();
+  const spaceId = getContextSpaceId();
+  const [row] = await db
+    .select({ base: busabaseBases })
+    .from(busabaseBases)
+    .innerJoin(
+      busabaseForms,
+      and(eq(busabaseForms.targetBaseId, busabaseBases.id), eq(busabaseForms.nodeId, formNodeId)),
+    )
+    .where(
+      and(
+        eq(busabaseBases.id, baseId),
+        eq(busabaseBases.spaceId, spaceId),
+        eq(busabaseForms.spaceId, spaceId),
+        eq(busabaseForms.status, "active"),
+        isNull(busabaseBases.archivedAt),
+        isNull(busabaseBases.deletedAt),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+
+  const fields = await db
+    .select()
+    .from(busabaseBaseFields)
+    .where(and(eq(busabaseBaseFields.baseId, row.base.id), isNull(busabaseBaseFields.deletedAt)));
+  return toBaseVO(row.base, fields);
+};
+
+/** Load a CR just created through the Form-authorized path without widening
+ * the normal CR read surface to the private target Base. */
+const getFormSubmissionChangeRequest = async (changeRequestId: string) => {
+  const db = await getDb();
+  const [changeRequest] = await db
+    .select()
+    .from(busabaseChangeRequests)
+    .where(
+      and(
+        eq(busabaseChangeRequests.id, changeRequestId),
+        eq(busabaseChangeRequests.spaceId, getContextSpaceId()),
+      ),
+    )
+    .limit(1);
+  return changeRequest ? hydrateChangeRequest(changeRequest) : null;
+};
+
+const createChangeRequestInternal = async (
   baseId: string,
   // `z.input` (not `z.infer`/output) — matches createBase/createDoc/
   // createFileNode/createFileTreeNode: callers may omit any field with a
   // schema default (e.g. `autoMerge`), since `.parse()` below fills it in.
-  input: z.input<typeof createChangeRequestInputSchema>,
+  input: CreateChangeRequestInput,
+  authorization: CreateChangeRequestAuthorization,
 ) => {
   await ensureReady();
   const db = await getDb();
-  const base = await getBase(baseId);
+  const base =
+    authorization.kind === "form"
+      ? await getFormSubmissionBase(authorization.formNodeId, baseId)
+      : await getBase(baseId);
   if (!base) {
     throw baseNotFound(baseId);
   }
   // ChangeRequest-submission gate (node ACL): read-level visibility (getBase
   // above) is not enough to propose — requires `changeRequest` level.
-  await assertBaseChangeRequestPermission(base.id);
+  if (authorization.kind === "base") {
+    await assertBaseChangeRequestPermission(base.id);
+  }
 
   const parsed = createChangeRequestInputSchema.parse(input);
   assertValidRecordFields(parsed.fields, base.fields);
@@ -360,7 +425,10 @@ export const createChangeRequest = async (
       parsed.idempotencyKey,
     );
     if (existingId) {
-      const existing = await getChangeRequest(existingId);
+      const existing =
+        authorization.kind === "form"
+          ? await getFormSubmissionChangeRequest(existingId)
+          : await getChangeRequest(existingId);
       if (existing) {
         // Retry returns whatever the first call produced, as-is (merged or
         // still pending) — always the ChangeRequestVO shape, never re-derived
@@ -405,7 +473,10 @@ export const createChangeRequest = async (
         parsed.idempotencyKey,
       );
       if (existingId) {
-        const existing = await getChangeRequest(existingId);
+        const existing =
+          authorization.kind === "form"
+            ? await getFormSubmissionChangeRequest(existingId)
+            : await getChangeRequest(existingId);
         if (existing) {
           return { ...existing, materialized: false as const };
         }
@@ -481,7 +552,10 @@ export const createChangeRequest = async (
     submittedBy,
   });
 
-  const changeRequest = await getChangeRequest(changeRequestId);
+  const changeRequest =
+    authorization.kind === "form"
+      ? await getFormSubmissionChangeRequest(changeRequestId)
+      : await getChangeRequest(changeRequestId);
   if (!changeRequest) {
     throw new Error("Failed to create changeRequest");
   }
@@ -509,6 +583,22 @@ export const createChangeRequest = async (
   }
   return { ...changeRequest, materialized: false as const };
 };
+
+/** Normal Base mutation entry: visibility + changeRequest permission required. */
+export const createChangeRequest = async (baseId: string, input: CreateChangeRequestInput) =>
+  createChangeRequestInternal(baseId, input, { kind: "base" });
+
+/**
+ * Form-only proposal entry. Form logic must authorize the Form before calling;
+ * this function verifies the active Form still targets the Base, then creates
+ * a pending proposal without exposing or sharing that Base with the visitor.
+ */
+export const createFormSubmissionChangeRequest = async (
+  formNodeId: string,
+  baseId: string,
+  input: CreateChangeRequestInput,
+) =>
+  createChangeRequestInternal(baseId, { ...input, autoMerge: false }, { kind: "form", formNodeId });
 
 /**
  * Propose many record creates as ONE change request: a single CR with N

--- a/packages/busabase-core/src/domains/dashboard/components/dashboard-shell.test.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/dashboard-shell.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Router } from "wouter";
+import { useCoreI18n } from "../../../i18n";
+import { BusabaseDashboardShell } from "./dashboard-shell";
+
+Object.assign(globalThis, { React });
+
+const useStaticLocation = (): [string, (path: string) => void] => ["/", () => undefined];
+const useStaticSearch = () => "";
+
+function ShareMessageProbe() {
+  const messages = useCoreI18n();
+  return <span>{messages.share.shareToWeb}</span>;
+}
+
+describe("BusabaseDashboardShell i18n", () => {
+  it("provides its locale to sidebar-owned dialogs", () => {
+    const queryClient = new QueryClient();
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <Router hook={useStaticLocation} searchHook={useStaticSearch}>
+          <BusabaseDashboardShell
+            activeChangeRequestCount={0}
+            chrome={{
+              hideUserMenu: true,
+              onSignOut: () => undefined,
+              user: { avatar: "", email: "tester@example.com", name: "Tester" },
+            }}
+            locale="zh-CN"
+            nodes={[]}
+            onCreateClick={() => undefined}
+            onSearchClick={() => undefined}
+          >
+            <ShareMessageProbe />
+          </BusabaseDashboardShell>
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("分享到网页");
+    expect(markup).not.toContain("Share to web");
+  });
+});

--- a/packages/busabase-core/src/domains/dashboard/components/dashboard-shell.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/dashboard-shell.tsx
@@ -28,7 +28,7 @@ import type { ComponentProps, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useLocation } from "wouter";
-import { coreMessagesByLocale } from "../../../i18n";
+import { CoreI18nProvider, coreMessagesByLocale } from "../../../i18n";
 import { nodeIconForType } from "../helpers/node-icons";
 import type { MoveNodePayload } from "../hooks/use-move-node";
 import { NodeDeleteDialog } from "./file-tree-browser";
@@ -646,115 +646,117 @@ export function BusabaseDashboardShell({
   };
 
   return (
-    <div data-busabase-dashboard-layout className="h-full min-h-0">
-      <Toaster position="top-right" />
-      <DashboardLayout
-        {...chrome}
-        className="h-full min-h-0"
-        defaultOpen
-        navMain={pinnedNav}
-        sidebarExtra={
-          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden group-data-[collapsible=icon]:overflow-hidden">
-            <NavMain
-              items={scrollNav}
-              onHeaderActionClick={handleHeaderActionClick}
-              onNavItemAction={handleNavItemAction}
-              onNodeDrop={onMoveNode ? handleNodeDrop : undefined}
-              isDropAllowed={onMoveNode ? isDropAllowed : undefined}
-              onExpand={onExpandNode ? (item) => item.id && onExpandNode(item.id) : undefined}
-            />
-          </div>
-        }
-        onHeaderActionClick={handleHeaderActionClick}
-        onNavItemAction={handleNavItemAction}
-        headerClassName="!h-0 !min-h-0 overflow-hidden border-0"
-        hideSidebarTrigger
-        pageClassName="gap-0 p-0"
-        sidebarClassName="h-full"
-      >
-        {children}
-      </DashboardLayout>
-      {orpc && permissionsTarget && (
-        <NodePermissionsDialog
-          nodeId={permissionsTarget.id}
-          nodeName={permissionsTarget.name}
-          onOpenChange={(next) => {
-            if (!next) setPermissionsTarget(null);
-          }}
-          open
-          orpc={orpc}
-        />
-      )}
-      {orpc && renameTarget && (
-        <NodeRenameDialog
-          nodeId={renameTarget.id}
-          nodeName={renameTarget.name}
-          nodeSlug={renameTarget.slug}
-          onOpenChange={(next) => {
-            if (!next) setRenameTarget(null);
-          }}
-          open
-          orpc={orpc}
-        />
-      )}
-      {promptsTarget && (
-        <NodeAgentPromptsDialog
-          nodeId={promptsTarget.id}
-          nodeName={promptsTarget.name}
-          nodeType={promptsTarget.type}
-          onOpenChange={(next) => {
-            if (!next) setPromptsTarget(null);
-          }}
-          open
-        />
-      )}
-      {orpc && shareTarget && (
-        <NodeShareDialog
-          nodeId={shareTarget.id}
-          nodeName={shareTarget.name}
-          nodeSlug={shareTarget.slug}
-          nodeType={shareTarget.type}
-          onOpenChange={(next) => {
-            if (!next) setShareTarget(null);
-          }}
-          open
-          orpc={orpc}
-        />
-      )}
-      {orpc && deleteTarget && (
-        <NodeDeleteDialog
-          childCount={deleteTarget.childCount}
-          /* Only bounce to the workbench root when the node being deleted is
-             the one currently open — otherwise the route you're on is about to
-             404. Deleting some OTHER node from the sidebar must leave you
-             exactly where you were; a detail page's own "•••" menu always
-             qualifies for the redirect and keeps the default. */
-          navigateHome={Boolean(
-            deleteTarget.href &&
-              (location === deleteTarget.href || location.startsWith(`${deleteTarget.href}/`)),
-          )}
-          nodeId={deleteTarget.id}
-          nodeName={deleteTarget.name}
-          nodeType={deleteTarget.type}
-          onOpenChange={(next) => {
-            if (!next) setDeleteTarget(null);
-          }}
-          open
-          orpc={orpc}
-        />
-      )}
-      {onMoveNode && moveTarget && (
-        <NodeMoveDialog
-          node={moveTarget}
-          nodes={nodes}
-          onMoveNode={onMoveNode}
-          onOpenChange={(next) => {
-            if (!next) setMoveTarget(null);
-          }}
-          open
-        />
-      )}
-    </div>
+    <CoreI18nProvider locale={locale}>
+      <div data-busabase-dashboard-layout className="h-full min-h-0">
+        <Toaster position="top-right" />
+        <DashboardLayout
+          {...chrome}
+          className="h-full min-h-0"
+          defaultOpen
+          navMain={pinnedNav}
+          sidebarExtra={
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden group-data-[collapsible=icon]:overflow-hidden">
+              <NavMain
+                items={scrollNav}
+                onHeaderActionClick={handleHeaderActionClick}
+                onNavItemAction={handleNavItemAction}
+                onNodeDrop={onMoveNode ? handleNodeDrop : undefined}
+                isDropAllowed={onMoveNode ? isDropAllowed : undefined}
+                onExpand={onExpandNode ? (item) => item.id && onExpandNode(item.id) : undefined}
+              />
+            </div>
+          }
+          onHeaderActionClick={handleHeaderActionClick}
+          onNavItemAction={handleNavItemAction}
+          headerClassName="!h-0 !min-h-0 overflow-hidden border-0"
+          hideSidebarTrigger
+          pageClassName="gap-0 p-0"
+          sidebarClassName="h-full"
+        >
+          {children}
+        </DashboardLayout>
+        {orpc && permissionsTarget && (
+          <NodePermissionsDialog
+            nodeId={permissionsTarget.id}
+            nodeName={permissionsTarget.name}
+            onOpenChange={(next) => {
+              if (!next) setPermissionsTarget(null);
+            }}
+            open
+            orpc={orpc}
+          />
+        )}
+        {orpc && renameTarget && (
+          <NodeRenameDialog
+            nodeId={renameTarget.id}
+            nodeName={renameTarget.name}
+            nodeSlug={renameTarget.slug}
+            onOpenChange={(next) => {
+              if (!next) setRenameTarget(null);
+            }}
+            open
+            orpc={orpc}
+          />
+        )}
+        {promptsTarget && (
+          <NodeAgentPromptsDialog
+            nodeId={promptsTarget.id}
+            nodeName={promptsTarget.name}
+            nodeType={promptsTarget.type}
+            onOpenChange={(next) => {
+              if (!next) setPromptsTarget(null);
+            }}
+            open
+          />
+        )}
+        {orpc && shareTarget && (
+          <NodeShareDialog
+            nodeId={shareTarget.id}
+            nodeName={shareTarget.name}
+            nodeSlug={shareTarget.slug}
+            nodeType={shareTarget.type}
+            onOpenChange={(next) => {
+              if (!next) setShareTarget(null);
+            }}
+            open
+            orpc={orpc}
+          />
+        )}
+        {orpc && deleteTarget && (
+          <NodeDeleteDialog
+            childCount={deleteTarget.childCount}
+            /* Only bounce to the workbench root when the node being deleted is
+               the one currently open — otherwise the route you're on is about to
+               404. Deleting some OTHER node from the sidebar must leave you
+               exactly where you were; a detail page's own "•••" menu always
+               qualifies for the redirect and keeps the default. */
+            navigateHome={Boolean(
+              deleteTarget.href &&
+                (location === deleteTarget.href || location.startsWith(`${deleteTarget.href}/`)),
+            )}
+            nodeId={deleteTarget.id}
+            nodeName={deleteTarget.name}
+            nodeType={deleteTarget.type}
+            onOpenChange={(next) => {
+              if (!next) setDeleteTarget(null);
+            }}
+            open
+            orpc={orpc}
+          />
+        )}
+        {onMoveNode && moveTarget && (
+          <NodeMoveDialog
+            node={moveTarget}
+            nodes={nodes}
+            onMoveNode={onMoveNode}
+            onOpenChange={(next) => {
+              if (!next) setMoveTarget(null);
+            }}
+            open
+          />
+        )}
+      </div>
+    </CoreI18nProvider>
   );
 }
 

--- a/packages/busabase-core/src/domains/dashboard/components/node-detail-views.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/node-detail-views.tsx
@@ -1,12 +1,25 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
+import type { FormVO, NodeVO } from "busabase-contract/types";
 import { CodeBlock } from "kui/ai-elements/code-block";
 import { FileTree } from "kui/ai-elements/file-tree";
 import { Button } from "kui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "kui/popover";
-import { AppWindow, File, FileText, Folder, HardDrive, Info, Sparkles, Table2 } from "lucide-react";
+import {
+  AppWindow,
+  File,
+  FileText,
+  Folder,
+  Form,
+  HardDrive,
+  Info,
+  Share2,
+  Sparkles,
+  Table2,
+} from "lucide-react";
 import { SPALink as Link } from "openlib/ui/dashboard";
 import { type ComponentProps, useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { useLocation, useSearch } from "wouter";
 import { fmt, useCoreI18n } from "../../../i18n";
 import { AirAppDetailView } from "../../airapp/components/AirAppDetailView";
@@ -20,6 +33,7 @@ import { useRegisterTopbarNodeActions } from "../hooks/use-register-topbar-node-
 import { useReportLoadedNode } from "../hooks/use-report-loaded-node";
 import { type NodeDetailProps, registerNodeDetail } from "../node-detail-registry";
 import { registerSidePanelTab, type SidePanelTabProps } from "../side-panel-registry";
+import { useIsAnonymousVisitor } from "../visitor-context";
 import { AssetMetadataBlock, assetKindIcon, formatAssetSize } from "./assets";
 import {
   buildFileTree,
@@ -31,6 +45,7 @@ import {
 } from "./file-tree-browser";
 import { NodeActionsMenu } from "./node-actions-menu";
 import { NodePinButton, nodeSidePanelTabId } from "./node-pin-button";
+import { NodeShareDialog } from "./node-share-button";
 import { EmptyState } from "./primitives";
 import { FileContentSkeleton, NodeDetailSkeleton } from "./skeletons";
 import { SplitSubmitButton } from "./split-submit-button";
@@ -982,6 +997,7 @@ export function FolderDetailView({
 
 const FOLDER_CHILD_ICONS: Record<string, typeof Folder> = {
   folder: Folder,
+  form: Form,
   base: Table2,
   doc: FileText,
   file: File,
@@ -991,7 +1007,110 @@ const FOLDER_CHILD_ICONS: Record<string, typeof Folder> = {
 };
 
 registerNodeDetail("folder", FolderDetailView);
-registerNodeDetail("form", FormDetailView);
+const findNodeBySlug = (nodes: NodeVO[], type: string, slug: string): NodeVO | null => {
+  for (const node of nodes) {
+    if (node.type === type && node.slug === slug) return node;
+    const match = findNodeBySlug(node.children, type, slug);
+    if (match) return match;
+  }
+  return null;
+};
+
+function FormShareButton({
+  form,
+  node,
+  orpc,
+}: {
+  form: FormVO;
+  node: NodeVO;
+  orpc: BusabaseQueryUtils;
+}) {
+  const messages = useCoreI18n();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const nodeShareQuery = useQuery(
+    orpc.nodes.share.get.queryOptions({ input: { nodeId: node.id } }),
+  );
+  const updateForm = useMutation(orpc.forms.update.mutationOptions());
+  const setNodeShare = useMutation(orpc.nodes.share.set.mutationOptions());
+  const busy = updateForm.isPending || setNodeShare.isPending;
+
+  const openShare = async () => {
+    try {
+      const creatingPublicForm = !form.share.isPublic;
+      if (creatingPublicForm) {
+        await updateForm.mutateAsync({
+          nodeId: node.id,
+          share: { ...form.share, isPublic: true, anonymousSubmit: true },
+        });
+      }
+      if (creatingPublicForm || nodeShareQuery.data?.scope !== "public") {
+        await setNodeShare.mutateAsync({ nodeId: node.id, scope: "public", capability: "submit" });
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.forms.getByNode.queryOptions({ input: { nodeId: node.slug } }).queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.nodes.share.get.queryOptions({ input: { nodeId: node.id } }).queryKey,
+        }),
+      ]);
+      setOpen(true);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : messages.share.failed);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        className="h-8 gap-1.5"
+        disabled={busy}
+        onClick={openShare}
+        size="sm"
+        variant="outline"
+      >
+        <Share2 className="size-3.5" />
+        {messages.share.title}
+      </Button>
+      <NodeShareDialog
+        nodeId={node.id}
+        nodeName={node.name}
+        nodeSlug={node.slug}
+        nodeType="form"
+        onOpenChange={setOpen}
+        open={open}
+        orpc={orpc}
+      />
+    </>
+  );
+}
+
+function FormNodeDetailView({ nodes = [], onNodeLoaded, orpc, slug }: NodeDetailProps) {
+  const isAnonymous = useIsAnonymousVisitor();
+  const nodeQuery = useQuery({
+    ...orpc.nodes.get.queryOptions({ input: { nodeId: slug ?? "", type: "form" } }),
+    enabled: Boolean(slug && !isAnonymous),
+    retry: false,
+  });
+  const nodeDetail = asNodeDetail(nodeQuery.data, "form");
+  const node = nodeDetail?.node ?? (slug ? findNodeBySlug(nodes, "form", slug) : null);
+  const formQuery = useQuery({
+    ...orpc.forms.getByNode.queryOptions({ input: { nodeId: slug ?? "" } }),
+    enabled: Boolean(slug),
+    retry: false,
+  });
+  const form = formQuery.data ?? null;
+  useReportLoadedNode(node, onNodeLoaded);
+
+  useRegisterTopbarNodeActions(
+    node && form && !isAnonymous ? <FormShareButton form={form} node={node} orpc={orpc} /> : null,
+  );
+
+  return <FormDetailView orpc={orpc} slug={slug} />;
+}
+
+registerNodeDetail("form", FormNodeDetailView);
 
 function FolderSidePanelPreview({ orpc, payload }: SidePanelTabProps) {
   const { nodeId } = payload as { nodeId: string };

--- a/packages/busabase-core/src/domains/dashboard/components/node-share-button.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/node-share-button.tsx
@@ -5,6 +5,7 @@ import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-quer
 import { Button } from "kui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -15,7 +16,7 @@ import { Input } from "kui/input";
 import { Label } from "kui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "kui/select";
 import { Switch } from "kui/switch";
-import { Check, Copy, Globe } from "lucide-react";
+import { Check, Copy, Globe, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useCoreI18n } from "../../../i18n";
@@ -154,7 +155,14 @@ export function NodeShareDialog({
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-lg" data-testid="node-share-dialog">
+      <DialogContent className="max-w-lg" data-testid="node-share-dialog" showCloseButton={false}>
+        <DialogClose
+          aria-label={t.close}
+          className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+        >
+          <X aria-hidden="true" className="h-4 w-4" />
+          <span className="sr-only">{t.close}</span>
+        </DialogClose>
         <DialogHeader>
           <DialogTitle>{t.dialogTitle}</DialogTitle>
           <DialogDescription>{nodeName}</DialogDescription>

--- a/packages/busabase-core/src/domains/dashboard/helpers/node-icons.test.ts
+++ b/packages/busabase-core/src/domains/dashboard/helpers/node-icons.test.ts
@@ -1,0 +1,11 @@
+import { Folder, Form } from "lucide-react";
+import { describe, expect, it } from "vitest";
+import { nodeIconForId, nodeIconForType } from "./node-icons";
+
+describe("node icons", () => {
+  it("uses the Lucide Form icon for Form nodes", () => {
+    expect(nodeIconForType("form")).toBe(Form);
+    expect(nodeIconForId("form")).toBe(Form);
+    expect(nodeIconForType("form")).not.toBe(Folder);
+  });
+});

--- a/packages/busabase-core/src/domains/dashboard/helpers/node-icons.ts
+++ b/packages/busabase-core/src/domains/dashboard/helpers/node-icons.ts
@@ -5,6 +5,7 @@ import {
   File,
   FileText,
   Folder,
+  Form,
   HardDrive,
   type LucideIcon,
   PenTool,
@@ -21,6 +22,7 @@ import {
  */
 const ICON_BY_ID: Record<string, LucideIcon> = {
   folder: Folder,
+  form: Form,
   table: Table2,
   sparkles: Sparkles,
   "hard-drive": HardDrive,

--- a/packages/busabase-core/src/domains/dashboard/index.tsx
+++ b/packages/busabase-core/src/domains/dashboard/index.tsx
@@ -251,8 +251,13 @@ function BusabaseDashboardContent({
     () => createKnownNodeCache(`${cacheSpaceKey}:${currentUserId ?? "anonymous"}`),
     [cacheSpaceKey, currentUserId],
   );
+  const [loadedDetailNode, setLoadedDetailNode] = useState<{
+    node: LoadedNode;
+    scopeKey: string;
+  } | null>(null);
   const recordLoadedNode = useCallback(
     (node: LoadedNode) => {
+      setLoadedDetailNode({ node, scopeKey: cacheSpaceKey });
       nodeCache.recordVisit(
         {
           id: node.id,
@@ -264,7 +269,7 @@ function BusabaseDashboardContent({
         new Date().toISOString(),
       );
     },
-    [nodeCache],
+    [cacheSpaceKey, nodeCache],
   );
   // Reads run through oRPC + React Query, seeded by the SSR props as initialData.
   const changeRequestsList = orpc.changeRequests.list.queryOptions({ input: {} });
@@ -379,6 +384,19 @@ function BusabaseDashboardContent({
     nodeDetailRoute,
     selectedChangeRequestId,
   } = useDashboardRoutes();
+  const activeDetailNode = useMemo(() => {
+    if (!nodeDetailRoute) return null;
+    const treeNode = flattenNodesForCache(nodeTree).find(
+      (node) => node.type === nodeDetailRoute.type && node.slug === nodeDetailRoute.slug,
+    );
+    if (treeNode) return treeNode;
+    const loadedNode = loadedDetailNode?.node;
+    return loadedDetailNode?.scopeKey === cacheSpaceKey &&
+      loadedNode?.type === nodeDetailRoute.type &&
+      loadedNode.slug === nodeDetailRoute.slug
+      ? loadedNode
+      : null;
+  }, [cacheSpaceKey, loadedDetailNode, nodeDetailRoute, nodeTree]);
   const activeBase = useMemo(
     () =>
       selectedBaseSlug
@@ -902,6 +920,13 @@ function BusabaseDashboardContent({
       return [{ href: "/assets", label: messages.nav.assets }, { label: messages.nav.assets }];
     }
 
+    if (nodeDetailRoute?.type === "form") {
+      return [
+        { label: messages.nav.workspace },
+        { label: activeDetailNode?.name ?? messages.form.tabForm },
+      ];
+    }
+
     if (isBaseSetupRoute) {
       return [
         { label: messages.nav.workspace },
@@ -977,6 +1002,7 @@ function BusabaseDashboardContent({
     return [{ label: messages.nav.home }];
   }, [
     activeBase,
+    activeDetailNode,
     activeRecord,
     isBaseSetupRoute,
     isChangeRequestRoute,
@@ -987,6 +1013,7 @@ function BusabaseDashboardContent({
     isBaseViewRoute,
     isRecordRoute,
     locationPath,
+    nodeDetailRoute,
     selectedBaseView,
     selectedChangeRequest,
     selectedOperation,

--- a/packages/busabase-core/src/domains/drive/handlers.ts
+++ b/packages/busabase-core/src/domains/drive/handlers.ts
@@ -39,6 +39,15 @@ export const createDriveChangeRequest = (
   input: z.input<typeof createDriveChangeRequestInputSchema>,
 ) => createFileTreeChangeRequest(driveFileTreeConfig, nodeIdOrSlug, input);
 
-export const materializeDriveNode = makeMaterializer(driveFileTreeConfig);
+// Built on first use, not at module evaluation: `makeMaterializer` comes from
+// filetree/handlers, and calling it here would make this module's evaluation
+// order relative to that one load-bearing (see logic/materialize.ts).
+let materializeDriveNodeImpl: ReturnType<typeof makeMaterializer> | undefined;
+export const materializeDriveNode: ReturnType<typeof makeMaterializer> = (ctx, args) => {
+  if (!materializeDriveNodeImpl) {
+    materializeDriveNodeImpl = makeMaterializer(driveFileTreeConfig);
+  }
+  return materializeDriveNodeImpl(ctx, args);
+};
 
 registerMaterializer("drive", materializeDriveNode);

--- a/packages/busabase-core/src/domains/form/components/form-detail-view.tsx
+++ b/packages/busabase-core/src/domains/form/components/form-detail-view.tsx
@@ -3,8 +3,9 @@ import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-quer
 import type { FormFieldBindingVO } from "busabase-contract/types";
 import { CheckCircle2, Code2, Eye, Globe, Lock } from "lucide-react";
 import { useCallback, useState } from "react";
-import { useCoreI18n } from "../../../i18n";
+import { useCoreI18n, useIString } from "../../../i18n";
 import { FormSandboxFrame } from "./form-sandbox-frame";
+import { GeneratedFormField } from "./generated-form-field";
 
 /**
  * Form node detail view.
@@ -17,16 +18,16 @@ import { FormSandboxFrame } from "./form-sandbox-frame";
  */
 export function FormDetailView({ orpc, slug }: { orpc: BusabaseQueryUtils; slug: string | null }) {
   const messages = useCoreI18n();
+  const resolveIString = useIString();
   const formQuery = useQuery({
     ...orpc.forms.getByNode.queryOptions({ input: { nodeId: slug ?? "" } }),
     enabled: Boolean(slug),
     retry: false,
   });
-  const submit = useMutation(orpc.forms.submit.mutationOptions());
-  const [values, setValues] = useState<Record<string, string>>({});
-  const [tab, setTab] = useState<"form" | "code">("form");
-
   const form = formQuery.data ?? null;
+  const submit = useMutation(orpc.forms.submit.mutationOptions());
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [tab, setTab] = useState<"form" | "code">("form");
 
   const doSubmit = useCallback(
     (payload: Record<string, unknown>) => {
@@ -47,8 +48,8 @@ export function FormDetailView({ orpc, slug }: { orpc: BusabaseQueryUtils; slug:
     );
   }
 
-  const { theme } = form.page;
   const hasCustomPage = Boolean(form.page.code);
+  const targetFieldsBySlug = new Map(form.boundFields.map((field) => [field.slug, field]));
 
   const submittedPanel = (
     <div className="px-6 py-16 text-center">
@@ -60,6 +61,73 @@ export function FormDetailView({ orpc, slug }: { orpc: BusabaseQueryUtils; slug:
       </p>
     </div>
   );
+
+  if (!hasCustomPage) {
+    return (
+      <div
+        className="h-full min-h-0 w-full overflow-auto bg-muted/35"
+        data-dashboard-scroll="generated-form"
+      >
+        <main className="mx-auto w-full max-w-4xl px-4 py-6 sm:px-6 sm:py-8 lg:py-10">
+          <section className="overflow-hidden rounded-md border border-border/70 bg-card">
+            <header className="border-border/60 border-b px-5 py-5 sm:px-7">
+              <h1 className="font-semibold text-2xl text-foreground leading-tight">{form.name}</h1>
+              {form.description ? (
+                <p className="mt-1.5 max-w-2xl text-muted-foreground text-sm leading-5">
+                  {form.description}
+                </p>
+              ) : null}
+            </header>
+
+            {submit.isSuccess ? (
+              submittedPanel
+            ) : (
+              <div className="px-5 py-5 sm:px-7">
+                <div className="space-y-3">
+                  {form.bindings.map((binding: FormFieldBindingVO) => {
+                    const field = targetFieldsBySlug.get(binding.fieldSlug);
+                    const label =
+                      binding.label ?? (field ? resolveIString(field.name) : binding.fieldSlug);
+                    return (
+                      <GeneratedFormField
+                        binding={binding}
+                        field={field}
+                        key={binding.inputName}
+                        label={label}
+                        onChange={(value) =>
+                          setValues((current) => ({ ...current, [binding.inputName]: value }))
+                        }
+                        value={values[binding.inputName]}
+                      />
+                    );
+                  })}
+                </div>
+
+                {submit.isError ? (
+                  <div className="mt-4 rounded-md border border-rejected/35 bg-rejected/17 px-3 py-2 text-rejected-strong text-sm">
+                    {submit.error instanceof Error
+                      ? submit.error.message
+                      : messages.form.submitFailed}
+                  </div>
+                ) : null}
+
+                <div className="mt-4 flex justify-end border-border/50 border-t pt-3">
+                  <button
+                    className="inline-flex h-9 min-w-28 items-center justify-center rounded-md bg-foreground px-4 font-medium text-background text-sm transition-colors hover:bg-foreground/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25 disabled:opacity-60"
+                    disabled={submit.isPending}
+                    onClick={() => doSubmit(values)}
+                    type="button"
+                  >
+                    {submit.isPending ? messages.common.submitting : messages.common.submit}
+                  </button>
+                </div>
+              </div>
+            )}
+          </section>
+        </main>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-6">
@@ -142,56 +210,7 @@ export function FormDetailView({ orpc, slug }: { orpc: BusabaseQueryUtils; slug:
             </div>
           ) : null}
         </div>
-      ) : (
-        <div>
-          {theme?.coverUrl ? (
-            <img alt="" className="mb-4 h-40 w-full rounded-lg object-cover" src={theme.coverUrl} />
-          ) : null}
-          {theme?.logoUrl ? (
-            <img alt="" className="mb-3 h-10 w-10 rounded object-contain" src={theme.logoUrl} />
-          ) : null}
-          {form.description ? (
-            <p className="mb-5 text-muted-foreground text-sm">{form.description}</p>
-          ) : null}
-          <div className="space-y-4">
-            {form.bindings.map((binding: FormFieldBindingVO) => (
-              <label className="block" key={binding.inputName}>
-                <span className="font-medium text-foreground text-sm">
-                  {binding.label ?? binding.fieldSlug}
-                  {binding.required ? <span className="ml-0.5 text-rejected-strong">*</span> : null}
-                </span>
-                {binding.help ? (
-                  <span className="mt-0.5 block text-muted-foreground text-xs">{binding.help}</span>
-                ) : null}
-                <input
-                  className="mt-1.5 h-9 w-full rounded-md border border-border/70 bg-card px-3 text-sm outline-none transition-colors focus:border-primary"
-                  data-input-name={binding.inputName}
-                  onChange={(event) =>
-                    setValues((current) => ({
-                      ...current,
-                      [binding.inputName]: event.target.value,
-                    }))
-                  }
-                  value={values[binding.inputName] ?? ""}
-                />
-              </label>
-            ))}
-          </div>
-          {submit.isError ? (
-            <div className="mt-4 rounded-md border border-rejected/35 bg-rejected/17 px-3 py-2 text-rejected-strong text-sm">
-              {submit.error instanceof Error ? submit.error.message : messages.form.submitFailed}
-            </div>
-          ) : null}
-          <button
-            className="mt-6 inline-flex h-9 items-center rounded-md bg-foreground px-4 font-medium text-background text-sm transition-colors hover:bg-foreground/85 disabled:opacity-60"
-            disabled={submit.isPending}
-            onClick={() => doSubmit(values)}
-            type="button"
-          >
-            {submit.isPending ? messages.common.submitting : messages.common.submit}
-          </button>
-        </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/packages/busabase-core/src/domains/form/components/generated-form-field.tsx
+++ b/packages/busabase-core/src/domains/form/components/generated-form-field.tsx
@@ -1,0 +1,125 @@
+import type { FormBoundFieldVO, FormFieldBindingVO } from "busabase-contract/types";
+import { type FieldInputKind, fieldInputKind } from "../../base/field-types";
+
+interface GeneratedFormFieldProps {
+  binding: FormFieldBindingVO;
+  field?: FormBoundFieldVO;
+  label: string;
+  onChange: (value: unknown) => void;
+  value: unknown;
+}
+
+const controlClassName =
+  "mt-1.5 w-full rounded-md border border-border/70 bg-card px-3 text-sm text-foreground outline-none transition-[border-color,box-shadow] focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15";
+
+const stringValue = (value: unknown): string =>
+  typeof value === "string" || typeof value === "number" ? String(value) : "";
+
+export const generatedFormControlKind = (field?: FormBoundFieldVO): FieldInputKind =>
+  field ? fieldInputKind(field.type) : "text";
+
+export function GeneratedFormField({
+  binding,
+  field,
+  label,
+  onChange,
+  value,
+}: GeneratedFormFieldProps) {
+  const controlKind = generatedFormControlKind(field);
+  const inputId = `form-field-${binding.inputName}`;
+  const sharedProps = {
+    "data-input-name": binding.inputName,
+    id: inputId,
+  };
+
+  const control =
+    controlKind === "textarea" ? (
+      <textarea
+        {...sharedProps}
+        aria-label={label}
+        className={`${controlClassName} min-h-16 resize-y py-2 leading-5`}
+        onChange={(event) => onChange(event.target.value)}
+        value={stringValue(value)}
+      />
+    ) : controlKind === "checkbox" ? (
+      <div className="mt-1.5 flex h-9 items-center">
+        <input
+          {...sharedProps}
+          aria-label={label}
+          checked={value === true}
+          className="size-4 rounded border-border text-primary accent-primary outline-none focus-visible:ring-2 focus-visible:ring-primary/20"
+          onChange={(event) => onChange(event.target.checked)}
+          type="checkbox"
+        />
+      </div>
+    ) : controlKind === "select" ? (
+      <select
+        {...sharedProps}
+        aria-label={label}
+        className={`${controlClassName} h-9`}
+        onChange={(event) => onChange(event.target.value)}
+        value={stringValue(value)}
+      >
+        <option value="">-</option>
+        {(field?.choices ?? []).map((choice) => (
+          <option key={choice.id} value={choice.id}>
+            {choice.name}
+          </option>
+        ))}
+      </select>
+    ) : controlKind === "multiselect" ? (
+      <select
+        {...sharedProps}
+        aria-label={label}
+        className={`${controlClassName} min-h-20 py-2`}
+        multiple
+        onChange={(event) =>
+          onChange(Array.from(event.currentTarget.selectedOptions).map((option) => option.value))
+        }
+        value={
+          Array.isArray(value)
+            ? value.filter((item): item is string => typeof item === "string")
+            : []
+        }
+      >
+        {(field?.choices ?? []).map((choice) => (
+          <option key={choice.id} value={choice.id}>
+            {choice.name}
+          </option>
+        ))}
+      </select>
+    ) : (
+      <input
+        {...sharedProps}
+        aria-label={label}
+        className={`${controlClassName} h-9`}
+        onChange={(event) =>
+          onChange(
+            controlKind === "number" && event.target.value !== ""
+              ? event.target.valueAsNumber
+              : event.target.value,
+          )
+        }
+        type={
+          controlKind === "number" ||
+          controlKind === "date" ||
+          controlKind === "url" ||
+          controlKind === "email" ||
+          controlKind === "tel"
+            ? controlKind
+            : "text"
+        }
+        value={stringValue(value)}
+      />
+    );
+
+  return (
+    <div className="min-w-0">
+      <label className="block font-medium text-foreground text-sm" htmlFor={inputId}>
+        {label}
+        {binding.required ? <span className="ml-0.5 text-rejected-strong">*</span> : null}
+      </label>
+      {control}
+    </div>
+  );
+}

--- a/packages/busabase-core/src/domains/form/logic/form-ops.ts
+++ b/packages/busabase-core/src/domains/form/logic/form-ops.ts
@@ -8,18 +8,24 @@ import type {
   SubmitFormDTO,
   UpdateFormDTO,
 } from "busabase-contract/types";
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, inArray, isNull, or } from "drizzle-orm";
 import { getContextSpaceId, isAnonymousVisitor, resolveActorId } from "../../../context";
 import { getDb } from "../../../db";
-import { busabaseBases, busabaseForms, busabaseNodes } from "../../../db/schema";
+import {
+  busabaseBaseFields,
+  busabaseBases,
+  busabaseForms,
+  busabaseNodes,
+} from "../../../db/schema";
 import { id, now } from "../../../logic/kernel";
 import {
   assertNodePermission,
   buildNodeVisibilityCondition,
+  getPublicScopeOf,
   hasNodePermission,
 } from "../../../logic/node-acl";
 import { ensureReady } from "../../../logic/seed";
-import { createChangeRequest } from "../../base/logic/record-ops";
+import { createFormSubmissionChangeRequest } from "../../base/logic/record-ops";
 import type { FormPO } from "../schema";
 
 const formNotFound = (nodeId: string) =>
@@ -38,6 +44,7 @@ const toFormVO = (po: FormPO): FormVO => ({
   name: po.name,
   description: po.description,
   bindings: po.bindings ?? [],
+  boundFields: [],
   page: po.page ?? {},
   share: { ...DEFAULT_SHARE, ...(po.share ?? {}) },
   submissionCount: po.submissionCount ?? 0,
@@ -70,13 +77,60 @@ export const getFormByNodeId = async (nodeIdOrSlug: string): Promise<FormVO | nu
     )
     .limit(1);
   if (!row) return null;
+  const form = toFormVO(row.form);
+  if (isAnonymousVisitor() && !form.share.isPublic) return null;
   const [targetBase] = await db
     .select({ nodeId: busabaseBases.nodeId })
     .from(busabaseBases)
     .where(and(eq(busabaseBases.id, row.form.targetBaseId), eq(busabaseBases.spaceId, spaceId)))
     .limit(1);
-  if (!targetBase || !(await hasNodePermission(targetBase.nodeId, "read"))) return null;
-  return toFormVO(row.form);
+  if (!targetBase) return null;
+  // A public Form is the disclosure boundary: visitors may render its curated
+  // page and bindings without gaining read access to the private target Base.
+  // Members still need normal Base visibility so a Form cannot reveal a Base
+  // that has been hidden from them.
+  if (!isAnonymousVisitor() && !(await hasNodePermission(targetBase.nodeId, "read"))) return null;
+
+  const boundSlugs = [...new Set(form.bindings.map((binding) => binding.fieldSlug))];
+  const boundFieldRows =
+    boundSlugs.length === 0
+      ? []
+      : await db
+          .select({
+            slug: busabaseBaseFields.slug,
+            name: busabaseBaseFields.name,
+            type: busabaseBaseFields.type,
+            options: busabaseBaseFields.options,
+          })
+          .from(busabaseBaseFields)
+          .where(
+            and(
+              eq(busabaseBaseFields.baseId, form.targetBaseId),
+              inArray(busabaseBaseFields.slug, boundSlugs),
+              isNull(busabaseBaseFields.deletedAt),
+            ),
+          );
+  const fieldsBySlug = new Map(boundFieldRows.map((field) => [field.slug, field]));
+
+  return {
+    ...form,
+    boundFields: form.bindings.flatMap((binding) => {
+      const field = fieldsBySlug.get(binding.fieldSlug);
+      return field
+        ? [
+            {
+              slug: field.slug,
+              name: field.name,
+              type: field.type,
+              choices: (field.options.choices ?? []).map((choice) => ({
+                id: choice.id,
+                name: choice.name,
+              })),
+            },
+          ]
+        : [];
+    }),
+  };
 };
 
 export const createForm = async (input: CreateFormDTO): Promise<FormVO> => {
@@ -187,6 +241,21 @@ export const submitForm = async (
     }
   }
 
+  // Authoritative read/submit capability check, on the node this submission
+  // actually resolved to. The router's anonymous guard runs first, but it only
+  // has the caller's ref — which for a public link is a node SLUG, and slugs
+  // are unique per parent, not per space. Re-checking the resolved id here is
+  // what makes that approximation safe: a read-only share cannot borrow a
+  // same-slug sibling's `submit` capability.
+  //
+  // Keyed on the CONTEXT (`isAnonymousVisitor`), not on the `caller` hint: a
+  // public-link visitor is a property of the request the host pinned, so a
+  // transport that forgets to pass `isAnonymous` cannot bypass this — which is
+  // exactly how the anonymous path broke before.
+  if (isAnonymousVisitor() && (await getPublicScopeOf(form.nodeId)) !== "submit") {
+    throw new ORPCError("FORBIDDEN", { message: "This form's public link is read-only." });
+  }
+
   // ── Server-side submit limit ──
   if (form.share.submitLimit != null && form.submissionCount >= form.share.submitLimit) {
     throw new ORPCError("TOO_MANY_REQUESTS", {
@@ -220,7 +289,7 @@ export const submitForm = async (
     });
   }
 
-  const changeRequest = await createChangeRequest(form.targetBaseId, {
+  const changeRequest = await createFormSubmissionChangeRequest(form.nodeId, form.targetBaseId, {
     fields,
     message: `Form submission: ${form.name}`,
     submittedBy: caller.isAnonymous ? ANONYMOUS_SUBMITTER : "local-producer",

--- a/packages/busabase-core/src/domains/form/router.ts
+++ b/packages/busabase-core/src/domains/form/router.ts
@@ -1,5 +1,6 @@
 import { implement, ORPCError } from "@orpc/server";
 import { busabaseContract } from "busabase-contract/contract/busabase";
+import { isAnonymousVisitor } from "../../context";
 import { createForm, getFormByNodeId, submitForm, updateForm } from "./logic/form-ops";
 
 const os = implement(busabaseContract);
@@ -19,9 +20,6 @@ export const formRouter = {
   }),
   submit: os.forms.submit.handler(async ({ input }) => {
     const { nodeId, ...rest } = input;
-    // Dashboard/internal RPC is always an authenticated space member; the
-    // anonymous path arrives through the public surface (which passes
-    // `isAnonymous`) — see spec §5.1 / §7.
-    return submitForm(nodeId, rest, { isAnonymous: false });
+    return submitForm(nodeId, rest, { isAnonymous: isAnonymousVisitor() });
   }),
 };

--- a/packages/busabase-core/src/domains/skill/handlers.ts
+++ b/packages/busabase-core/src/domains/skill/handlers.ts
@@ -91,6 +91,15 @@ export const mergeSkillMetadata = async (
     throw error;
   }
 };
-export const materializeSkillNode = makeMaterializer(skillFileTreeConfig);
+// Built on first use, not at module evaluation: `makeMaterializer` comes from
+// filetree/handlers, and calling it here would make this module's evaluation
+// order relative to that one load-bearing (see logic/materialize.ts).
+let materializeSkillNodeImpl: ReturnType<typeof makeMaterializer> | undefined;
+export const materializeSkillNode: ReturnType<typeof makeMaterializer> = (ctx, args) => {
+  if (!materializeSkillNodeImpl) {
+    materializeSkillNodeImpl = makeMaterializer(skillFileTreeConfig);
+  }
+  return materializeSkillNodeImpl(ctx, args);
+};
 
 registerMaterializer("skill", materializeSkillNode);

--- a/packages/busabase-core/src/logic/anonymous-allowlist.ts
+++ b/packages/busabase-core/src/logic/anonymous-allowlist.ts
@@ -70,10 +70,9 @@ const ANONYMOUS_READ_ALLOWLIST: ReadonlySet<string> = new Set([
   "records.list",
   "records.listPage",
   "records.get",
-  // Public form rendering. The `form` domain does not exist in the codebase
-  // yet (P1 shipped the `submit` capability, not the form surface); listed now
-  // so the read half lands correctly the moment it does.
-  "form.getByNode",
+  // Public form rendering. The form logic still enforces the Form's own share
+  // settings; this entry only makes the node-scoped procedure reachable.
+  "forms.getByNode",
 ]);
 
 /**
@@ -81,11 +80,7 @@ const ANONYMOUS_READ_ALLOWLIST: ReadonlySet<string> = new Set([
  * scope is exactly `"submit"`. A `"read"` share must never reach these — that
  * is the entire difference between the two capabilities.
  */
-const ANONYMOUS_SUBMIT_ALLOWLIST: ReadonlySet<string> = new Set([
-  // See the note on `form.getByNode`: not yet implemented, gated correctly in
-  // advance so it cannot land as an unguarded mutation.
-  "form.submit",
-]);
+const ANONYMOUS_SUBMIT_ALLOWLIST: ReadonlySet<string> = new Set(["forms.submit"]);
 
 /**
  * Node types an anonymous (public-link) visitor may read through `nodes.get`.

--- a/packages/busabase-core/src/logic/audit.ts
+++ b/packages/busabase-core/src/logic/audit.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { ORPCError } from "@orpc/server";
 import type { CommentSubjectType } from "busabase-contract/types";
-import { and, asc, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import {
   getContextIsSpaceManager,
@@ -329,6 +329,30 @@ export const createAuditEvent = async (input: z.infer<typeof auditEventInputSche
   return insertAuditEvent(db, input);
 };
 
+const listVisibleChangeRequestIds = async (
+  candidates: (typeof busabaseAuditEvents.$inferSelect)[],
+): Promise<Set<string>> => {
+  const changeRequestIds = [
+    ...new Set(
+      candidates.flatMap((event) => (event.changeRequestId ? [event.changeRequestId] : [])),
+    ),
+  ];
+  if (changeRequestIds.length === 0) return new Set();
+
+  const db = await getDb();
+  const rows = await db
+    .select({ id: busabaseChangeRequests.id })
+    .from(busabaseChangeRequests)
+    .where(
+      and(
+        eq(busabaseChangeRequests.spaceId, getContextSpaceId()),
+        inArray(busabaseChangeRequests.id, changeRequestIds),
+      ),
+    );
+  const { filterVisibleChangeRequestRows } = await import("./cr-lifecycle");
+  return new Set((await filterVisibleChangeRequestRows(rows)).map((row) => row.id));
+};
+
 export const listAuditEvents = async (input?: z.input<typeof listInputSchema>) => {
   const { ensureReady } = await import("./seed");
   await ensureReady();
@@ -345,8 +369,12 @@ export const listAuditEvents = async (input?: z.input<typeof listInputSchema>) =
       .orderBy(desc(busabaseAuditEvents.createdAt), desc(busabaseAuditEvents.id))
       .limit(batchSize)
       .offset(offset);
+    const visibleChangeRequestIds = await listVisibleChangeRequestIds(candidates);
     const visibility = await Promise.all(
       candidates.map(async (event) => {
+        if (event.changeRequestId) {
+          return visibleChangeRequestIds.has(event.changeRequestId);
+        }
         try {
           await assertAuditSubjectPermission(event, "read");
           return true;
@@ -392,7 +420,10 @@ export const listComments = async (input: z.infer<typeof commentSubjectInputSche
   return comments.map((comment) => toCommentVO(comment, users));
 };
 
-export const createComment = async (input: z.infer<typeof createCommentInputSchema>) => {
+// `z.input`, not `z.infer`: `mentionsAi` has `.optional().default(false)`, so the
+// inferred OUTPUT type makes it required while callers legitimately omit it.
+// `.parse()` below fills the default in. Matches `createDoc`/`createBase`.
+export const createComment = async (input: z.input<typeof createCommentInputSchema>) => {
   const { ensureReady } = await import("./seed");
   await ensureReady();
   const db = await getDb();

--- a/packages/busabase-core/src/logic/cr-lifecycle.ts
+++ b/packages/busabase-core/src/logic/cr-lifecycle.ts
@@ -77,6 +77,17 @@ import {
   mergeViewRestore as mergeViewRestoreBase,
   mergeViewUpdate as mergeViewUpdateBase,
 } from "../domains/base/handlers";
+// Side-effect imports: each registers a `node_create` materializer at import
+// time (logic/materialize.ts). Merging is the only place they are read, so the
+// merge kernel is what has to guarantee they are loaded — leaving it to whoever
+// else happened to import them meant `node_create` for a Skill/Drive/AirApp
+// silently fell back to the generic materializer and produced a node with zero
+// files. Safe to import in any order: each builds its materializer on first use.
+import "../domains/airapp/handlers";
+import "../domains/drive/handlers";
+import "../domains/file-node/handlers";
+import "../domains/folder/handlers";
+import "../domains/skill/handlers";
 import { resolveLookupValues } from "../domains/base/logic/lookup-values";
 import { mergeDocUpdate } from "../domains/doc/handlers";
 import { mergeFileTreeFile, mergeFileTreeMetadata } from "../domains/filetree/handlers";
@@ -1681,7 +1692,7 @@ const canViewChangeRequest = async (changeRequestId: string): Promise<boolean> =
 // Constrained to `{ id }` rather than the full ChangeRequestPO on purpose: the
 // body only ever reads `row.id`, and callers that are merely tallying should be
 // free to select three columns instead of paying for whole rows.
-const filterVisibleChangeRequestRows = async <T extends { id: string }>(
+export const filterVisibleChangeRequestRows = async <T extends { id: string }>(
   rows: T[],
 ): Promise<T[]> => {
   if (rows.length === 0 || getContextIsSpaceManager()) return rows;

--- a/packages/busabase-core/src/logic/demo-store.ts
+++ b/packages/busabase-core/src/logic/demo-store.ts
@@ -74,6 +74,8 @@ export const demoGetForm = (nodeIdOrSlug: string): FormVO | null => {
     return null;
   }
   const timestamp = nowIso();
+  const targetBase = (currentScenario().bases ?? []).find((base) => base.id === def.targetBaseId);
+  const fieldsBySlug = new Map((targetBase?.fields ?? []).map((field) => [field.slug, field]));
   return {
     id: def.formId,
     nodeId: def.nodeId,
@@ -82,6 +84,22 @@ export const demoGetForm = (nodeIdOrSlug: string): FormVO | null => {
     name: def.name,
     description: def.description,
     bindings: def.bindings,
+    boundFields: def.bindings.flatMap((binding) => {
+      const field = fieldsBySlug.get(binding.fieldSlug);
+      return field
+        ? [
+            {
+              slug: field.slug,
+              name: field.name,
+              type: field.type,
+              choices: (field.options.choices ?? []).map((choice) => ({
+                id: choice.id,
+                name: choice.name,
+              })),
+            },
+          ]
+        : [];
+    }),
     page: def.page ?? {},
     share: { isPublic: false, anonymousSubmit: false },
     submissionCount: 0,

--- a/packages/busabase-core/src/logic/node-acl.ts
+++ b/packages/busabase-core/src/logic/node-acl.ts
@@ -82,6 +82,51 @@ export async function getPublicScopeOf(nodeId: string): Promise<"read" | "submit
   return row?.scope ?? null;
 }
 
+/**
+ * The same capability read, for a node REFERENCE that may be an id OR a node
+ * slug.
+ *
+ * Why this exists next to `getPublicScopeOf`: the public surface passes
+ * user-visible refs around. A shared link is `/<nodeType>/<node slug>` and the
+ * detail route hands that slug straight through as the procedure's `nodeId`
+ * (which is why `getFormByNodeId` resolves either form) — so the slug, not the
+ * id, is what every real visitor sends. An id-only capability lookup fails
+ * closed on all of them: a public page that renders and then refuses to accept
+ * anything. Not a leak, but dead all the same.
+ *
+ * Slug matching is deliberately APPROXIMATE. Node slugs are unique per PARENT
+ * (`busabase_nodes_parent_slug_uniq`), not per space, so one ref can name
+ * several nodes; this returns the widest capability among the publicly shared
+ * candidates. That makes it a *reachability* answer and nothing more — the
+ * authoritative check belongs on the resolved node id inside the handler (see
+ * `submitForm`), which is the node the write will actually touch.
+ */
+export async function getPublicScopeOfNodeRef(
+  nodeIdOrSlug: string,
+): Promise<"read" | "submit" | null> {
+  // An id match is unambiguous, so it wins.
+  const byId = await getPublicScopeOf(nodeIdOrSlug);
+  if (byId) return byId;
+
+  const db = await getDb();
+  const rows = await db
+    .select({ scope: busabaseNodes.effectivePublicScope })
+    .from(busabaseNodes)
+    .where(
+      and(
+        eq(busabaseNodes.slug, nodeIdOrSlug),
+        eq(busabaseNodes.spaceId, getContextSpaceId()),
+        isNotNull(busabaseNodes.effectivePublicScope),
+        // The slug uniqueness index only covers live rows; archived/deleted
+        // nodes must not resurrect a link either.
+        isNull(busabaseNodes.archivedAt),
+        isNull(busabaseNodes.deletedAt),
+      ),
+    );
+  if (rows.some((row) => row.scope === "submit")) return "submit";
+  return rows.some((row) => row.scope === "read") ? "read" : null;
+}
+
 /** The stricter of two explicit visibilities; null = "no explicit constraint". */
 const strictest = (
   a: NodeVisibility | null | undefined,

--- a/packages/busabase-core/src/router.ts
+++ b/packages/busabase-core/src/router.ts
@@ -18,7 +18,7 @@ import { anonymousAccessKindFor, denyAnonymousProcedure } from "./logic/anonymou
 import { grepUnified } from "./logic/grep";
 import { subscribeBusabaseLiveEvents } from "./logic/live-events";
 import {
-  getPublicScopeOf,
+  getPublicScopeOfNodeRef,
   grantNodePrincipal,
   listNodePrincipals,
   revokeNodePrincipal,
@@ -295,10 +295,13 @@ const anonymousSurfaceGuard = os.middleware(async ({ next, path }, input) => {
   if (kind === "submit") {
     // A `submit` procedure must be authorized against the TARGET NODE's own
     // capability, not merely against "the visitor got in somehow": a node
-    // shared read-only must never accept writes. No resolvable node id means
-    // we cannot prove the capability, so we refuse.
-    const nodeId = readNodeId(input);
-    if (!nodeId || (await getPublicScopeOf(nodeId)) !== "submit") {
+    // shared read-only must never accept writes. No resolvable node ref means
+    // we cannot prove the capability, so we refuse. The ref may be an id or a
+    // node slug (a public link carries the slug), and slug resolution is
+    // approximate by nature — the handler re-checks the capability on the node
+    // it actually resolved. See `getPublicScopeOfNodeRef`.
+    const nodeRef = readNodeId(input);
+    if (!nodeRef || (await getPublicScopeOfNodeRef(nodeRef)) !== "submit") {
       denyAnonymousProcedure(path);
     }
   }

--- a/packages/busabase-core/src/skill-doc.ts
+++ b/packages/busabase-core/src/skill-doc.ts
@@ -703,51 +703,71 @@ function buildBootstrapMarkdown(origin: string, ctx?: SkillMarkdownContext): str
   const step0 = isCloud
     ? `## Step 0 — Connect to Busabase Cloud
 
-Busabase Cloud is hosted — nothing to install. Use RFC 8628 device authorization: it works on a
-local machine, over SSH, and in a container because the browser can be on any computer or phone.
-The CLI saves the selected API key without printing it. Never ask the user to paste a secret in chat,
-and never print or display \`~/.busabase/.env\`.
+${
+  preselectedSpaceId
+    ? `One move: sign in. The dashboard already chose the Space, so there is nothing to confirm
+afterwards.`
+    : `Two moves: sign in, then confirm the Space you landed in.
+
+### 0a. Sign in`
+}
+
+Busabase Cloud is hosted — nothing to install. Device authorization works on a local machine, over
+SSH, and in a container because the browser can be on any computer or phone. Run this once; it never
+blocks on a terminal prompt:
 
 \`\`\`bash
 ${BUSABASE_CLI} login --device-code --base-url ${site}${preselectedSpaceId ? ` --space-id ${preselectedSpaceId}` : ""}
 \`\`\`
+
 The terminal shows a short code and a verification URL, then waits. The user signs in, selects an
 existing API key or creates a new one, and approves in any browser. The browser never receives the
-key secret; the waiting CLI receives and saves it through a one-time exchange. On success the CLI
-prints a safe summary containing the selected Space plus
-\`createdSpace\` and \`bootstrapRequired\`; it never prints the credential.
+key secret; the waiting CLI receives and saves it through a one-time exchange. Never ask the user to
+paste a secret in chat, and never print or display \`~/.busabase/.env\` — on success the CLI prints a
+safe summary containing the selected Space, \`availableSpaces\`, \`createdSpace\` and
+\`bootstrapRequired\`; it never prints the credential.
 
-${
-  preselectedSpaceId
-    ? `The dashboard-supplied \`--space-id\` targets that Space explicitly, so login does not need a terminal
-Space selection.`
-    : `Login never blocks on a terminal Space selection, even if the agent's shell allocates a TTY: if the
-account belongs to more than one Space, it always accepts the server-resolved default (the one the
-user was most recently active in).`
-} The summary also includes
-\`availableSpaces\` (a list of every Space the account belongs to). Always tell the user which Space
-was selected (name + id) and, if it belongs to more than one, that they can say so and you'll switch
-with \`${BUSABASE_CLI} space use <id>\` — don't silently proceed to Step 1 on the default without
-surfacing this.
+If the code expires or authorization fails, explain what happened; if the user still wants to
+continue, rerun the same login command above once.
 
-\`\`\`bash
-${BUSABASE_CLI} whoami --output json
-\`\`\`
+${preselectedSpaceId ? `The dashboard supplied \`--space-id ${preselectedSpaceId}\` — lock it as the target: never create or\nswitch Spaces, and never ask the user to pick one. Preselection only fixes *which* Space; it does not\ndecide whether that Space needs initializing, so read \`bootstrapRequired\` below regardless.\n\n` : ""}Branch on the summary's \`bootstrapRequired\` alone, never on whether a Space happens to be empty:
 
-Branch only on the server-owned state, never on whether a Space happens to be empty:
-
-${preselectedSpaceId ? `- **Dashboard Space supplied (\`${preselectedSpaceId}\`)** → lock this as the target: never create or switch Spaces. Preselection does not decide whether initialization is required; continue by checking \`bootstrapRequired\`.` : ""}
 - **\`bootstrapRequired: false\`** → existing user/Space, including a preselected empty Space with no
   bootstrap marker. Connect only and jump to Step 3 with zero structure or record writes.
 - **\`bootstrapRequired: true\`** → the selected Space was auto-created for this user and still carries
   the persistent version-0 bootstrap marker. Ask the Step 1 scenario question, then initialize this
   Space even when the dashboard preselected it.
 
-An empty existing Space has no marker and is therefore connect-only. A retry after interrupted
-initialization still has the version-0 marker and safely resumes Step 2.
+Two edge cases fall out of that same rule: an empty *existing* Space has no marker and is therefore
+connect-only, not a trigger to initialize; and a retry after interrupted initialization still has the
+version-0 marker and safely resumes Step 2.
+${
+  preselectedSpaceId
+    ? ""
+    : `
+### 0b. Confirm the target Space
 
-If the code expires or authorization fails, explain what happened; if the user still wants to
-continue, rerun the same login command above once.`
+Login never asks which Space to use: it takes the server default (the Space the user was most
+recently active in) and lists the rest in \`availableSpaces\`. The user has not seen that choice yet.
+
+Always tell the user which Space was selected (name + id). Then, by \`availableSpaces\` length:
+
+- **One** → nothing to choose. Continue with the \`bootstrapRequired\` branch from 0a.
+- **More than one** → ask once, a lettered choice in the user's language: \`A\` keeps the current
+  Space, then one letter per remaining entry. Offer Spaces, never commands — switching is your job,
+  so never tell the user to run anything.
+
+  > 📂 You're in **{space.name}** (the Space you used most recently). Keep it, or switch?
+  > **A.** Keep **{space.name}**   **B.** {otherSpace1.name}   **C.** {otherSpace2.name}
+
+  On a switch, run both and re-decide the 0a branch from the new \`bootstrapRequired\` — the old one
+  belonged to the previous Space:
+
+  \`\`\`bash
+  ${BUSABASE_CLI} space use <id>
+  ${BUSABASE_CLI} whoami --output json
+  \`\`\``
+}`
     : `## Step 0 — Connect to Busabase Personal Desktop
 
 Everything runs locally — no account, no API key. The user has already confirmed this edition, so

--- a/packages/busabase-core/tests/activity-listpaged-orpc.test.ts
+++ b/packages/busabase-core/tests/activity-listpaged-orpc.test.ts
@@ -151,11 +151,21 @@ describe("activity.listPaged — keyset merge parity", () => {
   });
 
   it("continues past a newest window containing only hidden-node events", async () => {
-    await client.bases.createChangeRequest({
-      baseId,
-      fields: { name: "visible-before-hidden" },
-      autoMerge: true,
-    });
+    const createAndMergeChangeRequest = async (targetBaseId: string, name: string) => {
+      const changeRequest = await client.bases.createChangeRequest({
+        baseId: targetBaseId,
+        fields: { name },
+        autoMerge: false,
+      });
+      if (changeRequest.materialized) throw new Error("expected pending change request");
+      await client.changeRequests.review({
+        changeRequestIds: [changeRequest.id],
+        verdict: "approved",
+      });
+      await client.changeRequests.merge({ changeRequestIds: [changeRequest.id] });
+      return changeRequest;
+    };
+    const visibleChangeRequest = await createAndMergeChangeRequest(baseId, "visible-before-hidden");
     const privateBase = await client.bases.create({
       slug: "private-feed",
       name: "Private Feed",
@@ -164,25 +174,41 @@ describe("activity.listPaged — keyset merge parity", () => {
     });
     if (!privateBase.materialized) throw new Error("expected materialized private base");
     await client.nodes.updateVisibility({ nodeId: privateBase.nodeId, visibility: "private" });
+    const hiddenChangeRequestIds: string[] = [];
     for (let index = 0; index < 4; index++) {
-      await client.bases.createChangeRequest({
-        baseId: privateBase.id,
-        fields: { name: `hidden-${index}` },
-        autoMerge: true,
-      });
+      const hiddenChangeRequest = await createAndMergeChangeRequest(
+        privateBase.id,
+        `hidden-${index}`,
+      );
+      hiddenChangeRequestIds.push(hiddenChangeRequest.id);
     }
 
-    const page = await runWithBusabaseContext(
+    const { auditEvents, page } = await runWithBusabaseContext(
       {
         spaceId: LOCAL_SPACE_ID,
         actorId: "feed-member",
         isSpaceManager: false,
         permissionLevel: "read",
       },
-      () => client.activity.listPaged({ limit: 2 }),
+      async () => {
+        const [page, auditEvents] = await Promise.all([
+          client.activity.listPaged({ limit: 2 }),
+          client.auditEvents.list({ limit: 100 }),
+        ]);
+        return { auditEvents, page };
+      },
     );
     expect(page.items.length).toBe(2);
     expect(JSON.stringify(page.items)).not.toContain("hidden-");
     expect(JSON.stringify(page.items)).not.toContain(privateBase.id);
+    expect(auditEvents.some((event) => event.changeRequestId === visibleChangeRequest.id)).toBe(
+      true,
+    );
+    expect(
+      auditEvents.some(
+        (event) =>
+          event.changeRequestId !== null && hiddenChangeRequestIds.includes(event.changeRequestId),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/busabase-core/tests/anonymous-allowlist.test.ts
+++ b/packages/busabase-core/tests/anonymous-allowlist.test.ts
@@ -83,7 +83,7 @@ describe("anonymous allowlist (unit)", () => {
     expect(anonymousAllowlistSnapshot().read).toEqual([
       "bases.get",
       "bases.listViews",
-      "form.getByNode",
+      "forms.getByNode",
       // `docs.get` / `files.get` / `folders.get` collapsed into this one route.
       "nodes.get",
       "nodes.list",
@@ -120,8 +120,8 @@ describe("anonymous allowlist (unit)", () => {
     }
   });
 
-  it("classifies form.submit as submit-only, never as read", () => {
-    expect(anonymousAccessKindFor(["form", "submit"])).toBe("submit");
+  it("classifies forms.submit as submit-only, never as read", () => {
+    expect(anonymousAccessKindFor(["forms", "submit"])).toBe("submit");
     expect(anonymousAccessKindFor(["nodes", "list"])).toBe("read");
   });
 
@@ -141,7 +141,7 @@ describe("anonymous allowlist (unit)", () => {
     expect(anonymousAccessKindFor(["core", "nodes", "list"])).toBe("read");
     expect(anonymousAccessKindFor(["core", "records", "list"])).toBe("read");
     expect(anonymousAccessKindFor(["core", "records", "listPage"])).toBe("read");
-    expect(anonymousAccessKindFor(["core", "form", "submit"])).toBe("submit");
+    expect(anonymousAccessKindFor(["core", "forms", "submit"])).toBe("submit");
     // Denials must survive the prefix too.
     expect(anonymousAccessKindFor(["core", "vault", "get"])).toBeNull();
     expect(anonymousAccessKindFor(["core", "dump", "exportTables"])).toBeNull();

--- a/packages/busabase-core/tests/form-node.test.ts
+++ b/packages/busabase-core/tests/form-node.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { createRouterClient } from "@orpc/server";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { LOCAL_SPACE_ID, runWithBusabaseContext } from "../src/context";
+import { LOCAL_SPACE_ID, runWithAnonymousContext, runWithBusabaseContext } from "../src/context";
 import { DEMO_BASES, DEMO_FOLDERS } from "../src/demo/dataset";
 import {
   createForm,
@@ -11,6 +11,7 @@ import {
   submitForm,
   updateForm,
 } from "../src/domains/form/logic/form-ops";
+import { getPublicScopeOf } from "../src/logic/node-acl";
 import { seedScenario } from "../src/logic/seed";
 import { busabaseRouter } from "../src/router";
 
@@ -30,6 +31,7 @@ describe("Form-as-Node — submission + access gates", () => {
   let client: ReturnType<typeof createRouterClient<typeof busabaseRouter, Record<never, never>>>;
   let blogBaseId = "";
   let formNodeId = "";
+  let publicFormNodeId = "";
 
   beforeAll(async () => {
     originalCwd = process.cwd();
@@ -47,7 +49,15 @@ describe("Form-as-Node — submission + access gates", () => {
     // A form node to bind the form row to.
     await client.nodes.createChangeRequest({
       autoMerge: true,
-      operations: [{ kind: "create", nodeType: "form", slug: "t-form", name: "T Form" }],
+      operations: [
+        { kind: "create", nodeType: "form", slug: "t-form", name: "T Form" },
+        {
+          kind: "create",
+          nodeType: "form",
+          slug: "t-public-form",
+          name: "T Public Form",
+        },
+      ],
     });
     const nodes = await client.nodes.list({});
     const flat: Array<{ id: string; slug: string; type: string; children?: unknown[] }> = [];
@@ -62,6 +72,17 @@ describe("Form-as-Node — submission + access gates", () => {
     };
     walk(nodes as unknown[]);
     formNodeId = flat.find((n) => n.slug === "t-form" && n.type === "form")?.id ?? "";
+    publicFormNodeId = flat.find((n) => n.slug === "t-public-form" && n.type === "form")?.id ?? "";
+
+    await createForm({
+      nodeId: publicFormNodeId,
+      targetBaseId: blogBaseId,
+      name: "T Public Form",
+      bindings: [
+        { inputName: "subject", fieldSlug: "title", required: true },
+        { inputName: "msg", fieldSlug: "body", required: true },
+      ],
+    });
   }, 120_000);
 
   afterAll(async () => {
@@ -135,6 +156,131 @@ describe("Form-as-Node — submission + access gates", () => {
     await expect(
       submitForm(formNodeId, { values: { subject: "over", msg: "limit" } }, { isAnonymous: true }),
     ).rejects.toThrow(/submission limit/i);
+  });
+
+  it("submits through the anonymous Router without exposing the target Base", async () => {
+    expect(publicFormNodeId).not.toBe("");
+    const target = await client.bases.get({ baseId: blogBaseId });
+    if (!target) throw new Error("expected target Base");
+
+    await client.nodes.share.set({
+      nodeId: publicFormNodeId,
+      scope: "public",
+      capability: "submit",
+    });
+    await updateForm(publicFormNodeId, {
+      share: { isPublic: true, anonymousSubmit: false },
+    });
+
+    await runWithAnonymousContext({}, async () => {
+      const publicForm = await client.forms.getByNode({ nodeId: publicFormNodeId });
+      expect(publicForm).toMatchObject({ nodeId: publicFormNodeId });
+      expect(publicForm?.boundFields).toEqual([
+        expect.objectContaining({ slug: "title", type: "text" }),
+        expect.objectContaining({ slug: "body", type: "markdown" }),
+      ]);
+      await expect(
+        client.forms.submit({
+          nodeId: publicFormNodeId,
+          values: { subject: "Login required", msg: "Should be rejected" },
+        }),
+      ).rejects.toThrow(/sign-in/i);
+    });
+
+    await updateForm(publicFormNodeId, {
+      share: { isPublic: true, anonymousSubmit: true },
+    });
+    await client.nodes.share.set({
+      nodeId: publicFormNodeId,
+      scope: "public",
+      capability: "read",
+    });
+    await runWithAnonymousContext({}, async () => {
+      await expect(
+        client.forms.submit({
+          nodeId: publicFormNodeId,
+          values: { subject: "Read only", msg: "Should be rejected" },
+        }),
+      ).rejects.toThrow(/anonymous/i);
+    });
+
+    await client.nodes.share.set({
+      nodeId: publicFormNodeId,
+      scope: "public",
+      capability: "submit",
+    });
+    const { records: before } = await client.records.list({});
+    const submission = await runWithAnonymousContext({}, () =>
+      client.forms.submit({
+        nodeId: publicFormNodeId,
+        values: { subject: "Public submission", msg: "Pending review" },
+      }),
+    );
+    expect(submission.status).toBe("pending_review");
+
+    const { records: after } = await client.records.list({});
+    expect(after).toHaveLength(before.length);
+    expect(await getPublicScopeOf(target.nodeId)).toBeNull();
+    await runWithAnonymousContext({}, async () => {
+      await expect(client.bases.get({ baseId: blogBaseId })).rejects.toThrow(/not found/i);
+    });
+  });
+
+  it("accepts an anonymous submission that names the form by node SLUG", async () => {
+    // The public link is `/<nodeType>/<node slug>` and the dashboard route
+    // passes that URL segment straight through as `nodeId` — so the slug, not
+    // the id, is what every real visitor sends. Every other anonymous test here
+    // uses the id, which is how an id-only capability gate shipped looking fine.
+    const slug = "t-public-form";
+    await client.nodes.share.set({
+      nodeId: publicFormNodeId,
+      scope: "public",
+      capability: "submit",
+    });
+    await updateForm(publicFormNodeId, { share: { isPublic: true, anonymousSubmit: true } });
+
+    const { records: before } = await client.records.list({});
+    const submission = await runWithAnonymousContext({}, async () => {
+      await expect(client.forms.getByNode({ nodeId: slug })).resolves.toMatchObject({
+        nodeId: publicFormNodeId,
+      });
+      return client.forms.submit({
+        nodeId: slug,
+        values: { subject: "Slug submission", msg: "Pending review" },
+      });
+    });
+    expect(submission.status).toBe("pending_review");
+    const { records: after } = await client.records.list({});
+    expect(after).toHaveLength(before.length);
+
+    // A read-only share still refuses the slug path, at BOTH layers: the router
+    // guard (reachability) and the handler's own check on the resolved node id.
+    await client.nodes.share.set({
+      nodeId: publicFormNodeId,
+      scope: "public",
+      capability: "read",
+    });
+    await runWithAnonymousContext({}, async () => {
+      await expect(
+        client.forms.submit({
+          nodeId: slug,
+          values: { subject: "Read only", msg: "Should be rejected" },
+        }),
+      ).rejects.toThrow(/anonymous|read-only/i);
+      await expect(
+        submitForm(
+          slug,
+          { values: { subject: "Read only", msg: "Rejected" } },
+          { isAnonymous: true },
+        ),
+      ).rejects.toThrow(/read-only/i);
+    });
+
+    await client.nodes.share.set({
+      nodeId: publicFormNodeId,
+      scope: "public",
+      capability: "submit",
+    });
   });
 
   it("hides form configuration when its target Base is not visible", async () => {

--- a/packages/busabase-core/tests/generated-form-field.test.ts
+++ b/packages/busabase-core/tests/generated-form-field.test.ts
@@ -1,0 +1,31 @@
+import type { FieldType, FormBoundFieldVO } from "busabase-contract/types";
+import { describe, expect, it } from "vitest";
+import { generatedFormControlKind } from "../src/domains/form/components/generated-form-field";
+
+const field = (type: FieldType): FormBoundFieldVO => ({
+  slug: type,
+  name: type,
+  type,
+  choices: [],
+});
+
+describe("generatedFormControlKind", () => {
+  it.each([
+    ["text", "text"],
+    ["longtext", "textarea"],
+    ["number", "number"],
+    ["date", "date"],
+    ["checkbox", "checkbox"],
+    ["select", "select"],
+    ["multiselect", "multiselect"],
+    ["url", "url"],
+    ["email", "email"],
+    ["phone", "tel"],
+  ] satisfies Array<[FieldType, string]>)('maps Base field type "%s" to "%s"', (type, kind) => {
+    expect(generatedFormControlKind(field(type))).toBe(kind);
+  });
+
+  it("uses a text control while Base metadata is unavailable", () => {
+    expect(generatedFormControlKind()).toBe("text");
+  });
+});

--- a/packages/busabase-core/tests/skill-doc.test.ts
+++ b/packages/busabase-core/tests/skill-doc.test.ts
@@ -127,11 +127,9 @@ describe("generated Cloud onboarding", () => {
         .split("\n")
         .find((line) => line.startsWith("npx --yes busabase-cli@latest login ")),
     ).toBe("npx --yes busabase-cli@latest login --device-code --base-url https://busabase.com");
+    expect(cloudWithoutPreselectedSpace).toContain("Login never asks which Space to use");
     expect(cloudWithoutPreselectedSpace).toContain(
-      "Login never blocks on a terminal Space selection, even if the agent's shell allocates a TTY",
-    );
-    expect(cloudWithoutPreselectedSpace).toContain(
-      "it always accepts the server-resolved default (the one the\nuser was most recently active in)",
+      "it takes the server default (the Space the user was most\nrecently active in)",
     );
     expect(cloudBootstrap).not.toContain("--use-default-space");
     expect(localBootstrap).not.toContain("--use-default-space");
@@ -153,12 +151,38 @@ describe("generated Cloud onboarding", () => {
 
     expect(cloudWithoutPreselectedSpace).toContain("availableSpaces");
     expect(cloudWithoutPreselectedSpace).toContain(
-      "Always tell the user which Space\nwas selected (name + id)",
+      "Always tell the user which Space was selected (name + id)",
     );
     expect(cloudWithoutPreselectedSpace).toContain("busabase-cli@latest space use <id>");
     expect(cloudWithoutPreselectedSpace).not.toContain(
       "if the selected Space is not the\none intended, switch with",
     );
+  });
+
+  it("asks the user to confirm the Space only when the account has more than one", () => {
+    const cloudWithoutPreselectedSpace = buildSkillMarkdown("https://busabase.com", {
+      mode: "cloud",
+      stage: "bootstrap",
+      editionConfirmed: true,
+    });
+
+    expect(cloudWithoutPreselectedSpace).toContain("### 0b. Confirm the target Space");
+    expect(cloudWithoutPreselectedSpace).toContain(
+      "- **One** → nothing to choose. Continue with the `bootstrapRequired` branch from 0a.",
+    );
+    expect(cloudWithoutPreselectedSpace).toContain(
+      "- **More than one** → ask once, a lettered choice in the user's language",
+    );
+    // `space use <id>` is the agent's own mechanism, never an instruction handed to the user.
+    expect(cloudWithoutPreselectedSpace).toContain(
+      "Offer Spaces, never commands — switching is your job,\n  so never tell the user to run anything",
+    );
+    expect(cloudWithoutPreselectedSpace).toContain(
+      "re-decide the 0a branch from the new `bootstrapRequired`",
+    );
+    // A dashboard-preselected Space is locked, so there is no confirmation question at all.
+    expect(cloudBootstrap).not.toContain("### 0b. Confirm the target Space");
+    expect(cloudBootstrap).toContain("never ask the user to pick one");
   });
 
   it("uses the cross-platform CLI runner for every connection-stage command", () => {
@@ -171,7 +195,6 @@ describe("generated Cloud onboarding", () => {
 
     expect(cloudCliLines).toEqual([
       "npx --yes busabase-cli@latest login --device-code --base-url https://busabase.com --space-id spc_x",
-      "npx --yes busabase-cli@latest whoami --output json",
     ]);
     expect(desktopCliLines).toEqual([
       'npx --yes busabase-cli@latest login --base-url "http://localhost:15419"',
@@ -194,9 +217,11 @@ describe("generated Cloud onboarding", () => {
   });
 
   it("uses a dashboard-selected Space as a locked target, not as proof it is existing", () => {
-    expect(cloudBootstrap).toContain("Dashboard Space supplied (`spc_x`)");
     expect(cloudBootstrap).toContain(
-      "Preselection does not decide whether initialization is required",
+      "The dashboard supplied `--space-id spc_x` — lock it as the target",
+    );
+    expect(cloudBootstrap).toContain(
+      "Preselection only fixes *which* Space; it does not\ndecide whether that Space needs initializing",
     );
     expect(cloudBootstrap).toContain("including a preselected empty Space with no");
     expect(cloudBootstrap).toContain(

--- a/packages/busabase-package/package.json
+++ b/packages/busabase-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-package",
   "description": "The `busabase-package@1` format: GitHub source, layout read/write, install planning, and the five-pass apply. Shared by busabase-cli (`install` / `export`) and busabase-core's server-side install domain. Node-only APIs are fine here — it is never browser-bundled.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/packages/busabase-package",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8922,8 +8922,8 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -19993,7 +19993,7 @@ snapshots:
       expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.7
       react-fast-compare: 3.2.2
@@ -20045,7 +20045,7 @@ snapshots:
       expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.7
       react-fast-compare: 3.2.2
@@ -20097,7 +20097,7 @@ snapshots:
       expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.3
       react-fast-compare: 3.2.2
@@ -20148,7 +20148,7 @@ snapshots:
       expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.7
       react-fast-compare: 3.2.2
@@ -22809,7 +22809,7 @@ snapshots:
       lru.min: 1.1.4
     optional: true
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanoid@3.3.3: {}
 
@@ -23267,19 +23267,19 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Publishes Busabase `v0.14.0` from the kapps monorepo.

Generated by `scripts/publish-busabase-repo.ts`. Merging this PR is what
publishes to npm and builds the Docker image, so let CI finish first.