### PR TITLE
fix(ci): grant contents:write to ci-main's checks call

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -26,6 +26,11 @@ concurrency:
 jobs:
   checks:
     uses: ./.github/workflows/ci-checks.yml
+    # The coverage job commits the refreshed badge; without granting it here,
+    # GitHub rejects the whole run at startup (startup_failure, zero jobs)
+    # rather than just failing that one job — every push to main has hit this.
+    permissions:
+      contents: write
     with:
       run-benchmark: true
     secrets: inherit


### PR DESCRIPTION
## What
`ci-main.yml`'s `checks` job calls the reusable `ci-checks.yml` without a
`permissions:` block. That reusable workflow's `coverage` job requests
`contents: write` (to commit the refreshed badge). Without the caller
granting it, GitHub rejects the **entire run** at startup —
`startup_failure`, zero jobs scheduled — instead of just failing that one job.

## Evidence
Every recorded push to `main` has hit this (`gh run list --workflow ci-main.yml`):
v0.11.4, v0.13.0, the ci-badge merge-base fix, and v0.14.0 — 100% failure rate.

Confirmed the fix on a throwaway branch with `permissions: contents: write`
added to the caller job: full green run, including `benchmark`
(https://github.com/busabase/busabase/actions/runs/31561871007).

`ci-pr.yml`'s equivalent call to the same reusable workflow already grants
this correctly; `ci-main.yml` was the one missing it.

## Testing
- Diagnostic branch ran clean end-to-end (lint, typecheck, test, coverage,
  e2e, benchmark all passed) with this exact change.
- This PR's own `ci-pr.yml` run will validate the change doesn't regress the
  PR gate.