### PR TITLE
docs(ci): tidy workflow header comments

### DIFF
--- a/.github/workflows/ci-badge.yml
+++ b/.github/workflows/ci-badge.yml
@@ -20,10 +20,6 @@
 # then fail every later push, since none of those pushes are themselves
 # badge-only. `push` path filters look only at the commits in that specific
 # push, which is what "was this commit a badge-only commit" actually needs.
-#
-# Owned by this open-source repo (busabase/busabase). The kapps sync
-# (scripts/publish-busabase-repo.ts) PRESERVES `.github`, so it never overwrites
-# this file — edit it here.
 name: CI (badge only)
 
 on:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -2,10 +2,6 @@
 # (post-merge on main). Has no triggers of its own — callers own those, so the
 # PR and main pipelines can diverge (benchmark, badge commits) without either
 # file duplicating ~200 lines of job definitions.
-#
-# Owned by this open-source repo (busabase/busabase). The kapps sync
-# (scripts/publish-busabase-repo.ts) PRESERVES `.github`, so it never overwrites
-# these files — edit them here.
 name: CI checks
 
 on:
@@ -111,9 +107,9 @@ jobs:
           pct=$(node -p "require('./packages/busabase-core/coverage/coverage-summary.json').total.lines.pct")
           echo "## Coverage (busabase-core: logic/ + domains/)" >> "$GITHUB_STEP_SUMMARY"
           echo "Lines: **${pct}%**" >> "$GITHUB_STEP_SUMMARY"
-      # Releases arrive as a pull request (scripts/publish-busabase-repo.ts --pr),
-      # so the badge is refreshed on the release branch and merges as part of the
-      # release commit. Committing on `main` instead put a
+      # Releases arrive as a pull request from a `release/*` branch, so the badge
+      # is refreshed on that branch and merges as part of the release commit.
+      # Committing on `main` instead put a
       # `chore: update coverage badge` bot commit after every single release --
       # 26 of main's first 144 commits -- carrying no information the release
       # commit could not have carried itself.

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -8,10 +8,6 @@
 # It does NOT gate publish-npm.yml or docker.yml — those trigger on the same
 # push and run alongside this. That is exactly why the pull-request gate has to
 # be the real one.
-#
-# Owned by this open-source repo (busabase/busabase). The kapps sync
-# (scripts/publish-busabase-repo.ts) PRESERVES `.github`, so it never overwrites
-# this file — edit it here.
 name: CI (main)
 
 on:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -15,10 +15,6 @@
 # match the PR's cumulative diff against `main`, not a single push, so once a
 # release branch has any real changes this condition never re-triggers a skip
 # — which is correct: every later push should get the full suite.
-#
-# Owned by this open-source repo (busabase/busabase). The kapps sync
-# (scripts/publish-busabase-repo.ts) PRESERVES `.github`, so it never overwrites
-# this file — edit it here.
 name: CI (pull request)
 
 on:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,14 @@
-# Managed by kapps scripts/publish-busabase-repo.ts — edit the template there,
-# not in this repo (the open-source sync overwrites it).
-#
 # Builds the Busabase image from apps/busabase/Dockerfile and pushes multi-arch
 # (amd64 + arm64) to GHCR and Docker Hub, on GitHub's official ubuntu-latest
-# runner. After publishing, it can dispatch the private deploy workflow.
+# runner. After publishing, it can dispatch a downstream deploy workflow.
 #
 # Required secrets: DOCKERHUB_TOKEN (a Docker Hub access token for the `busabase`
 # org with push rights). GHCR uses the built-in GITHUB_TOKEN.
-# Required for deploy dispatch: CR_PAT, DEPLOY_REPOSITORY (for example,
-# vikadata/ops-manager), and DEPLOY_EVENT_TYPE (for example, deploy-bika).
+# Optional, for the deploy dispatch: CR_PAT (a token that may dispatch to the
+# target repository), DEPLOY_REPOSITORY (the `owner/name` to dispatch to) and
+# DEPLOY_EVENT_TYPE (the `repository_dispatch` event type to send). All three
+# are read as secrets; if any is unset the dispatch step no-ops and the build
+# still succeeds, so a fork needs none of them.
 name: Docker
 
 on:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,7 +1,3 @@
-# Owned by this open-source repo (busabase/busabase). The kapps sync
-# (scripts/publish-busabase-repo.ts) PRESERVES `.github`, so it never overwrites
-# this file — edit it here.
-#
 # Publishes busabase-package + busabase-cli + busabase-sdk + busabase-cms + busabase to npm with
 # provenance, from the public repo, on GitHub's official ubuntu-latest runner.
 # It also publishes short-name alias packages busa-cli + busa-sdk from the same

--- a/.github/workflows/vercel-cms-example.yml
+++ b/.github/workflows/vercel-cms-example.yml
@@ -1,6 +1,3 @@
-# Owned by this open-source repo (busabase/busabase). The kapps publish script
-# preserves `.github`, so future source syncs do not overwrite this workflow.
-#
 # Required repository secrets: VERCEL_TOKEN, VERCEL_ORG_ID, and
 # VERCEL_PROJECT_ID.
 name: Deploy Busabase CMS example to Vercel


### PR DESCRIPTION
## What

Comment-only cleanup of `.github/workflows/`. No job, trigger, step or permission changed.

Every workflow header carried a paragraph about tooling that does not exist anywhere in this repository, phrased as an instruction ("edit it here", "the sync preserves `.github`"). There is nothing in the tree it refers to, so for anyone reading these files it is noise at best and misleading at worst. Removed it from `ci-pr.yml`, `ci-main.yml`, `ci-checks.yml`, `ci-badge.yml`, `publish-npm.yml` and `vercel-cms-example.yml`.

The rest of each header is untouched — why `ci-ok` is the only required check on `main`, why `ci-badge.yml` is `push`-triggered rather than `pull_request`-triggered, why `INSTALL_FILTER` is mirrored instead of using `pnpm -r`, why the badge commit deliberately omits `[skip ci]`. That reasoning is the expensive part and it stays.

Two more targeted fixes:

- **`ci-checks.yml`** — the coverage-commit comment pointed at a script name to explain where releases come from. Restated as the fact it was standing in for: releases arrive as a pull request from a `release/*` branch.
- **`docker.yml`** — the first line claimed the file was generated elsewhere and would be overwritten. That was never true; this workflow is edited here like every other one, and following the instruction would have meant edits silently going nowhere. Replaced with an accurate description of what the workflow does.

## Deploy dispatch secrets

While correcting the `docker.yml` header I checked the `Dispatch internal deploy` step. It is live — it fired successfully on the v0.14.0 release build — so it stays exactly as-is. But the header documented the three secrets by quoting one deployment's concrete values, which is odd in a file where those values are deliberately kept in secrets, and useless to a fork. Rewrote it to describe what each secret *is* (`owner/name` to dispatch to, `repository_dispatch` event type, a token permitted to send it) and to note the step no-ops when any is unset, so a fork needs none of them.

## Verification

- `python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]"` over `.github/workflows/*.yml` — parses clean.
- `git diff` is comment lines only; no YAML key, value or indentation touched.