### PR TITLE
Release v0.16.1

### DIFF
--- a/apps/busabase-cli/package.json
+++ b/apps/busabase-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Command-line client for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server`.",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-cli",

--- a/apps/busabase-desktop/package.json
+++ b/apps/busabase-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@busabase/desktop",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "scripts": {
     "dev": "next dev --port 3064",

--- a/apps/busabase-desktop/src-tauri/Cargo.lock
+++ b/apps/busabase-desktop/src-tauri/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "busabase_desktop"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "semver",
  "serde",

--- a/apps/busabase-desktop/src-tauri/Cargo.toml
+++ b/apps/busabase-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busabase_desktop"
-version = "0.16.0"
+version = "0.16.1"
 description = "Busabase Desktop - private local-first Busabase knowledge base shell"
 authors = ["Busabase Team"]
 edition = "2021"

--- a/apps/busabase-desktop/src-tauri/tauri.conf.json
+++ b/apps/busabase-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Busabase Desktop",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "identifier": "com.busabase.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/busabase-mobile/app.json
+++ b/apps/busabase-mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Busabase",
     "slug": "busabase-mobile",
     "scheme": "busabase",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -17,6 +17,7 @@
       "supportsTablet": true,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
+        "WKAppBoundDomains": ["busabase.com", "demo.busabase.com"],
         "NSAppTransportSecurity": {
           "NSAllowsLocalNetworking": true
         }

--- a/apps/busabase-mobile/app/airapp/[nodeId]/index.tsx
+++ b/apps/busabase-mobile/app/airapp/[nodeId]/index.tsx
@@ -12,6 +12,7 @@ import { ConnectionGuard } from "~/components/busabase/ConnectionGuard";
 import { NativeEmptyState, NativeErrorState, NativeLoadingState } from "~/components/native-screen";
 import { Button } from "~/components/ui/Button";
 import { useConnection } from "~/connection/connection-store";
+import { buildAirAppEmbedUrl } from "~/lib/airapp-embed-url";
 import { asNodeDetail } from "~/lib/node-detail";
 import { mobile, radius, typography } from "~/theme/tokens";
 import { useTokens } from "~/theme/use-tokens";
@@ -33,20 +34,6 @@ import { useTokens } from "~/theme/use-tokens";
  *   bridge route that validates the bearer, mints a cookie session for the
  *   same user, and 302s to the target with that session attached.
  */
-function buildAirAppEmbedUrl(
-  serverUrl: string,
-  mode: "self-hosted" | "demo" | "cloud",
-  bearerToken: string | null,
-  nodeId: string,
-): string | null {
-  const target = `/dashboard/airapp/${encodeURIComponent(nodeId)}?chromeless=1`;
-  const base = serverUrl.replace(/\/+$/, "");
-  if (mode !== "cloud") {
-    return `${base}${target}`;
-  }
-  if (!bearerToken) return null;
-  return `${base}/api/auth/mobile-embed-token?token=${encodeURIComponent(bearerToken)}&target=${encodeURIComponent(target)}`;
-}
 
 function AirAppDetailContent() {
   const params = useLocalSearchParams<{ nodeId?: string }>();
@@ -59,6 +46,7 @@ function AirAppDetailContent() {
   const buda = useBusabaseOrpc();
   const { state } = useConnection();
   const connection = state.status === "connected" ? state.connection : null;
+  const selectedSpaceId = connection?.selectedSpace?.id ?? null;
   const webviewRef = useRef<WebView>(null);
   const [webviewError, setWebviewError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
@@ -81,15 +69,34 @@ function AirAppDetailContent() {
   const notAnAirApp = !airappQuery.isLoading && (Boolean(airappQuery.error) || !airapp);
 
   const embedUrlQuery = useQuery({
-    queryKey: ["airapp-embed-url", connection?.serverUrl, connection?.mode, nodeId, reloadToken],
+    queryKey: [
+      "airapp-embed-url",
+      connection?.serverUrl,
+      connection?.mode,
+      selectedSpaceId,
+      nodeId,
+      reloadToken,
+    ],
     queryFn: async () => {
       if (!connection || !nodeId) return null;
       if (connection.mode !== "cloud") {
-        return buildAirAppEmbedUrl(connection.serverUrl, connection.mode, null, nodeId);
+        return buildAirAppEmbedUrl({
+          serverUrl: connection.serverUrl,
+          mode: connection.mode,
+          bearerToken: null,
+          spaceId: selectedSpaceId,
+          nodeId,
+        });
       }
       const session = await getValidBusabaseCloudSession();
       const token = getCloudSessionToken(session);
-      return buildAirAppEmbedUrl(connection.serverUrl, connection.mode, token, nodeId);
+      return buildAirAppEmbedUrl({
+        serverUrl: connection.serverUrl,
+        mode: connection.mode,
+        bearerToken: token,
+        spaceId: selectedSpaceId,
+        nodeId,
+      });
     },
     enabled: Boolean(connection && nodeId),
   });
@@ -104,7 +111,10 @@ function AirAppDetailContent() {
 
   const embedUrl = embedUrlQuery.data ?? null;
   const preparingUrl = embedUrlQuery.isLoading || embedUrlQuery.isRefetching;
-  const noSession = !preparingUrl && !embedUrl && connection?.mode === "cloud";
+  const noCloudSpace =
+    !preparingUrl && !embedUrl && connection?.mode === "cloud" && !selectedSpaceId;
+  const noSession =
+    !preparingUrl && !embedUrl && connection?.mode === "cloud" && Boolean(selectedSpaceId);
 
   return (
     <SafeAreaView edges={["top"]} style={[styles.safe, { backgroundColor: tokens.background }]}>
@@ -135,6 +145,11 @@ function AirAppDetailContent() {
           <NativeEmptyState description="This AirApp is not available." title="AirApp not found" />
         ) : webviewError ? (
           <NativeErrorState message={webviewError} onRetry={retry} />
+        ) : noCloudSpace ? (
+          <NativeErrorState
+            message="Select a Busabase Cloud workspace, then try opening this AirApp again."
+            onRetry={retry}
+          />
         ) : noSession ? (
           <NativeErrorState
             message="Your Busabase Cloud session has expired. Reconnect and try again."
@@ -155,6 +170,9 @@ function AirAppDetailContent() {
             ref={webviewRef}
             key={reloadToken}
             source={{ uri: embedUrl }}
+            limitsNavigationsToAppBoundDomains={
+              Platform.OS === "ios" && (connection?.mode === "cloud" || connection?.mode === "demo")
+            }
             style={styles.webview}
             startInLoadingState
             renderLoading={() => <NativeLoadingState label="Loading AirApp" />}

--- a/apps/busabase-mobile/package.json
+++ b/apps/busabase-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-mobile",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "expo-router/entry",
   "private": true,
   "scripts": {

--- a/apps/busabase-mobile/src/lib/airapp-embed-url.test.ts
+++ b/apps/busabase-mobile/src/lib/airapp-embed-url.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildAirAppEmbedUrl } from "./airapp-embed-url";
+
+describe("buildAirAppEmbedUrl", () => {
+  it("includes the selected space in a Cloud AirApp target", () => {
+    const url = buildAirAppEmbedUrl({
+      serverUrl: "https://busabase.com/",
+      mode: "cloud",
+      bearerToken: "bso_test token",
+      spaceId: "spc_test",
+      nodeId: "aap_test",
+    });
+
+    expect(url).not.toBeNull();
+    const parsed = new URL(url as string);
+    expect(parsed.pathname).toBe("/api/auth/mobile-embed-token");
+    expect(parsed.searchParams.get("token")).toBe("bso_test token");
+    expect(parsed.searchParams.get("target")).toBe(
+      "/dashboard/spc_test/airapp/aap_test?chromeless=1",
+    );
+  });
+
+  it("refuses to build a Cloud target without a selected space or bearer token", () => {
+    const input = {
+      serverUrl: "https://busabase.com",
+      mode: "cloud" as const,
+      bearerToken: "bso_test",
+      spaceId: "spc_test",
+      nodeId: "aap_test",
+    };
+
+    expect(buildAirAppEmbedUrl({ ...input, spaceId: null })).toBeNull();
+    expect(buildAirAppEmbedUrl({ ...input, bearerToken: null })).toBeNull();
+  });
+
+  it("keeps self-hosted and demo targets on their compatibility route", () => {
+    expect(
+      buildAirAppEmbedUrl({
+        serverUrl: "http://127.0.0.1:15419/",
+        mode: "self-hosted",
+        bearerToken: null,
+        spaceId: null,
+        nodeId: "Air App/1",
+      }),
+    ).toBe("http://127.0.0.1:15419/dashboard/airapp/Air%20App%2F1?chromeless=1");
+  });
+});

--- a/apps/busabase-mobile/src/lib/airapp-embed-url.ts
+++ b/apps/busabase-mobile/src/lib/airapp-embed-url.ts
@@ -1,0 +1,32 @@
+interface AirAppEmbedUrlOptions {
+  serverUrl: string;
+  mode: "self-hosted" | "demo" | "cloud";
+  bearerToken: string | null;
+  spaceId: string | null;
+  nodeId: string;
+}
+
+export const buildAirAppEmbedUrl = ({
+  serverUrl,
+  mode,
+  bearerToken,
+  spaceId,
+  nodeId,
+}: AirAppEmbedUrlOptions): string | null => {
+  if (!nodeId) return null;
+
+  const base = serverUrl.replace(/\/+$/, "");
+  const dashboardBase =
+    mode === "cloud"
+      ? spaceId
+        ? `/dashboard/${encodeURIComponent(spaceId)}`
+        : null
+      : "/dashboard";
+  if (!dashboardBase) return null;
+
+  const target = `${dashboardBase}/airapp/${encodeURIComponent(nodeId)}?chromeless=1`;
+  if (mode !== "cloud") return `${base}${target}`;
+  if (!bearerToken) return null;
+
+  return `${base}/api/auth/mobile-embed-token?token=${encodeURIComponent(bearerToken)}&target=${encodeURIComponent(target)}`;
+};

--- a/apps/busabase-sdk/package.json
+++ b/apps/busabase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-sdk",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Typed TypeScript/JavaScript SDK for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server` (or Busabase Cloud).",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-sdk",

--- a/apps/busabase-sdk/src/airapp.test.ts
+++ b/apps/busabase-sdk/src/airapp.test.ts
@@ -528,3 +528,39 @@ describe("additive field migration", () => {
     expect(spies.bases.fieldChangeRequest).not.toHaveBeenCalled();
   });
 });
+
+describe("AirAppFieldDeclaration accepts a hand-authored plain-JS declaration", () => {
+  // Real callers write `appConfig` as a literal object in a plain .js config
+  // file — no `as const`, no cast. This helper reproduces that: its return
+  // type's `type` property is exactly `string`, the same widened inference
+  // TypeScript gives a `.js` file's exported object literal. If
+  // AirAppFieldDeclaration ever narrows `type` back to the contract's field-type
+  // enum, this file stops compiling — `tsc --noEmit` catches it even though
+  // vitest itself does not type-check.
+  const declareField = (slug: string, name: string, type: string, required: boolean) => ({
+    slug,
+    name,
+    type,
+    required,
+  });
+
+  it("type-checks and resolves without a cast", () => {
+    const declaredConfig: AirAppResourceConfig = {
+      appId: "kelly-plain",
+      appName: "Kelly Plain",
+      schemaVersion: 1,
+      folder: { slug: "kelly-plain", name: "Kelly Plain", description: "" },
+      bases: [
+        {
+          key: "contacts",
+          slug: "kelly-plain-contacts-v1",
+          name: "Contacts",
+          description: "",
+          fields: [declareField("name", "Name", "text", true)],
+        },
+      ],
+    };
+    const result = resolveProvisionedFolder(null, declaredConfig);
+    expect(result.missing).toHaveLength(1);
+  });
+});

--- a/apps/busabase-sdk/src/airapp.ts
+++ b/apps/busabase-sdk/src/airapp.ts
@@ -45,12 +45,28 @@ import type { BusabaseClient } from "./client.js";
 type NodeChangeRequestInput = Parameters<BusabaseClient["nodes"]["createChangeRequest"]>[0];
 type NodeOperationInput = NodeChangeRequestInput["operations"][number];
 type CreateNodeOperationInput = Extract<NodeOperationInput, { kind: "create" }>;
+type FieldChangeRequestInput = Parameters<BusabaseClient["bases"]["fieldChangeRequest"]>[0];
+type CreateFieldChangeRequestInput = Extract<FieldChangeRequestInput, { operation: "create" }>;
 
 /**
- * A Base field, typed straight off the contract so a declaration can never drift
- * from what `nodes.createChangeRequest` actually accepts.
+ * A Base field, as an app declares it.
+ *
+ * `type` is a plain `string`, not the contract's narrow field-type union — an
+ * app's declaration is ordinarily a hand-authored object literal (`type:
+ * "text"`), and TypeScript infers a plain-JS object literal's string
+ * properties as `string`, not as that literal. Deriving this type straight
+ * from the contract made every such declaration a type error. The contract's
+ * narrow union still applies where it actually matters — the server validates
+ * every field type on the wire — this type only relaxes the *declaration*
+ * surface to match how declarations are actually written.
  */
-export type AirAppFieldDeclaration = NonNullable<CreateNodeOperationInput["fields"]>[number];
+export interface AirAppFieldDeclaration {
+  slug: string;
+  name: string;
+  type: string;
+  required?: boolean;
+  options?: Record<string, unknown>;
+}
 
 /** The client surface provisioning needs. Both `BusabaseClient` and `Busabase` satisfy it. */
 export type AirAppProvisioningClient = Pick<BusabaseClient, "nodes" | "bases">;
@@ -437,7 +453,9 @@ export function buildProvisionOperations(
       name: base.name,
       description: base.description ?? "",
       metadata: resourceMetadata(config, base.key),
-      fields: base.fields,
+      // The declaration's `type` is a plain `string` (see AirAppFieldDeclaration);
+      // the server validates the real field-type enum on the wire.
+      fields: base.fields as CreateNodeOperationInput["fields"],
     });
   }
   return operations;
@@ -648,7 +666,9 @@ async function repairResourceOwnership(
         baseId: migration.repair.baseId as string,
         slug: field.slug,
         name: field.name,
-        type: field.type,
+        // The declaration's `type` is a plain `string` (see AirAppFieldDeclaration);
+        // the server validates the real field-type enum on the wire.
+        type: field.type as CreateFieldChangeRequestInput["type"],
         required: field.required,
         message: `Upgrade ${config.appName}: add ${field.slug}`,
         submittedBy: config.appId,

--- a/apps/busabase/package.json
+++ b/apps/busabase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase",
   "description": "Open-source Busabase review app + CLI. `busabase server` boots a zero-setup local instance (pglite); other subcommands act as an OpenAPI client.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase",

--- a/apps/busabase/tests/e2e/field-header-actions.spec.ts
+++ b/apps/busabase/tests/e2e/field-header-actions.spec.ts
@@ -40,12 +40,14 @@ test("field header actions require a saved view and support keyboard quick sorti
   await page.keyboard.press("Enter");
   const savedViewPrompt = page.getByText(/Create or open a saved view to sort, filter/);
   await expect(savedViewPrompt).toBeVisible();
-  await savedViewPrompt
-    .locator("xpath=..")
-    .getByRole("button", { name: "New view", exact: true })
-    .click();
-  await expect(page.getByRole("dialog").getByRole("heading", { name: "New View" })).toBeVisible();
-  await page.getByRole("dialog").getByRole("button", { name: "Cancel" }).click();
+  // With no saved view open, the panel offers "Edit field" (-> the Design tab)
+  // rather than a "New view" action that opens a creation dialog inline —
+  // creating a view is Design's job now, matching the "Edit field" link this
+  // same panel already shows once a view exists (asserted below).
+  await expect(
+    savedViewPrompt.locator("xpath=..").getByRole("link", { name: "Edit field" }),
+  ).toHaveAttribute("href", "/dashboard/local/base/blog/design");
+  await page.keyboard.press("Escape");
 
   await page.goto(`/dashboard/local/base/blog/${merged.view.slug}`);
   const titleHeader = page.locator('[role="columnheader"][data-field-slug="title"]');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-repo",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1",
   "packageManager": "pnpm@10.15.1",
   "workspaces": [
     "apps/*",

--- a/packages/busabase-contract/package.json
+++ b/packages/busabase-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-contract",
   "description": "Client-safe Busabase surface: oRPC contracts (OSS + cloud), node-type kernel, VO types, and the oRPC client factories. Pure leaf — no db/logic/server deps. Consumed by busabase-cli, busabase-mobile, busabase-core, busabase, and busabase-cloud.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/busabase-core/package.json
+++ b/packages/busabase-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-core",
   "description": "Shared Busabase open-core protocol, local store, API helpers, and dashboard components.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/busabase-core/src/domains/airapp/utils/nodepod-service-worker.ts
+++ b/packages/busabase-core/src/domains/airapp/utils/nodepod-service-worker.ts
@@ -33,6 +33,16 @@ const POD_HEARTBEAT_INTERVAL_MS = 5_000;
 /** Upper bound on waiting for a re-registered worker to activate. */
 const SW_READY_TIMEOUT_MS = 5_000;
 
+const NODEPOD_SW_ERROR_MESSAGE =
+  "AirApp preview requires HTTPS and Service Worker support. Open this workspace in Safari or Chrome, or use the desktop app.";
+
+export class NodepodServiceWorkerError extends Error {
+  constructor(options?: ErrorOptions) {
+    super(NODEPOD_SW_ERROR_MESSAGE, options);
+    this.name = "NodepodServiceWorkerError";
+  }
+}
+
 /**
  * Route prefixes that legitimately run pods and must keep the SW.
  * `/embed/*` is the public AirApp Embed host; `/dashboard*` is the Run panel.
@@ -41,6 +51,24 @@ const POD_HOST_PATH_PREFIXES = ["/dashboard", "/embed", "/__virtual__", "/__prev
 
 const hasServiceWorker = (): boolean =>
   typeof navigator !== "undefined" && "serviceWorker" in navigator;
+
+const waitForController = async (): Promise<void> => {
+  if (navigator.serviceWorker.controller) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange);
+      reject(new Error("Service Worker did not take control of this page"));
+    }, SW_READY_TIMEOUT_MS);
+    const onControllerChange = () => {
+      if (!navigator.serviceWorker.controller) return;
+      clearTimeout(timeout);
+      navigator.serviceWorker.removeEventListener("controllerchange", onControllerChange);
+      resolve();
+    };
+    navigator.serviceWorker.addEventListener("controllerchange", onControllerChange);
+  });
+};
 
 const readStorage = (key: string): string | null => {
   try {
@@ -99,20 +127,30 @@ export const beginPodHeartbeat = (): (() => void) => {
  * `controllerchange` makes Nodepod redo its init handshake.
  */
 export const ensureRegistered = async (): Promise<void> => {
-  if (!hasServiceWorker()) return;
+  if (typeof window !== "undefined" && !window.isSecureContext) {
+    throw new NodepodServiceWorkerError();
+  }
+  if (!hasServiceWorker()) {
+    throw new NodepodServiceWorkerError();
+  }
   try {
     const existing = await navigator.serviceWorker.getRegistration("/");
-    if (existing) return;
-    await navigator.serviceWorker.register(SW_PATH, { scope: "/", updateViaCache: "none" });
-    // Bounded: `ready` is a convenience, not a requirement — Nodepod's own
-    // `initServiceWorker` awaits activation with its own timeout right after
-    // this. Never let a wait here be what stops a run from starting.
+    if (!existing) {
+      await navigator.serviceWorker.register(SW_PATH, { scope: "/", updateViaCache: "none" });
+    }
     await Promise.race([
       navigator.serviceWorker.ready,
-      new Promise((resolve) => setTimeout(resolve, SW_READY_TIMEOUT_MS)),
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Service Worker activation timed out")),
+          SW_READY_TIMEOUT_MS,
+        ),
+      ),
     ]);
-  } catch {
-    // Nodepod's own boot-time registration still runs and surfaces the error.
+    await waitForController();
+  } catch (cause) {
+    if (cause instanceof NodepodServiceWorkerError) throw cause;
+    throw new NodepodServiceWorkerError({ cause });
   }
 };
 

--- a/packages/busabase-core/tests/nodepod-service-worker.test.ts
+++ b/packages/busabase-core/tests/nodepod-service-worker.test.ts
@@ -41,6 +41,9 @@ const installFakeStorage = () => {
 const installFakeServiceWorker = (registrations: FakeRegistration[]) => {
   const register = vi.fn(async (url: string) => makeRegistration(`https://app.test${url}`));
   const container = {
+    controller: {},
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
     getRegistrations: vi.fn(async () => registrations),
     getRegistration: vi.fn(async () => registrations[0]),
     register,
@@ -145,7 +148,7 @@ describe("ensureRegistered", () => {
     expect(sw.register).not.toHaveBeenCalled();
   });
 
-  it("never throws or blocks a boot when the SW API misbehaves", async () => {
+  it("surfaces a useful error when the SW API rejects registration", async () => {
     vi.stubGlobal("navigator", {
       serviceWorker: {
         getRegistration: async () => {
@@ -153,12 +156,29 @@ describe("ensureRegistered", () => {
         },
       },
     });
-    await expect(ensureRegistered()).resolves.toBeUndefined();
+    await expect(ensureRegistered()).rejects.toThrow(
+      "AirApp preview requires HTTPS and Service Worker support",
+    );
   });
 
-  it("is a no-op where service workers do not exist at all", async () => {
+  it("stops the run where service workers do not exist at all", async () => {
     vi.stubGlobal("navigator", {});
-    await expect(ensureRegistered()).resolves.toBeUndefined();
+    await expect(ensureRegistered()).rejects.toThrow(
+      "AirApp preview requires HTTPS and Service Worker support",
+    );
     await expect(releaseOnHostPage("/zh-CN/home")).resolves.toBe(false);
+  });
+
+  it("waits until a newly activated worker controls the current page", async () => {
+    const sw = installFakeServiceWorker([]);
+    sw.getRegistration = vi.fn(async () => undefined);
+    sw.controller = null as unknown as object;
+    sw.addEventListener.mockImplementation((_event, listener) => {
+      sw.controller = {};
+      (listener as () => void)();
+    });
+
+    await expect(ensureRegistered()).resolves.toBeUndefined();
+    expect(sw.addEventListener).toHaveBeenCalledWith("controllerchange", expect.any(Function));
   });
 });

--- a/packages/busabase-package/package.json
+++ b/packages/busabase-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-package",
   "description": "The `busabase-package@1` format: GitHub source, layout read/write, install planning, and the five-pass apply. Shared by busabase-cli (`install` / `export`) and busabase-core's server-side install domain. Node-only APIs are fine here — it is never browser-bundled.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/packages/busabase-package",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 1.58.2
       '@scelar/nodepod':
         specifier: ^1.9.9
-        version: 1.9.9(patch_hash=bb10bcb3da69440351db6b772d39928bdcd28ef8f1bc0bc416d241d9ba15c412)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(vite@5.4.21(@types/node@24.13.2)(less@3.13.1)(lightningcss@1.31.1)(sass@1.101.0)(stylus@0.64.0)(terser@5.49.0))
+        version: 1.9.9(patch_hash=bb10bcb3da69440351db6b772d39928bdcd28ef8f1bc0bc416d241d9ba15c412)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(vite@7.1.9(@types/node@24.13.2)(jiti@2.7.0)(less@3.13.1)(lightningcss@1.31.1)(sass@1.101.0)(stylus@0.64.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/postcss':
         specifier: ^4.1.17
         version: 4.1.18
@@ -16726,21 +16726,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
-
-  '@scelar/nodepod@1.9.9(patch_hash=bb10bcb3da69440351db6b772d39928bdcd28ef8f1bc0bc416d241d9ba15c412)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(vite@5.4.21(@types/node@24.13.2)(less@3.13.1)(lightningcss@1.31.1)(sass@1.101.0)(stylus@0.64.0)(terser@5.49.0))':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
-      brotli: 1.3.3
-      brotli-wasm: 3.0.1
-      comlink: 4.4.2
-      pako: 2.1.0
-      resolve.exports: 2.0.3
-      set-cookie-parser: 3.1.2
-    optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
-      vite: 5.4.21(@types/node@24.13.2)(less@3.13.1)(lightningcss@1.31.1)(sass@1.101.0)(stylus@0.64.0)(terser@5.49.0)
 
   '@scelar/nodepod@1.9.9(patch_hash=bb10bcb3da69440351db6b772d39928bdcd28ef8f1bc0bc416d241d9ba15c412)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(vite@7.1.9(@types/node@24.13.2)(jiti@2.7.0)(less@3.13.1)(lightningcss@1.31.1)(sass@1.101.0)(stylus@0.64.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
Busabase v0.16.1.

- chore(core): engine and API contract updates
- fix(server): update field-header-actions e2e for the Edit-field panel
- fix(cli): stop AirAppFieldDeclaration.type rejecting real declarations
- fix(desktop): busabase mobile airapp page not found
- chore(release): v0.16.1

Merging this publishes to npm and builds the Docker image, so let CI finish
first.