### PR TITLE
fix: stop shipping a private sibling app's path in biome.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
-  "formatter": { "enabled": true, "indentStyle": "space", "indentWidth": 2, "lineWidth": 100 },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
   "linter": {
     "enabled": true,
     "rules": {
@@ -32,12 +37,6 @@
   "files": {
     "includes": [
       "**",
-      "!boilerplates",
-      "!videos",
-      "!**/playwright-report",
-      "!apps/costory/**/*.js",
-      "!**/scripts/cookbook-pdf/book",
-      "!**/.react-email",
       "!**/.source",
       "!**/dist",
       "!**/.data",


### PR DESCRIPTION
## Summary
- `biome.json`'s `files.includes` carried a few entries that only made sense in the private repo this project is published from, including a literal path into another app that isn't public.
- Trimmed to genuine build-artifact excludes (`dist`, `coverage`, generated i18n files, etc.); `formatter`/`linter`/`assist` settings are unchanged.

## Test plan
- [x] `npx @biomejs/biome check` runs clean against the trimmed config
- [x] Confirmed via `publish-npm.yml`/`docker.yml`'s own `paths:` filters that a `biome.json`-only change doesn't touch either — this PR won't trigger a publish or image build