### PR TITLE
docs: add community health and security guidance

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Respecting differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior include:
+
+- Sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct that could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing these standards and will take appropriate and fair corrective action in response to behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that do not align with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and when an individual officially represents the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to `support@busabase.com`. All complaints will be reviewed and investigated promptly and fairly. The privacy and safety of the reporter will be respected.
+
+## Enforcement Guidelines
+
+Maintainers will follow the Contributor Covenant Community Impact Guidelines when determining consequences for violations: correction, warning, temporary ban, or permanent ban, according to the impact and pattern of behavior.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to Busabase
+
+Thanks for helping improve Busabase. Bug reports, feature ideas, documentation fixes, and pull requests are welcome.
+
+## Before you start
+
+- Use [GitHub Discussions](https://github.com/busabase/busabase/discussions) for questions and early-stage ideas.
+- Search [existing issues](https://github.com/busabase/busabase/issues) before opening a new one.
+- For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) instead of opening a public issue.
+
+## Local development
+
+Prerequisites: Node.js 24.18 or newer and pnpm 10.
+
+```bash
+pnpm install
+cp apps/busabase/.env.example apps/busabase/.env
+pnpm dev
+```
+
+Busabase opens at `http://localhost:15419`. The default setup uses embedded PGlite and local file storage.
+
+## Validate your change
+
+Run the checks that cover the code you changed. At minimum:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test
+```
+
+For browser-facing behavior, also run the relevant Playwright spec:
+
+```bash
+pnpm --filter busabase test:e2e -- path/to/spec.ts
+```
+
+## Pull requests
+
+- Keep each pull request focused on one problem.
+- Explain the user-visible behavior and why the change is needed.
+- Add or update tests when behavior changes.
+- Include screenshots or recordings for UI changes.
+- Use a clear Conventional Commit title, such as `fix: preserve node icons after rename`.
+- Do not commit secrets, local data, `.env` files, or generated build output.
+
+By participating, you agree to follow our [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report reproducible behavior that is incorrect or unexpected.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please do not include secrets or private workspace data.
+  - type: checkboxes
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find the same problem.
+          required: true
+        - label: I am using the latest Busabase release.
+          required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Self-hosted server
+        - Desktop app
+        - Mobile app
+        - CLI
+        - SDK or API
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output from `npx busabase --version`, app version, or commit SHA.
+      placeholder: 0.19.1
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. Start Busabase with ...
+        2. Open ...
+        3. Click ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, browser, Node.js version, database mode, and deployment method.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Remove credentials, tokens, personal data, and private workspace content.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and setup help
+    url: https://github.com/busabase/busabase/discussions/categories/q-a
+    about: Ask the community before opening a bug report.
+  - name: Product ideas and discussion
+    url: https://github.com/busabase/busabase/discussions/categories/ideas
+    about: Discuss an idea before turning it into a scoped feature request.
+  - name: Security vulnerability
+    url: https://github.com/busabase/busabase/security/advisories/new
+    about: Report security issues privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Propose an improvement to the Busabase agent workspace.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: checkboxes
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and Discussions for this idea.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or agent workflow is difficult today?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the behavior and user value, not only an implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: How do you handle this workflow today?
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Relevant surface
+      options:
+        - Bases and records
+        - Docs, files, and drives
+        - Skills and agents
+        - AirApps and rich nodes
+        - Change Requests and review
+        - CLI, SDK, MCP, or OpenAPI
+        - Desktop or mobile
+        - Other
+    validations:
+      required: true

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version of Busabase. Please reproduce issues against the latest release before reporting when possible.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability.
+
+Use GitHub's private reporting flow:
+
+1. Open the repository's [Security tab](https://github.com/busabase/busabase/security).
+2. Select **Report a vulnerability**.
+3. Include affected versions, impact, reproduction steps, and any suggested mitigation.
+
+You may also contact `support@busabase.com`. We will acknowledge reports as soon as practical, investigate them privately, and coordinate disclosure and remediation with the reporter.
+
+Never include real credentials, personal data, or secrets in a report. Use minimal test data and revoke any credential that may have been exposed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What changed
+
+<!-- Describe the behavior change and why it is needed. -->
+
+## Validation
+
+<!-- List the exact commands and real workflows you tested. -->
+
+## Screenshots
+
+<!-- Required for user-visible changes. Remove this section when not applicable. -->
+
+## Checklist
+
+- [ ] The change is focused and does not include unrelated refactors.
+- [ ] Tests cover new or changed behavior.
+- [ ] Typecheck and lint pass for the affected packages.
+- [ ] Documentation is updated when user-facing behavior changes.
+- [ ] No secrets, local data, or generated build output are included.


### PR DESCRIPTION
## Problem

Busabase welcomes issues, discussions, and pull requests, but the repository does not yet provide contribution guidelines, a code of conduct, private security-reporting guidance, or structured templates. Contributors can easily send a report through the wrong channel, and the GitHub Community Profile is only 50% complete.

## Changes

- Add contributor guidance for local development, validation, and pull requests.
- Add the Contributor Covenant code of conduct.
- Add a security policy that directs vulnerability reports to GitHub's enabled private vulnerability-reporting flow.
- Add structured bug and feature issue forms.
- Route setup questions, product ideas, and security reports to the appropriate Discussions or Security surfaces.
- Add a pull request checklist covering behavior, tests, documentation, and UI evidence.

## Validation

- Parsed every issue-form YAML file and verified the required `name`, `description`, and `body` fields.
- Confirmed the referenced `bug` and `enhancement` labels exist.
- Confirmed the Q&A and Ideas Discussion categories exist.
- Scanned `.github/**` for environment files, credentials, internal repository names, and private publishing details; no leaks were found.
- Confidence: High. The file layout and schemas follow GitHub's documented Community health and Issue Form conventions.
- Known limitation: The Community Profile score updates only after these files merge into the default branch.
- Screenshots: Not applicable. This pull request adds repository documentation and templates without changing the product UI.

## Files Affected

- `.github/CONTRIBUTING.md`
- `.github/CODE_OF_CONDUCT.md`
- `.github/SECURITY.md`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/pull_request_template.md`
