### PR TITLE
Release v0.21.0

### DIFF
--- a/apps/busabase-cli/package.json
+++ b/apps/busabase-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Command-line client for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server`.",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-cli",

--- a/apps/busabase-cli/src/backup/commands.ts
+++ b/apps/busabase-cli/src/backup/commands.ts
@@ -5,7 +5,7 @@
  */
 import type { BusabaseClient } from "busabase-sdk";
 import { exportFull } from "./export/full-exporter.js";
-import { readArchive } from "./format/archive-reader.js";
+import { verifyArchive } from "./format/archive-reader.js";
 import { importFull } from "./import/full-importer.js";
 
 /** Progress is diagnostics, not data — it must never pollute `--output json` on stdout. */
@@ -115,19 +115,22 @@ export const runRestore = async (
   }
 
   reportProgress(`Reading ${options.file} …`);
-  // Integrity-verifies the whole archive before a single row is replayed.
-  const archive = await readArchive(options.file);
+  // Streams the whole archive once, hashing incrementally (never buffering a
+  // whole entry — see archive-reader.ts), and verifies every entry against
+  // the manifest before a single row is replayed.
+  const manifest = await verifyArchive(options.file);
   reportProgress(
-    `Archive: fidelity=${archive.manifest.fidelity} space=${archive.manifest.spaceId} exportedAt=${archive.manifest.exportedAt}`,
+    `Archive: fidelity=${manifest.fidelity} space=${manifest.spaceId} exportedAt=${manifest.exportedAt}`,
   );
-  if (archive.manifest.fidelity !== "full") throw new Error(STATE_ONLY_RESTORE_MESSAGE);
+  if (manifest.fidelity !== "full") throw new Error(STATE_ONLY_RESTORE_MESSAGE);
   if (options.intoFolder) {
     throw new Error("--into-folder only applies to state-only archives.");
   }
 
   const result = await importFull({
     client,
-    archive,
+    archivePath: options.file,
+    sourceSpaceId: manifest.spaceId,
     onProgress: (message) => reportProgress(`  ${message}`),
   });
 
@@ -135,7 +138,7 @@ export const runRestore = async (
     return {
       restored: result.ok,
       file: options.file,
-      spaceId: archive.manifest.spaceId,
+      spaceId: manifest.spaceId,
       warnings: result.warnings,
     };
   }

--- a/apps/busabase-cli/src/backup/export/full-exporter.ts
+++ b/apps/busabase-cli/src/backup/export/full-exporter.ts
@@ -1,15 +1,72 @@
 import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
 import { type DumpTable, DumpTableSchema } from "busabase-contract/domains/dump/types";
 import type { BusabaseClient } from "busabase-sdk";
 import { ArchiveWriter } from "../format/archive-writer.js";
 import { FORMAT_VERSION, type Manifest } from "../format/manifest.js";
+import { IMPORT_ORDER } from "../import/full-importer.js";
+
+/**
+ * The CLI's shared `withRetry` (retry.ts) wraps `fetch` and only inspects the
+ * HTTP status — a response that comes back `200` but whose body was
+ * truncated or corrupted in transit (observed live against a real,
+ * large production space: a many-thousand-page `dump.exportTables` pull threw
+ * `Cannot parse response body` partway through, at a different table on each
+ * attempt) already looks "successful" to that wrapper and is never retried.
+ * A single flaky page must not fail an entire multi-hour backup, so retry
+ * the one page here, close to the failure, rather than widening the shared
+ * fetch-level wrapper (which would change retry behavior for every command).
+ */
+const PAGE_FETCH_RETRIES = 3;
+const PAGE_FETCH_RETRY_DELAY_MS = 1000;
+
+const fetchPageWithRetry = async <T>(
+  fetchPage: () => Promise<T>,
+  onRetry?: (attempt: number, error: unknown) => void,
+): Promise<T> => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fetchPage();
+    } catch (error) {
+      if (attempt >= PAGE_FETCH_RETRIES) throw error;
+      onRetry?.(attempt + 1, error);
+      await new Promise((resolve) =>
+        setTimeout(resolve, PAGE_FETCH_RETRY_DELAY_MS * (attempt + 1)),
+      );
+    }
+  }
+};
+
+/**
+ * Write an NDJSON archive entry from already-collected rows without ever
+ * concatenating them into a single JS string first. A real production table
+ * (e.g. `fieldValues` holding long CMS/article-body content) can produce an
+ * NDJSON blob well past V8's max string length — `"".join("\n")` on such a
+ * table throws `RangeError: Invalid string length` and aborts the whole
+ * backup. Building one `Buffer` per line and streaming them through
+ * `ArchiveWriter.addStream` (already built for exactly this — see its own
+ * doc comment) avoids ever holding one oversized string/buffer.
+ */
+const writeNdjsonEntry = async (
+  writer: ArchiveWriter,
+  path: string,
+  rows: Array<Record<string, unknown>>,
+): Promise<void> => {
+  const lineBuffers = rows.map((row) => Buffer.from(`${JSON.stringify(row)}\n`, "utf8"));
+  const totalSize = lineBuffers.reduce((sum, buf) => sum + buf.length, 0);
+  await writer.addStream(path, totalSize, Readable.from(lineBuffers));
+};
 
 // Every dump-eligible table, taken straight from the contract enum (the single
-// source of truth). Export order is irrelevant — each table is drained
-// independently, and the post-loop doc-body / attachment-blob passes read from
-// the already-collected `tableRows`. Deriving this instead of hand-maintaining
-// a parallel copy is what stops a newly-registered table (e.g. the
-// `nodePrincipals` permissions table) from being silently skipped on backup.
+// source of truth). FETCH order here is irrelevant — each table is drained
+// independently into `tableRows`, and the doc-body / attachment-blob passes
+// below read from that already-collected map. Deriving this instead of
+// hand-maintaining a parallel copy is what stops a newly-registered table
+// (e.g. the `nodePrincipals` permissions table) from being silently skipped
+// on backup.
+//
+// WRITE order (which archive entries actually land in, below) is a separate
+// concern and does matter — see the write-phase comment.
 const EXPORT_TABLES: DumpTable[] = [...DumpTableSchema.options];
 
 const HISTORY_TABLES: DumpTable[] = [
@@ -64,15 +121,19 @@ export async function exportFull(options: FullExportOptions): Promise<Manifest> 
     const rows: Array<Record<string, unknown>> = [];
     let cursor: string | undefined;
     do {
-      const page = await client.dump.exportTables({ table, cursor, limit: pageLimit });
+      const page = await fetchPageWithRetry(
+        () => client.dump.exportTables({ table, cursor, limit: pageLimit }),
+        (attempt, error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          log(`  retrying ${table} page (attempt ${attempt}/${PAGE_FETCH_RETRIES}): ${message}`);
+        },
+      );
       rows.push(...(page.rows as Array<Record<string, unknown>>));
       cursor = page.nextCursor ?? undefined;
     } while (cursor);
 
     tableRows[table] = rows;
     tableCounts[table] = rows.length;
-    const ndjson = `${rows.map((row) => JSON.stringify(row)).join("\n")}${rows.length ? "\n" : ""}`;
-    await writer.addBuffer(`tree/${table}.ndjson`, ndjson);
     log(`exported ${table}: ${rows.length} rows`);
   }
 
@@ -84,19 +145,35 @@ export async function exportFull(options: FullExportOptions): Promise<Manifest> 
   // needs every body — there is no list endpoint that returns them in bulk, and
   // pretending otherwise would silently drop content from the archive.
   const docNodes = (tableRows.nodes ?? []).filter((n) => n.type === "doc");
-  let docBodyCount = 0;
+  const docBodyEntries: Array<{ nodeId: string; body: string }> = [];
+  const skippedDocBodies: string[] = [];
   for (const node of docNodes) {
     const nodeId = node.id as string;
-    const detail = await client.nodes.get({ nodeId, type: "doc" });
-    if (detail.type !== "doc") {
-      // The server resolves `type: "doc"`, so this can only fire if the contract
-      // and the server drift. Fail loudly rather than archiving an empty body.
-      throw new Error(`Expected a doc node for ${nodeId}, got "${detail.type}"`);
+    try {
+      // `nodes.get` deliberately 404s on an archived node (Trash is read
+      // through a different, metadata-only endpoint — see node-detail.ts) —
+      // but the raw `nodes` table dump above still includes archived rows, by
+      // design, so a full-fidelity backup genuinely needs. A space with even
+      // one archived-but-not-purged Doc previously crashed the ENTIRE backup
+      // here with an uncaught `NOT_FOUND`. Same treatment as the attachment
+      // and asset-text loops below: skip that one body with a warning rather
+      // than losing everything else in the archive over it.
+      const detail = await client.nodes.get({ nodeId, type: "doc" });
+      if (detail.type !== "doc") {
+        // The server resolves `type: "doc"`, so this can only fire if the
+        // contract and the server drift. Fail loudly rather than archiving an
+        // empty body.
+        throw new Error(`Expected a doc node for ${nodeId}, got "${detail.type}"`);
+      }
+      // Written later, in the write phase below — see that comment for why.
+      docBodyEntries.push({ nodeId, body: detail.body ?? "" });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      skippedDocBodies.push(nodeId);
+      log(`  WARNING: could not read doc body for node ${nodeId}, skipping it (${message})`);
     }
-    await writer.addBuffer(`docs/${nodeId}.md`, detail.body ?? "");
-    docBodyCount += 1;
   }
-  log(`exported ${docBodyCount} doc bodies`);
+  log(`fetched ${docBodyEntries.length} doc bodies, skipped ${skippedDocBodies.length}`);
 
   // Attachment blobs — download every exported Asset's bytes and archive them
   // keyed by the OWNING `busabase_attachments` row's own `storageKey` (written
@@ -145,12 +222,8 @@ export async function exportFull(options: FullExportOptions): Promise<Manifest> 
       log(`  WARNING: could not download asset ${assetId}, skipping its blob (${message})`);
     }
   }
-  const blobNdjson = `${attachmentBlobRows.map((row) => JSON.stringify(row)).join("\n")}${
-    attachmentBlobRows.length ? "\n" : ""
-  }`;
-  await writer.addBuffer("tree/attachmentBlobs.ndjson", blobNdjson);
   log(
-    `exported ${blobCount} attachment blobs (${blobBytes} bytes), skipped ${skippedAssets.length}`,
+    `fetched ${blobCount} attachment blobs (${blobBytes} bytes), skipped ${skippedAssets.length}`,
   );
 
   // Asset-text blobs — the extracted-text objects `busabase_asset_texts` rows
@@ -213,12 +286,33 @@ export async function exportFull(options: FullExportOptions): Promise<Manifest> 
       );
     }
   }
-  const textBlobNdjson = `${textBlobRows.map((row) => JSON.stringify(row)).join("\n")}${
-    textBlobRows.length ? "\n" : ""
-  }`;
-  await writer.addBuffer("tree/assetTextBlobs.ndjson", textBlobNdjson);
   log(
-    `exported ${textBlobCount} asset-text blobs (${textBlobBytes} bytes), skipped ${skippedAssetTexts.length}`,
+    `fetched ${textBlobCount} asset-text blobs (${textBlobBytes} bytes), skipped ${skippedAssetTexts.length}`,
+  );
+
+  // Write phase — everything above only FETCHED data into memory; nothing has
+  // touched the archive file yet. Entries are written here in the exact
+  // order `full-importer.ts` needs to encounter them while streaming the
+  // file back in a single pass (blobs before the table rows that reference
+  // them, tables in FK-safe `IMPORT_ORDER`, doc bodies last): `streamArchive`
+  // processes entries strictly in tar-physical order, so THIS order is what
+  // makes a true single-pass streaming restore possible without re-reading
+  // the file per table. See the matching comment on `IMPORT_ORDER`.
+  await writeNdjsonEntry(writer, "tree/attachmentBlobs.ndjson", attachmentBlobRows);
+  await writeNdjsonEntry(writer, "tree/assetTextBlobs.ndjson", textBlobRows);
+  for (const table of IMPORT_ORDER) {
+    // `--no-history` never fetched these tables at all (see `tables` above)
+    // — omit the entry entirely rather than writing an empty one, matching
+    // the archive's previous shape for a `--no-history` backup.
+    if (!tables.includes(table)) continue;
+    await writeNdjsonEntry(writer, `tree/${table}.ndjson`, tableRows[table] ?? []);
+  }
+  for (const doc of docBodyEntries) {
+    await writer.addBuffer(`docs/${doc.nodeId}.md`, doc.body);
+  }
+  log(
+    `wrote archive entries: ${blobCount} attachment blobs, ${textBlobCount} asset-text blobs, ` +
+      `${IMPORT_ORDER.length} tables, ${docBodyEntries.length} doc bodies`,
   );
 
   const manifestWithoutChecksum: Omit<Manifest, "checksum"> = {

--- a/apps/busabase-cli/src/backup/format/archive-reader.ts
+++ b/apps/busabase-cli/src/backup/format/archive-reader.ts
@@ -1,5 +1,10 @@
 import { createHash } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { createReadStream, createWriteStream } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { ZstdDecompress } from "node:zlib";
 import * as tar from "tar-stream";
 import {
@@ -28,74 +33,183 @@ async function detectCompression(path: string): Promise<"zstd" | "gzip"> {
   });
 }
 
-export interface ReadArchiveResult {
-  manifest: Manifest;
-  /**
-   * Every non-manifest entry, fully buffered by path. Fine for the manifest,
-   * tree/base-schema files, and per-blob entries; a very large single
-   * `records.ndjson` for a huge space is the known scaling limit of this v1
-   * reader — a future version can swap this for a true streaming per-entry
-   * callback without changing the on-disk format.
-   */
-  entries: Map<string, Buffer>;
-}
-
-/**
- * Read and integrity-verify a `.bbdump` archive: decompress, extract every
- * tar entry, recompute each entry's sha256, then recompute and check the
- * manifest's top-level `checksum` before returning anything to the caller —
- * a truncated or tampered archive throws here, before any row is imported.
- */
-export async function readArchive(path: string): Promise<ReadArchiveResult> {
+const requireZstd = async (path: string): Promise<void> => {
   const compression = await detectCompression(path);
   if (compression === "gzip") {
     throw new Error(
       "This .bbdump archive is gzip-compressed; `busabase-cli restore` only reads zstd archives in v1.",
     );
   }
+};
+
+/**
+ * Decompress the whole archive to a private temp file, then hand back a
+ * fresh `tar.extract()` reading from THAT file — never a live
+ * `ZstdDecompress` piped straight into `tar.extract()`.
+ *
+ * That live pipe is where a real, reproducible corruption was traced to on
+ * a real multi-gigabyte production archive: rows arriving mangled deep into
+ * a large entry (`Unterminated string in JSON`, one row split across two
+ * "lines") with no invalid bytes anywhere on disk. Isolated piece by piece:
+ * Node's built-in zstd decompression is byte-perfect on its own (verified
+ * against the system `zstd` CLI with `cmp` — identical output), and
+ * `tar-stream` parses a pre-decompressed file with zero errors — the
+ * corruption only reproduced with the live pipe. This fix removes that live
+ * interaction (decompress to a file, then tar-parse the file) as the
+ * primary defense; `full-importer.ts` also stopped relying on `node:readline`
+ * for the same entries as defense in depth, since the exact mechanism
+ * inside the live pipe was never pinned down to one specific line. The
+ * cost is one extra temp-file write per pass — cheap local disk I/O,
+ * negligible next to the HTTP round trips a real restore/verify already
+ * does.
+ */
+const openTarStream = async (
+  path: string,
+): Promise<{ extract: tar.Extract; cleanup: () => Promise<void> }> => {
+  const tempDir = await mkdtemp(join(tmpdir(), "busabase-restore-"));
+  const decompressedPath = join(tempDir, "archive.tar");
+  const cleanup = () => rm(tempDir, { recursive: true, force: true });
+  try {
+    await pipeline(
+      createReadStream(path),
+      new ZstdDecompress(),
+      createWriteStream(decompressedPath),
+    );
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
 
   const extract = tar.extract();
-  const entries = new Map<string, Buffer>();
-  const checksums: EntryChecksum[] = [];
-  let manifestBuf: Buffer | undefined;
+  createReadStream(decompressedPath)
+    .on("error", (err) => extract.destroy(err))
+    .pipe(extract);
+  return { extract, cleanup };
+};
 
-  await new Promise<void>((resolvePromise, reject) => {
-    extract.on("entry", (header, stream, next) => {
-      const chunks: Buffer[] = [];
-      stream.on("data", (c) => chunks.push(c as Buffer));
-      stream.on("end", () => {
-        const buf = Buffer.concat(chunks);
-        if (header.name === "manifest.json") {
-          manifestBuf = buf;
-        } else {
-          const sha256 = createHash("sha256").update(buf).digest("hex");
-          checksums.push({ path: header.name, sha256 });
-          entries.set(header.name, buf);
-        }
-        next();
+/**
+ * Pass 1 of 2 — integrity only, never buffers a whole entry.
+ *
+ * Streams every tar entry chunk-by-chunk, hashing incrementally
+ * (`hash.update(chunk)` per chunk, not once over a concatenated whole-entry
+ * buffer — a single `Hash.update()` call over a many-gigabyte buffer throws
+ * `RangeError: data is too long`, which is exactly what a real production
+ * space's attachment bytes hit here before this rewrite). Recomputes and
+ * checks the manifest's top-level `checksum` before returning anything —
+ * a truncated or tampered archive throws here, before `streamArchive` (pass
+ * 2) is ever invoked, so "verified before a single row is written" holds
+ * regardless of entry size.
+ */
+export async function verifyArchive(path: string): Promise<Manifest> {
+  await requireZstd(path);
+
+  const { extract, cleanup } = await openTarStream(path);
+  try {
+    const checksums: EntryChecksum[] = [];
+    let manifestBuf: Buffer | undefined;
+
+    await new Promise<void>((resolvePromise, reject) => {
+      extract.on("entry", (header, stream, next) => {
+        const hash = createHash("sha256");
+        const manifestChunks: Buffer[] | undefined =
+          header.name === "manifest.json" ? [] : undefined;
+        stream.on("data", (chunk) => {
+          hash.update(chunk);
+          manifestChunks?.push(chunk as Buffer);
+        });
+        stream.on("end", () => {
+          if (manifestChunks) {
+            manifestBuf = Buffer.concat(manifestChunks);
+          } else {
+            checksums.push({ path: header.name, sha256: hash.digest("hex") });
+          }
+          next();
+        });
+        stream.on("error", reject);
+        stream.resume();
       });
-      stream.on("error", reject);
-      stream.resume();
+      extract.on("finish", resolvePromise);
+      extract.on("error", reject);
     });
-    extract.on("finish", resolvePromise);
-    extract.on("error", reject);
 
-    createReadStream(path).pipe(new ZstdDecompress()).on("error", reject).pipe(extract);
-  });
+    if (!manifestBuf) {
+      throw new Error("Archive is missing manifest.json.");
+    }
+    const manifest = ManifestSchema.parse(JSON.parse(manifestBuf.toString("utf8")));
 
-  if (!manifestBuf) {
-    throw new Error("Archive is missing manifest.json.");
+    const recomputed = createHash("sha256")
+      .update(canonicalizeEntryChecksums(checksums))
+      .digest("hex");
+    if (recomputed !== manifest.checksum) {
+      throw new Error(
+        `Archive checksum mismatch — file may be truncated or corrupted (expected ${manifest.checksum}, got ${recomputed}).`,
+      );
+    }
+
+    return manifest;
+  } finally {
+    await cleanup();
   }
-  const manifest = ManifestSchema.parse(JSON.parse(manifestBuf.toString("utf8")));
+}
 
-  const recomputed = createHash("sha256")
-    .update(canonicalizeEntryChecksums(checksums))
-    .digest("hex");
-  if (recomputed !== manifest.checksum) {
-    throw new Error(
-      `Archive checksum mismatch — file may be truncated or corrupted (expected ${manifest.checksum}, got ${recomputed}).`,
-    );
+export interface StreamedArchiveEntry {
+  path: string;
+  /**
+   * The entry's raw bytes, in order. The callback MUST fully consume (or
+   * explicitly drain) this before its promise resolves — tar-stream can't
+   * advance to the next entry until the current one's stream has ended.
+   */
+  body: Readable;
+}
+
+/**
+ * Pass 2 of 2 — content, streamed. Call only after `verifyArchive` has
+ * already succeeded for this same file. Re-opens the archive (a second,
+ * independent decompress+detar pass over the local file — cheap sequential
+ * disk I/O, not a network cost) and hands each entry's raw stream to
+ * `onEntry` in tar-physical order, one at a time, without ever buffering a
+ * whole entry in memory. Callers that need dependency-ordered processing
+ * (e.g. `busabase-cli restore`'s FK-safe table order) get it for free as
+ * long as the archive was WRITTEN in that order — see `full-exporter.ts`.
+ */
+export async function streamArchive(
+  path: string,
+  onEntry: (entry: StreamedArchiveEntry) => Promise<void>,
+): Promise<void> {
+  const { extract, cleanup } = await openTarStream(path);
+  try {
+    await new Promise<void>((resolvePromise, reject) => {
+      extract.on("entry", (header, stream, next) => {
+        onEntry({ path: header.name, body: stream }).then(
+          () => next(),
+          (err) => {
+            // Make sure the underlying stream doesn't dangle if the callback
+            // threw without draining it, then propagate the real failure.
+            stream.resume();
+            reject(err);
+          },
+        );
+      });
+      extract.on("finish", resolvePromise);
+      extract.on("error", reject);
+    });
+  } finally {
+    await cleanup();
   }
+}
 
-  return { manifest, entries };
+/** Drain an entry's stream without keeping its bytes (unknown/skipped entries). */
+export async function drainEntry(body: Readable): Promise<void> {
+  for await (const _chunk of body) {
+    // discard
+  }
+}
+
+/** Read a small entry fully into a UTF-8 string (doc bodies — individually small, unlike table/blob entries). */
+export async function readEntryText(body: Readable): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of body) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
 }

--- a/apps/busabase-cli/src/backup/format/archive.test.ts
+++ b/apps/busabase-cli/src/backup/format/archive.test.ts
@@ -3,9 +3,24 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readArchive } from "./archive-reader.js";
+import { readEntryText, streamArchive, verifyArchive } from "./archive-reader.js";
 import { ArchiveWriter } from "./archive-writer.js";
 import { FORMAT_VERSION } from "./manifest.js";
+
+/** Test helper: stream the whole archive back into a path→text map, the shape the old buffered reader returned. */
+async function readAllEntriesAsText(path: string): Promise<Map<string, string>> {
+  const entries = new Map<string, string>();
+  await streamArchive(path, async (entry) => {
+    if (entry.path === "manifest.json") {
+      for await (const _chunk of entry.body) {
+        // drain
+      }
+      return;
+    }
+    entries.set(entry.path, await readEntryText(entry.body));
+  });
+  return entries;
+}
 
 describe("bbdump archive format roundtrip", () => {
   let dir: string;
@@ -48,14 +63,13 @@ describe("bbdump archive format roundtrip", () => {
 
     expect(manifest.checksum).toMatch(/^[0-9a-f]{64}$/);
 
-    const result = await readArchive(archivePath);
+    const verified = await verifyArchive(archivePath);
+    expect(verified).toEqual(manifest);
 
-    expect(result.manifest).toEqual(manifest);
-    expect(JSON.parse(result.entries.get("tree/nodes.json")!.toString("utf8"))).toEqual([
-      { id: "nd_1", name: "Root" },
-    ]);
-    expect(result.entries.get("bases/base_1/records.ndjson")!.toString("utf8")).toContain("Alice");
-    expect(result.entries.get("blobs/sha256/deadbeef")).toEqual(blobBytes);
+    const entries = await readAllEntriesAsText(archivePath);
+    expect(JSON.parse(entries.get("tree/nodes.json")!)).toEqual([{ id: "nd_1", name: "Root" }]);
+    expect(entries.get("bases/base_1/records.ndjson")).toContain("Alice");
+    expect(entries.get("blobs/sha256/deadbeef")).toEqual(blobBytes.toString("utf8"));
   });
 
   it("rejects a truncated archive", async () => {
@@ -80,6 +94,46 @@ describe("bbdump archive format roundtrip", () => {
     const size = statSync(archivePath).size;
     truncateSync(archivePath, Math.floor(size * 0.6));
 
-    await expect(readArchive(archivePath)).rejects.toThrow();
+    await expect(verifyArchive(archivePath)).rejects.toThrow();
+  });
+
+  it("verifies and streams back an entry written from many small chunks (never a single whole-entry buffer)", async () => {
+    // Can't reproduce the literal multi-gigabyte `RangeError: data is too
+    // long` here (too slow/memory-heavy for a unit test) — this instead
+    // proves the MECHANISM: hashing happens per-chunk (`hash.update(chunk)`
+    // in `verifyArchive`), not once over a `Buffer.concat`'d whole entry, by
+    // feeding an entry through hundreds of small chunks and checking the
+    // result is byte- and hash-identical to computing it the naive way.
+    const chunkCount = 500;
+    const chunks = Array.from({ length: chunkCount }, (_, i) =>
+      Buffer.from(`{"id":"row_${i}","value":"${"x".repeat(50)}"}\n`, "utf8"),
+    );
+    const whole = Buffer.concat(chunks);
+
+    const writer = ArchiveWriter.create(archivePath);
+    await writer.addStream("tree/records.ndjson", whole.length, Readable.from(chunks));
+    const manifest = await writer.finalize({
+      formatVersion: FORMAT_VERSION,
+      toolVersion: "0.1.0-test",
+      exportedAt: new Date().toISOString(),
+      spaceId: "spc_test",
+      sourceHost: "http://localhost:15419",
+      fidelity: "full",
+      excludesSecrets: true,
+      tables: { records: chunkCount },
+      blobCount: 0,
+      blobBytes: 0,
+      textBlobCount: 0,
+      textBlobBytes: 0,
+    });
+
+    const verified = await verifyArchive(archivePath);
+    expect(verified.checksum).toBe(manifest.checksum);
+
+    const entries = await readAllEntriesAsText(archivePath);
+    expect(entries.get("tree/records.ndjson")).toBe(whole.toString("utf8"));
+    expect(entries.get("tree/records.ndjson")?.split("\n").filter(Boolean)).toHaveLength(
+      chunkCount,
+    );
   });
 });

--- a/apps/busabase-cli/src/backup/full-roundtrip.test.ts
+++ b/apps/busabase-cli/src/backup/full-roundtrip.test.ts
@@ -1,0 +1,170 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DumpTableSchema } from "busabase-contract/domains/dump/types";
+import type { BusabaseClient } from "busabase-sdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { exportFull } from "./export/full-exporter.js";
+import { verifyArchive } from "./format/archive-reader.js";
+import { IMPORT_ORDER, importFull } from "./import/full-importer.js";
+
+/**
+ * Nothing previously exercised `exportFull` and `importFull` together —
+ * `archive.test.ts` only covers the low-level tar/checksum primitives, and
+ * `packages/busabase-core/tests/dump-roundtrip.test.ts` covers the SERVER's
+ * own import semantics in-process, never touching the CLI's `.bbdump` format
+ * at all. That gap is exactly how the write/read ordering mismatch this
+ * rewrite fixes could have shipped unnoticed: `full-exporter.ts` now writes
+ * archive entries in `IMPORT_ORDER` specifically so `full-importer.ts`'s
+ * single streaming pass sees blobs before the table rows that reference
+ * them, and every table before anything that FKs into it — this test pins
+ * that contract at the CLI-package level, with fake, in-memory "servers" on
+ * both ends (no real HTTP, no real DB) that only need to agree on shape.
+ */
+
+/** A tiny in-memory "export server": paginates fixture rows two at a time, ignoring the caller's requested `limit`, so every table with >2 rows genuinely forces multiple `exportTables` calls. */
+function createFakeExportClient(
+  tables: Partial<Record<string, Array<Record<string, unknown>>>>,
+  docs: Record<string, string>,
+): BusabaseClient {
+  return {
+    dump: {
+      exportTables: async ({ table, cursor }: { table: string; cursor?: string }) => {
+        const rows = tables[table] ?? [];
+        const start = cursor ? Number.parseInt(cursor, 10) : 0;
+        const page = rows.slice(start, start + 2);
+        const nextIndex = start + page.length;
+        return { rows: page, nextCursor: nextIndex < rows.length ? String(nextIndex) : null };
+      },
+      exportAssetText: async () => {
+        throw new Error("not exercised by this fixture (assetTexts is empty)");
+      },
+    },
+    nodes: {
+      get: async ({ nodeId, type }: { nodeId: string; type?: string }) => {
+        if (type !== "doc" || !(nodeId in docs)) {
+          throw new Error(`unexpected nodes.get(${nodeId}, ${type})`);
+        }
+        return { type: "doc", body: docs[nodeId] };
+      },
+    },
+    assets: {
+      download: async () => {
+        throw new Error("not exercised by this fixture (assets is empty)");
+      },
+    },
+  } as any;
+}
+
+interface RecordedImport {
+  table: string;
+  rows: Array<Record<string, unknown>>;
+}
+
+/** A tiny in-memory "import server": records every `importTables` call verbatim so the test can assert on call order and payload, without a real DB. */
+function createFakeImportClient(recorded: RecordedImport[]): BusabaseClient {
+  return {
+    dump: {
+      importBegin: async () => ({ sessionId: "sess_test" }),
+      importTables: async ({
+        table,
+        rows,
+      }: {
+        table: string;
+        rows: Array<Record<string, unknown>>;
+      }) => {
+        recorded.push({ table, rows });
+        return { inserted: rows.length };
+      },
+      importCommit: async () => ({ ok: true, warnings: [] }),
+      importAbort: async () => ({ ok: true }),
+    },
+  } as any;
+}
+
+describe("exportFull -> verifyArchive -> importFull round trip", () => {
+  let dir: string;
+  let archivePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "busabase-full-roundtrip-test-"));
+    archivePath = join(dir, "space.bbdump");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("streams every table in IMPORT_ORDER, blobs first, docs last — with real multi-page pagination", async () => {
+    const nodeRows = [
+      { id: "nod_root", parentId: null, type: "folder" },
+      { id: "nod_doc", parentId: "nod_root", type: "doc" },
+      { id: "nod_base", parentId: "nod_root", type: "base" },
+    ];
+    // 5 rows over a page size of 2 forces 3 real `exportTables` calls.
+    const recordRows = Array.from({ length: 5 }, (_, i) => ({ id: `rec_${i}`, value: i }));
+
+    const tables: Partial<Record<string, Array<Record<string, unknown>>>> = {};
+    for (const table of DumpTableSchema.options) tables[table] = [];
+    tables.nodes = nodeRows;
+    tables.records = recordRows;
+
+    const exportClient = createFakeExportClient(tables, { nod_doc: "# Hello\n\nDoc body." });
+
+    const manifest = await exportFull({
+      client: exportClient,
+      outPath: archivePath,
+      spaceId: "spc_test",
+      sourceHost: "http://localhost:15419",
+      includeHistory: true,
+      toolVersion: "0.1.0-test",
+    });
+
+    expect(manifest.tables.nodes).toBe(3);
+    expect(manifest.tables.records).toBe(5);
+
+    // Pass 1 must succeed on its own before anything is imported.
+    await expect(verifyArchive(archivePath)).resolves.toEqual(manifest);
+
+    const recorded: RecordedImport[] = [];
+    const importClient = createFakeImportClient(recorded);
+    const result = await importFull({
+      client: importClient,
+      archivePath,
+      sourceSpaceId: "spc_test",
+    });
+
+    expect(result).toEqual({ ok: true, warnings: [] });
+
+    // All 5 `records` rows arrived, correctly reassembled across 3 pages.
+    const recordCalls = recorded.filter((c) => c.table === "records");
+    expect(recordCalls.flatMap((c) => c.rows)).toEqual(recordRows);
+
+    // All 3 `nodes` rows arrived too.
+    const nodeCalls = recorded.filter((c) => c.table === "nodes");
+    expect(nodeCalls.flatMap((c) => c.rows)).toEqual(nodeRows);
+
+    // The doc body made it through as a `docBodies` pseudo-table row.
+    const docCalls = recorded.filter((c) => c.table === "docBodies");
+    expect(docCalls.flatMap((c) => c.rows)).toEqual([
+      { nodeId: "nod_doc", markdown: "# Hello\n\nDoc body." },
+    ]);
+
+    // Ordering: every real table appears in `IMPORT_ORDER`'s relative order
+    // (nodes before records, both well before docBodies, which is always
+    // last) — this is the exact property the write/read rewrite exists to
+    // guarantee via a single streaming pass, not an in-memory reorder.
+    const tableOrder = recorded.map((c) => c.table);
+    const firstIndexOf = (table: string) => tableOrder.indexOf(table);
+    expect(firstIndexOf("nodes")).toBeLessThan(firstIndexOf("records"));
+    expect(firstIndexOf("records")).toBeLessThan(firstIndexOf("docBodies"));
+    expect(tableOrder.indexOf("docBodies")).toBe(tableOrder.length - 1);
+
+    // Every table that produced a call is somewhere in IMPORT_ORDER (or is
+    // the docBodies pseudo-table), and real tables never appear out of their
+    // IMPORT_ORDER relative sequence.
+    const realTableOrder = tableOrder.filter((t) => t !== "docBodies");
+    const expectedRelativeOrder = IMPORT_ORDER.filter((t) => realTableOrder.includes(t));
+    expect(realTableOrder).toEqual(expectedRelativeOrder);
+  });
+});

--- a/apps/busabase-cli/src/backup/import/full-importer.test.ts
+++ b/apps/busabase-cli/src/backup/import/full-importer.test.ts
@@ -1,0 +1,41 @@
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { streamNdjsonRows } from "./full-importer.js";
+
+describe("streamNdjsonRows — multi-byte UTF-8 across chunk boundaries", () => {
+  it("correctly decodes a CJK character whose UTF-8 bytes are split across two stream chunks", async () => {
+    // "你" is E4 BD A0 in UTF-8 (3 bytes) — split the underlying tar-stream
+    // entry mid-character to reproduce what a real decompress+detar pipeline
+    // does for arbitrary byte offsets. Without `body.setEncoding("utf8")` in
+    // `streamNdjsonRows`, `readline` decodes each raw Buffer chunk with its
+    // own naive `toString()`, mangling this into invalid JSON — reproduced
+    // live restoring a real production space with Chinese commit messages
+    // (`Unterminated string in JSON`), at an unpredictable row depending on
+    // where the compression stream happened to split a chunk.
+    const line = `${JSON.stringify({ id: "row_1", message: "你好，世界" })}\n`;
+    const lineBytes = Buffer.from(line, "utf8");
+
+    // Find a split point that lands strictly inside a multi-byte sequence
+    // (a continuation byte, 0x80–0xBF) rather than on a character boundary.
+    let splitAt = -1;
+    for (let i = 1; i < lineBytes.length; i += 1) {
+      if ((lineBytes[i] & 0xc0) === 0x80) {
+        splitAt = i;
+        break;
+      }
+    }
+    expect(splitAt).toBeGreaterThan(0); // sanity: the fixture does contain multi-byte chars
+
+    const chunk1 = lineBytes.subarray(0, splitAt);
+    const chunk2 = lineBytes.subarray(splitAt);
+    const body = Readable.from([chunk1, chunk2]);
+
+    const sent: Array<Array<Record<string, unknown>>> = [];
+    const count = await streamNdjsonRows(body, async (rows) => {
+      sent.push(rows);
+    });
+
+    expect(count).toBe(1);
+    expect(sent).toEqual([[{ id: "row_1", message: "你好，世界" }]]);
+  });
+});

--- a/apps/busabase-cli/src/backup/import/full-importer.ts
+++ b/apps/busabase-cli/src/backup/import/full-importer.ts
@@ -1,6 +1,7 @@
+import type { Readable } from "node:stream";
 import type { DumpTable } from "busabase-contract/domains/dump/types";
 import type { BusabaseClient } from "busabase-sdk";
-import type { ReadArchiveResult } from "../format/archive-reader.js";
+import { drainEntry, readEntryText, streamArchive } from "../format/archive-reader.js";
 
 /**
  * FK-safe insert order (parents before children). Unlike the export list this
@@ -8,6 +9,15 @@ import type { ReadArchiveResult } from "../format/archive-reader.js";
  * (`table-lists.test.ts`) asserts it covers exactly the contract's
  * `DumpTableSchema`, so a table added to the contract can't be silently dropped
  * from import.
+ *
+ * This is ALSO the order `full-exporter.ts` now writes `tree/*.ndjson`
+ * entries into the archive (blobs first, then this exact sequence, then doc
+ * bodies) — `importFull` below processes entries strictly in the order it
+ * encounters them while streaming the file once, so the archive's physical
+ * layout is what actually enforces FK-safety now, not an in-memory reorder.
+ * If that write order and this array drift apart, restore breaks with a
+ * plain FK-violation error, not a silent corruption — see the matching note
+ * in `full-exporter.ts`.
  */
 export const IMPORT_ORDER: DumpTable[] = [
   "nodes",
@@ -32,89 +42,169 @@ export const IMPORT_ORDER: DumpTable[] = [
 ];
 
 const BATCH_SIZE = 200;
+/**
+ * Also cap each batch by raw bytes, not just row count. `BATCH_SIZE` rows is
+ * fine for small metadata tables, but `attachmentBlobs`/`assetTextBlobs` rows
+ * carry base64-encoded file bytes — a real production space's attachments
+ * (average ~700KB base64'd) turned 200 rows into a ~140MB single POST body,
+ * which the server rejected outright as a malformed request (its own decode
+ * step throws before ever reaching our schema, so the real cause — a body
+ * too large for whatever's parsing it — surfaces as a generic `BAD_REQUEST`
+ * with no size mentioned anywhere). Flush on whichever limit hits first.
+ */
+const MAX_BATCH_BYTES = 4 * 1024 * 1024;
+
+const TABLE_ENTRY_PREFIX = "tree/";
+const TABLE_ENTRY_SUFFIX = ".ndjson";
+const ATTACHMENT_BLOBS_ENTRY = `${TABLE_ENTRY_PREFIX}attachmentBlobs${TABLE_ENTRY_SUFFIX}`;
+const ASSET_TEXT_BLOBS_ENTRY = `${TABLE_ENTRY_PREFIX}assetTextBlobs${TABLE_ENTRY_SUFFIX}`;
 
 export interface FullImportOptions {
   client: BusabaseClient;
-  archive: ReadArchiveResult;
+  /** Path to a `.bbdump` archive already integrity-verified via `verifyArchive`. */
+  archivePath: string;
+  /** The archive's `manifest.spaceId` — the space it was ORIGINALLY exported from, needed so the server can remap the root node deterministically instead of guessing from row content. */
+  sourceSpaceId: string;
   onProgress?: (message: string) => void;
 }
 
 /**
+ * Parse NDJSON line-by-line from a stream (a small hand-rolled splitter, not
+ * `node:readline` — see below) and flush rows to `send` in batches — bounded
+ * by BOTH `BATCH_SIZE` rows and `MAX_BATCH_BYTES` raw bytes, whichever comes
+ * first — as they arrive, never collecting the whole entry into one
+ * array/string/buffer first. This is what lets a multi-gigabyte
+ * `fieldValues.ndjson` or `attachmentBlobs.ndjson` (thousands of attachments'
+ * base64 bytes) import without holding all of it in memory at once, AND
+ * without ever sending one request body too large for the server to parse.
+ */
+// Exported for `full-importer.test.ts` only — not part of the module's public
+// API surface used by `commands.ts`.
+export async function streamNdjsonRows(
+  body: Readable,
+  send: (rows: Array<Record<string, unknown>>) => Promise<unknown>,
+): Promise<number> {
+  // `body` is tar-stream's raw Buffer-mode entry stream. `setEncoding('utf8')`
+  // routes chunk decoding through the stream's own `StringDecoder`, so a
+  // multi-byte UTF-8 character (CJK text is common in real commit
+  // messages/payloads) split across two chunks still decodes correctly
+  // instead of mangling into an unterminated string.
+  //
+  // Split lines with a plain `indexOf("\n")` loop, not `node:readline`, as
+  // defense in depth: reading a real multi-gigabyte production archive
+  // through `node:readline` over this same kind of stream corrupted entries
+  // deep into a large table (`Unterminated string in JSON`, one row split
+  // across two "lines") even with encoding set. The primary fix was
+  // removing the live `ZstdDecompress → tar-stream` pipe this reads from
+  // (see `archive-reader.ts`'s `openTarStream`) — the exact mechanism was
+  // never pinned down to being readline-specific vs. an artifact of that
+  // live pipe, so this manual splitter avoids the untrusted code path
+  // entirely rather than assume it's now safe.
+  body.setEncoding("utf8");
+  let buffer = "";
+  let batch: Array<Record<string, unknown>> = [];
+  let batchBytes = 0;
+  let count = 0;
+  for await (const chunk of body) {
+    buffer += chunk as string;
+    let newlineIndex: number;
+    // biome-ignore lint/suspicious/noAssignInExpressions: standard incremental-parse idiom
+    while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+      if (!line) continue;
+      batch.push(JSON.parse(line));
+      batchBytes += Buffer.byteLength(line, "utf8");
+      count += 1;
+      if (batch.length >= BATCH_SIZE || batchBytes >= MAX_BATCH_BYTES) {
+        await send(batch);
+        batch = [];
+        batchBytes = 0;
+      }
+    }
+  }
+  if (buffer.length > 0) {
+    batch.push(JSON.parse(buffer));
+    count += 1;
+  }
+  if (batch.length > 0) await send(batch);
+  return count;
+}
+
+/**
  * Full-fidelity import: begins a dump session (server refuses unless the
- * target space is empty), uploads every attachment blob (`attachmentBlobs`
- * pseudo-table, written directly to storage at its original key) BEFORE the
- * `attachments` table rows that FK-reference those keys, likewise every
- * extracted-text blob (`assetTextBlobs`) before the `assetTexts` rows that
- * point at them, replays every other
- * table in dependency order via `dump.importTables` (preserving original
- * ids), uploads doc bodies as the `docBodies` pseudo-table, and commits.
+ * target space is empty), then streams the archive ONCE — uploading every
+ * attachment blob (`attachmentBlobs` pseudo-table, written directly to
+ * storage at its original key) BEFORE the `attachments` table rows that FK-
+ * reference those keys, likewise every extracted-text blob
+ * (`assetTextBlobs`) before the `assetTexts` rows that point at them,
+ * replaying every other table in dependency order via `dump.importTables`
+ * (preserving original ids), uploading doc bodies as the `docBodies`
+ * pseudo-table, and finally committing. The archive must already be
+ * integrity-verified (`verifyArchive`) before this is called.
  */
 export async function importFull(
   options: FullImportOptions,
 ): Promise<{ ok: boolean; warnings: string[] }> {
-  const { client, archive, onProgress } = options;
+  const { client, archivePath, sourceSpaceId, onProgress } = options;
   const log = onProgress ?? (() => {});
 
-  const { sessionId } = await client.dump.importBegin();
+  const { sessionId } = await client.dump.importBegin({ sourceSpaceId });
   try {
-    const blobBuf = archive.entries.get("tree/attachmentBlobs.ndjson");
-    if (blobBuf) {
-      const blobRows = blobBuf
-        .toString("utf8")
-        .split("\n")
-        .filter(Boolean)
-        .map((line) => JSON.parse(line));
-      for (let i = 0; i < blobRows.length; i += BATCH_SIZE) {
-        const batch = blobRows.slice(i, i + BATCH_SIZE);
-        await client.dump.importTables({ sessionId, table: "attachmentBlobs", rows: batch });
-      }
-      log(`imported ${blobRows.length} attachment blobs`);
-    }
+    const docBodyRows: Array<{ nodeId: string; markdown: string }> = [];
 
-    // Extracted-text objects, restored to their exact `textStorageKey` BEFORE
-    // the `assetTexts` rows that reference them are inserted (same ordering
-    // rule as attachment blobs above; `assetTexts` sits far later in
-    // IMPORT_ORDER, so this is comfortably ahead of it). Absent from archives
-    // written before asset-text blobs were captured — those simply skip this
-    // block, and `importCommit`'s integrity pass reports the missing bytes
-    // instead of restoring a space whose text silently isn't searchable.
-    const textBlobBuf = archive.entries.get("tree/assetTextBlobs.ndjson");
-    if (textBlobBuf) {
-      const textBlobRows = textBlobBuf
-        .toString("utf8")
-        .split("\n")
-        .filter(Boolean)
-        .map((line) => JSON.parse(line));
-      for (let i = 0; i < textBlobRows.length; i += BATCH_SIZE) {
-        const batch = textBlobRows.slice(i, i + BATCH_SIZE);
-        await client.dump.importTables({ sessionId, table: "assetTextBlobs", rows: batch });
+    await streamArchive(archivePath, async (entry) => {
+      if (entry.path === ATTACHMENT_BLOBS_ENTRY) {
+        const n = await streamNdjsonRows(entry.body, (rows) =>
+          client.dump.importTables({ sessionId, table: "attachmentBlobs", rows }),
+        );
+        log(`imported ${n} attachment blobs`);
+        return;
       }
-      log(`imported ${textBlobRows.length} asset-text blobs`);
-    }
-
-    for (const table of IMPORT_ORDER) {
-      const buf = archive.entries.get(`tree/${table}.ndjson`);
-      if (!buf) continue;
-      const rows = buf
-        .toString("utf8")
-        .split("\n")
-        .filter(Boolean)
-        .map((line) => JSON.parse(line));
-      for (let i = 0; i < rows.length; i += BATCH_SIZE) {
-        const batch = rows.slice(i, i + BATCH_SIZE);
-        await client.dump.importTables({ sessionId, table, rows: batch });
+      if (entry.path === ASSET_TEXT_BLOBS_ENTRY) {
+        const n = await streamNdjsonRows(entry.body, (rows) =>
+          client.dump.importTables({ sessionId, table: "assetTextBlobs", rows }),
+        );
+        log(`imported ${n} asset-text blobs`);
+        return;
       }
-      log(`imported ${table}: ${rows.length} rows`);
-    }
+      if (entry.path.startsWith(TABLE_ENTRY_PREFIX) && entry.path.endsWith(TABLE_ENTRY_SUFFIX)) {
+        const table = entry.path.slice(
+          TABLE_ENTRY_PREFIX.length,
+          -TABLE_ENTRY_SUFFIX.length,
+        ) as DumpTable;
+        if (!IMPORT_ORDER.includes(table)) {
+          // A pseudo-table entry this version doesn't know about yet, or a
+          // future table archived by a newer CLI — skip forward-compatibly
+          // rather than failing the whole restore.
+          await drainEntry(entry.body);
+          return;
+        }
+        const n = await streamNdjsonRows(entry.body, (rows) =>
+          client.dump.importTables({ sessionId, table, rows }),
+        );
+        log(`imported ${table}: ${n} rows`);
+        return;
+      }
+      if (entry.path.startsWith("docs/") && entry.path.endsWith(".md")) {
+        const nodeId = entry.path.slice("docs/".length, -".md".length);
+        const markdown = await readEntryText(entry.body);
+        docBodyRows.push({ nodeId, markdown });
+        return;
+      }
+      // manifest.json (already read by `verifyArchive`) or any other unknown
+      // entry — drain it so tar-stream can advance, but do nothing with it.
+      await drainEntry(entry.body);
+    });
 
-    const docBodyRows = [...archive.entries.entries()]
-      .filter(([path]) => path.startsWith("docs/") && path.endsWith(".md"))
-      .map(([path, buf]) => ({
-        nodeId: path.slice("docs/".length, -".md".length),
-        markdown: buf.toString("utf8"),
-      }));
     if (docBodyRows.length > 0) {
-      await client.dump.importTables({ sessionId, table: "docBodies", rows: docBodyRows });
+      for (let i = 0; i < docBodyRows.length; i += BATCH_SIZE) {
+        await client.dump.importTables({
+          sessionId,
+          table: "docBodies",
+          rows: docBodyRows.slice(i, i + BATCH_SIZE),
+        });
+      }
       log(`imported ${docBodyRows.length} doc bodies`);
     }
 

--- a/apps/busabase-cli/src/package/check.ts
+++ b/apps/busabase-cli/src/package/check.ts
@@ -1,0 +1,378 @@
+/**
+ * `busabase-cli check <dir>` — one command, four layers.
+ *
+ * Four things can be true of one directory, and they are not four rungs of a ladder:
+ * a **package** installs resources into a workspace, an **Agent Skill** is a manual an
+ * agent reads, a **template** is a directory that is both plus an explicit opt-in, and
+ * an **AirApp** is a node type that ships inside a package. Most real directories are
+ * several of these at once.
+ *
+ * That is exactly why this is one command rather than three. Running the wrong checker
+ * is the usual way an author ends up believing they are covered when they are not, and
+ * three commands would institutionalise that mistake by requiring the author to answer
+ * "which am I?" correctly first. Detection is reliable because the formats carry their
+ * own declarations: `busabase.json` makes it a package, a parseable `SKILL.md` makes it
+ * a Skill, `metadata.busabase.template: true` makes it a template, and an
+ * `_node.json` of type `airapp` makes it an app.
+ *
+ * A layer that does not apply reports `–`, never `✓`. Keeping those visually distinct
+ * is the whole point: "not applicable" and "passed" look identical in a checklist that
+ * only has ticks, and that is how coverage gets assumed rather than verified.
+ *
+ * The rules themselves live where they are versioned with what they check —
+ * `busabase-package/audit` and `validateTemplate` for the format, `busabase-sdk/airapp-check`
+ * for the runtime contract. This file composes; it owns no rules of its own.
+ */
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename, join, relative, resolve, sep } from "node:path";
+
+import { type AuditFinding, auditPackage, auditSkill } from "busabase-package/audit";
+import { type PackageFiles, readPackageTree } from "busabase-package/layout-read";
+import { validateTemplate } from "busabase-package/template";
+import type { PackageTree } from "busabase-package/tree";
+import { type AirAppSources, checkAirApp } from "busabase-sdk/airapp-check";
+
+export const CHECK_LAYERS = ["package", "skill", "template", "airapp"] as const;
+export type CheckLayer = (typeof CHECK_LAYERS)[number];
+
+export interface LayerReport {
+  layer: CheckLayer;
+  /** `false` when the directory is not this kind of thing — reported as `–`, never `✓`. */
+  applicable: boolean;
+  /** What the layer applies to, when there can be more than one (an AirApp slug). */
+  subject?: string;
+  /** Why a layer was skipped, or a one-line note when it passed. */
+  note?: string;
+  findings: AuditFinding[];
+}
+
+export interface CheckResult {
+  name: string;
+  layers: LayerReport[];
+  errors: number;
+  warnings: number;
+  ok: boolean;
+}
+
+export interface CheckCommandOptions {
+  /** Warnings fail too. The right default for CI on a shared catalog. */
+  strict?: boolean;
+  /**
+   * Judge the directory as this layer even if it has not declared itself one.
+   *
+   * The single thing detection cannot recover: intent. Everything else is on disk,
+   * but "I am building toward a template and have not added the opt-in yet" is not.
+   */
+  as?: CheckLayer;
+  /** Report only this layer. Its exit code then ignores the others. */
+  only?: CheckLayer;
+  json: boolean;
+}
+
+/** Every file under `dir`, keyed by POSIX path relative to it. */
+const readDirectoryFiles = async (dir: string): Promise<PackageFiles> => {
+  const files: PackageFiles = new Map();
+  const walk = async (current: string): Promise<void> => {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      // A vendored copy is not something this directory publishes, and `.git` holds
+      // object blobs that would be scanned as if they were source.
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      const absolute = join(current, entry.name);
+      // `stat`, not the dirent: a symlink reports as neither, and skill repositories
+      // use them to share one directory between several client layouts.
+      const info = await stat(absolute).catch(() => null);
+      if (!info) continue;
+      if (info.isDirectory()) await walk(absolute);
+      else if (info.isFile()) {
+        files.set(relative(dir, absolute).split(sep).join("/"), await readFile(absolute));
+      }
+    }
+  };
+  await walk(dir);
+  return files;
+};
+
+const text = (bytes: Buffer | undefined): string | undefined => bytes?.toString("utf8");
+
+/**
+ * Assemble one AirApp's sources the way `checkAirApp` documents they must be assembled.
+ *
+ * Both traps here were hit for real against shipped apps before this collector existed:
+ *
+ * - **The server is the whole subtree.** A `server.js` that mounts `server/hono.ts` keeps
+ *   the runtime route in the module, so reading only the entry reported two correct apps
+ *   as missing it entirely.
+ * - **`app/vendor/` is excluded.** A bundled `busabase-sdk` legitimately builds an
+ *   `Authorization: Bearer …` header, so sweeping it in reports every app that bundles
+ *   the SDK as leaking a credential.
+ *
+ * The logic/downloads split is inherited from the scaffold's own gate and is equally
+ * load-bearing: structural rules run over the app's logic files only, because an
+ * asset-path or hostname rule false-positives on UI copy; credentials are scanned over
+ * everything the browser receives, because a key in a string table ships just the same.
+ */
+const airAppSources = (
+  files: readonly { path: string; bytes: Buffer }[],
+  slug: string,
+): AirAppSources => {
+  const at = (path: string) => files.find((file) => file.path === path)?.bytes;
+  const join_ = (predicate: (path: string) => boolean) =>
+    files
+      .filter((file) => predicate(file.path))
+      .map((file) => file.bytes.toString("utf8"))
+      .join("\n");
+
+  const isVendor = (path: string) => path.startsWith("app/vendor/");
+  const isLogic = (path: string) =>
+    !isVendor(path) &&
+    (/^app\/js\/(?:app|config|busabase-client|runtime)\.[jt]s$/.test(path) ||
+      /^app\/js\/providers\/busabase-provider\.[jt]s$/.test(path) ||
+      /^lib\/.*\.[jt]s$/.test(path));
+  const isDownload = (path: string) =>
+    !isVendor(path) && (path === "app/index.html" || /^app\/(?:js|i18n)\/.*\.[jt]s$/.test(path));
+  const isServer = (path: string) =>
+    path === "server.js" || path === "server.py" || /^server\//.test(path);
+
+  const server = join_(isServer);
+  return {
+    packageJson: text(at("package.json")),
+    ...(server ? { server } : {}),
+    serverLanguage: files.some((file) => file.path === "server.py") ? "python" : "node",
+    browserLogic: join_(isLogic),
+    browserDownloads: join_(isDownload),
+    ...(text(at("app/js/config.js")) !== undefined ? { config: text(at("app/js/config.js")) } : {}),
+    shippedSlug: slug,
+  };
+};
+
+const airApps = (
+  tree: PackageTree,
+): { slug: string; files: { path: string; bytes: Buffer }[] }[] => {
+  const found: { slug: string; files: { path: string; bytes: Buffer }[] }[] = [];
+  const visit = (nodes: PackageTree["nodes"]): void => {
+    for (const node of nodes) {
+      if (node.type === "airapp") found.push({ slug: node.slug, files: node.files });
+      else if (node.type === "folder") visit(node.children);
+    }
+  };
+  visit(tree.nodes);
+  return found;
+};
+
+/** Run every applicable layer over one directory. */
+export const checkDirectory = async (
+  dir: string,
+  options: Pick<CheckCommandOptions, "as" | "only"> = {},
+): Promise<CheckResult> => {
+  const root = resolve(dir);
+  const name = basename(root);
+  const files = await readDirectoryFiles(root);
+  const layers: LayerReport[] = [];
+  const wanted = (layer: CheckLayer) => options.only === undefined || options.only === layer;
+
+  const skip = (layer: CheckLayer, note: string) => {
+    if (wanted(layer)) layers.push({ layer, applicable: false, note, findings: [] });
+  };
+
+  if (!files.has("busabase.json")) {
+    // Without a manifest there is no tree to read, so every layer that needs one is
+    // out. A directory holding only a SKILL.md is a perfectly ordinary Agent Skill.
+    skip("package", "no busabase.json");
+    skip("template", "not a package");
+    skip("airapp", "not a package");
+    if (wanted("skill")) {
+      layers.push(
+        files.has("SKILL.md")
+          ? {
+              layer: "skill",
+              applicable: true,
+              note: "standalone Agent Skill",
+              findings: auditSkill(files),
+            }
+          : { layer: "skill", applicable: false, note: "no SKILL.md", findings: [] },
+      );
+    }
+    return summarise(name, layers, options);
+  }
+
+  let tree: PackageTree;
+  try {
+    tree = readPackageTree(files);
+  } catch (cause) {
+    return summarise(
+      name,
+      [
+        {
+          layer: "package",
+          applicable: true,
+          findings: [
+            {
+              severity: "error",
+              rule: "package/unreadable",
+              message: (cause as Error).message,
+            },
+          ],
+        },
+      ],
+      options,
+    );
+  }
+
+  if (wanted("package")) {
+    layers.push({
+      layer: "package",
+      applicable: true,
+      findings: auditPackage(tree, files, { directoryName: name }),
+    });
+  }
+
+  if (wanted("skill")) {
+    if (tree.rootSkill === undefined && options.as !== "skill") {
+      skip("skill", "no root SKILL.md");
+    } else {
+      layers.push({ layer: "skill", applicable: true, findings: auditSkill(files) });
+    }
+  }
+
+  if (wanted("template")) {
+    const declared = tree.rootSkill !== undefined;
+    if (!declared && options.as !== "template") {
+      skip("template", "no root SKILL.md");
+    } else {
+      const validation = validateTemplate(tree);
+      layers.push({
+        layer: "template",
+        applicable: true,
+        note: validation.ok ? "declared, qualifies" : undefined,
+        findings: [
+          ...validation.errors.map((message) => ({
+            severity: "error" as const,
+            rule: "template/invalid",
+            message,
+          })),
+          ...validation.warnings.map((message) => ({
+            severity: "warning" as const,
+            rule: "template/incomplete",
+            message,
+          })),
+        ],
+      });
+    }
+  }
+
+  if (wanted("airapp")) {
+    const apps = airApps(tree);
+    if (apps.length === 0) {
+      skip("airapp", "no AirApp under content/");
+    } else {
+      for (const app of apps) {
+        layers.push({
+          layer: "airapp",
+          applicable: true,
+          subject: app.slug,
+          findings: checkAirApp(airAppSources(app.files, app.slug)),
+        });
+      }
+    }
+  }
+
+  return summarise(name, layers, options);
+};
+
+const summarise = (
+  name: string,
+  layers: LayerReport[],
+  _options: Pick<CheckCommandOptions, "as" | "only">,
+): CheckResult => {
+  // Reported in a fixed order, never the order the checks happened to run in — a
+  // reader comparing two directories should not have to re-find each layer.
+  layers.sort(
+    (left, right) => CHECK_LAYERS.indexOf(left.layer) - CHECK_LAYERS.indexOf(right.layer),
+  );
+  let errors = 0;
+  let warnings = 0;
+  for (const layer of layers) {
+    for (const finding of layer.findings) {
+      if (finding.severity === "error") errors += 1;
+      else warnings += 1;
+    }
+  }
+  return { name, layers, errors, warnings, ok: errors === 0 };
+};
+
+const LAYER_WIDTH = Math.max(...CHECK_LAYERS.map((layer) => layer.length));
+
+export const formatCheck = (results: CheckResult[], strict: boolean): string => {
+  const lines: string[] = [];
+  let errors = 0;
+  let warnings = 0;
+  for (const result of results) {
+    errors += result.errors;
+    warnings += result.warnings;
+    lines.push(result.name);
+    for (const layer of result.layers) {
+      const label = layer.layer.padEnd(LAYER_WIDTH);
+      if (!layer.applicable) {
+        lines.push(`  ${label} –     ${layer.note ?? ""}`.trimEnd());
+        continue;
+      }
+      const bad = layer.findings.filter((finding) => finding.severity === "error").length;
+      const soft = layer.findings.length - bad;
+      const mark = bad > 0 ? "✗" : soft > 0 ? "!" : "✓";
+      const counts = [
+        bad > 0 ? `${bad} error${bad === 1 ? "" : "s"}` : "",
+        soft > 0 ? `${soft} warning${soft === 1 ? "" : "s"}` : "",
+      ]
+        .filter(Boolean)
+        .join(", ");
+      lines.push(
+        `  ${label} ${mark}     ${[counts, layer.subject, layer.note].filter(Boolean).join("  ")}`.trimEnd(),
+      );
+      for (const finding of layer.findings) {
+        lines.push(
+          `     ${finding.severity === "error" ? "✗" : "!"} [${finding.rule}] ${finding.message}`,
+        );
+      }
+    }
+    lines.push("");
+  }
+  lines.push(
+    `${results.length} directory(ies): ${errors} error(s), ${warnings} warning(s)${
+      strict ? " (--strict: warnings fail)" : ""
+    }.`,
+  );
+  return lines.join("\n");
+};
+
+/**
+ * A repository of templates is anything with a `templates/` directory; every entry under
+ * it is checked. Otherwise the argument is one directory.
+ */
+const resolveTargets = async (dir: string): Promise<string[]> => {
+  const root = resolve(dir);
+  const templates = join(root, "templates");
+  if (
+    await stat(templates).then(
+      () => true,
+      () => false,
+    )
+  ) {
+    const entries = await readdir(templates, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(templates, entry.name));
+  }
+  return [root];
+};
+
+export const runCheck = async (dir: string, options: CheckCommandOptions): Promise<unknown> => {
+  const targets = await resolveTargets(dir);
+  const results: CheckResult[] = [];
+  for (const target of targets) results.push(await checkDirectory(target, options));
+
+  const errors = results.reduce((total, result) => total + result.errors, 0);
+  const warnings = results.reduce((total, result) => total + result.warnings, 0);
+  const ok = errors === 0 && (!options.strict || warnings === 0);
+  if (!ok) process.exitCode = 1;
+  return options.json ? { ok, results } : formatCheck(results, Boolean(options.strict));
+};

--- a/apps/busabase-cli/src/package/commands.test.ts
+++ b/apps/busabase-cli/src/package/commands.test.ts
@@ -1,0 +1,72 @@
+/**
+ * `install <source>` reads a GitHub URL (unchanged) or, now, a local
+ * directory / `file://` URL — the exact output `busabase-cli export` writes.
+ * Covers only the source-resolution split; `resolvePackageSource`'s GitHub
+ * branch is exercised elsewhere (server-side install tests already fetch a
+ * synthetic zipball), so this stays scoped to what changed: telling a path
+ * apart from a URL, and reading a real directory from disk.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isLocalPackageSource, resolvePackageSource } from "./commands";
+
+describe("isLocalPackageSource", () => {
+  it("treats http(s) URLs as GitHub sources", () => {
+    expect(isLocalPackageSource("https://github.com/acme/support-kb-template")).toBe(false);
+    expect(isLocalPackageSource("http://github.com/acme/support-kb-template")).toBe(false);
+  });
+
+  it("treats a bare or relative filesystem path as local", () => {
+    expect(isLocalPackageSource("./support-kb-template")).toBe(true);
+    expect(isLocalPackageSource("../export-out")).toBe(true);
+    expect(isLocalPackageSource("/tmp/support-kb-template")).toBe(true);
+    expect(isLocalPackageSource("support-kb-template")).toBe(true);
+  });
+
+  it("treats a file:// URL as local", () => {
+    expect(isLocalPackageSource("file:///tmp/support-kb-template")).toBe(true);
+  });
+
+  it("does not mistake any other scheme for a local path or accept it as GitHub", () => {
+    // Neither branch should silently swallow an unexpected scheme — the
+    // GitHub path already rejects non-github.com hosts; a non-http(s) scheme
+    // reaching `isLocalPackageSource` should read as local so `readDirectoryFiles`
+    // (not a silent host-allowlist bypass) is what reports it's not a real path.
+    expect(isLocalPackageSource("git://github.com/acme/support-kb-template")).toBe(true);
+  });
+});
+
+describe("resolvePackageSource — local directory", () => {
+  let dir: string;
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("reads every file under a local directory, keyed by its relative POSIX path", async () => {
+    dir = await mkdtemp(join(tmpdir(), "busabase-install-local-"));
+    await writeFile(join(dir, "busabase.json"), JSON.stringify({ format: "busabase-package@1" }));
+    await mkdir(join(dir, "content", "blog"), { recursive: true });
+    await writeFile(join(dir, "content", "blog", "base.json"), "{}");
+
+    const resolved = await resolvePackageSource(dir, {});
+    expect(resolved.github).toBeUndefined();
+    expect(resolved.label).toBe(dir);
+    expect([...resolved.files.keys()].sort()).toEqual(["busabase.json", "content/blog/base.json"]);
+  });
+
+  it("reads the same directory via a file:// URL", async () => {
+    dir = await mkdtemp(join(tmpdir(), "busabase-install-local-"));
+    await writeFile(join(dir, "busabase.json"), "{}");
+
+    const resolved = await resolvePackageSource(`file://${dir}`, {});
+    expect(resolved.files.has("busabase.json")).toBe(true);
+  });
+
+  it("errors clearly on an empty or missing directory instead of installing nothing", async () => {
+    dir = await mkdtemp(join(tmpdir(), "busabase-install-local-empty-"));
+    await expect(resolvePackageSource(dir, {})).rejects.toThrow(/No files found under/);
+  });
+});

--- a/apps/busabase-cli/src/package/commands.ts
+++ b/apps/busabase-cli/src/package/commands.ts
@@ -4,6 +4,7 @@
  */
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   PACKAGE_SKILL_ENTRY,
   TemplateManifestSchema,
@@ -17,7 +18,7 @@ import {
 import { applyInstall } from "busabase-package/apply";
 import { collectPackageTree, findSourceNode } from "busabase-package/collect";
 import { type DiscoveredPackage, resolvePackageToInstall } from "busabase-package/discover";
-import { fetchGithubPackageFiles } from "busabase-package/github";
+import { fetchGithubPackageFiles, type ParsedGithubUrl } from "busabase-package/github";
 import { buildTemplateIndex, renderTemplateIndex } from "busabase-package/index-build";
 import { readPackageTree } from "busabase-package/layout-read";
 import { renderPackageTree, writePackageFiles } from "busabase-package/layout-write";
@@ -65,16 +66,61 @@ export interface InstallCommandOptions {
   noSampleRecords?: boolean;
 }
 
+/**
+ * `install <source>` accepts a GitHub repo URL (unchanged) or, for local
+ * package-authoring/testing, a directory on disk or a `file://` URL to one —
+ * the exact output `busabase-cli export` writes. `new URL(...)` throws on a
+ * bare/relative filesystem path (no scheme), which is what makes a path fall
+ * through to "local" here without needing its own flag.
+ */
+export const isLocalPackageSource = (raw: string): boolean => {
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    return true;
+  }
+  return url.protocol !== "http:" && url.protocol !== "https:";
+};
+
+interface ResolvedPackageSource {
+  /** Human-readable origin for progress messages and re-suggested commands. */
+  label: string;
+  files: Map<string, Buffer>;
+  /** Set only for a GitHub source — a local install has no repo/ref to stamp. */
+  github?: ParsedGithubUrl;
+}
+
+export const resolvePackageSource = async (
+  rawSource: string,
+  options: { githubToken?: string },
+): Promise<ResolvedPackageSource> => {
+  if (!isLocalPackageSource(rawSource)) {
+    const { source, files } = await fetchGithubPackageFiles(rawSource, {
+      githubToken: options.githubToken,
+    });
+    return { label: `${source.owner}/${source.repo}`, files, github: source };
+  }
+  const dir = rawSource.trim().startsWith("file://") ? fileURLToPath(rawSource.trim()) : rawSource;
+  const files = await readDirectoryFiles(dir);
+  if (files.size === 0) {
+    throw new Error(
+      `No files found under "${dir}". Expected a package directory written by \`busabase-cli export\` (a busabase.json at its root).`,
+    );
+  }
+  return { label: dir, files };
+};
+
 export const runInstall = async (
   client: BusabaseClient,
   repoUrl: string,
   options: InstallCommandOptions,
 ): Promise<unknown> => {
-  reportProgress(`Fetching ${repoUrl} …`);
-  const { source, files } = await fetchGithubPackageFiles(repoUrl, {
+  reportProgress(`Reading ${repoUrl} …`);
+  const { label, files, github } = await resolvePackageSource(repoUrl, {
     githubToken: options.githubToken,
   });
-  reportProgress(`Downloaded ${files.size} file(s) from ${source.owner}/${source.repo}.`);
+  reportProgress(`Loaded ${files.size} file(s) from ${label}.`);
 
   // The zip extractor already stripped the archive root and the addressed subdir,
   // so a package's manifest sits at the root of what we hold — but the URL may
@@ -122,12 +168,11 @@ export const runInstall = async (
     serverUrl: options.serverUrl,
     installSampleRecords: !options.noSampleRecords,
     source: {
-      repo: `${source.owner}/${source.repo}`,
-      ref: source.ref,
+      ...(github ? { repo: `${github.owner}/${github.repo}`, ref: github.ref } : {}),
       ...(resolved.subdir
         ? { subdir: resolved.subdir }
-        : source.subdir
-          ? { subdir: source.subdir }
+        : github?.subdir
+          ? { subdir: github.subdir }
           : {}),
     },
   });

--- a/apps/busabase-cli/src/run.ts
+++ b/apps/busabase-cli/src/run.ts
@@ -46,6 +46,7 @@ import {
   runLogout,
   runRefresh,
 } from "./login.js";
+import { type CheckLayer, runCheck } from "./package/check.js";
 import { runExport, runIndex, runInstall } from "./package/commands.js";
 import { paginateAll } from "./paginate.js";
 import { withRetry } from "./retry.js";
@@ -1707,8 +1708,13 @@ Examples:
     );
 
   addGlobalFlags(program.command("install"))
-    .description("Install a Busabase package from a GitHub repo into this space")
-    .argument("<github-url>", "GitHub repo URL, optionally /tree/<ref>[/<subdir>]")
+    .description(
+      "Install a Busabase package from a GitHub repo or a local directory into this space",
+    )
+    .argument(
+      "<source>",
+      "GitHub repo URL (optionally /tree/<ref>[/<subdir>]), or a local directory / file:// URL written by `busabase-cli export`",
+    )
     .option("--into-folder <name>", "target folder slug (default: the package's manifest name)")
     .option("--dry-run", "print the plan (tree, record counts, collisions) and create nothing")
     .option(
@@ -1733,11 +1739,17 @@ Examples:
 The URL's git ref is the version pin — a tag installs that tag's content forever,
 even after the branch moves on. GITHUB_TOKEN is honored for private repos.
 
+A local directory or a \`file://\` URL installs straight from disk instead of
+GitHub — the same package \`busabase-cli export\` just wrote, useful for
+authoring/testing a package before it has anywhere to be pushed. Anything that
+is not an http(s):// URL is read as a local path.
+
 Examples:
   busabase-cli install https://github.com/acme/support-kb-template
   busabase-cli install https://github.com/acme/packages/tree/v1.2.0/skills/pdf-summarizer
   busabase-cli install https://github.com/acme/support-kb-template --dry-run
   busabase-cli install https://github.com/acme/support-kb-template --into-folder support --auto-merge
+  busabase-cli install ./support-kb-template --dry-run
 
 Folders, Bases, their fields and their views are structure and are always created
 immediately. Records are content: by default they land as change requests for you
@@ -1771,6 +1783,42 @@ field with nothing linked yet does not trigger this.`,
           json: config.output === "json",
           githubToken: process.env.GITHUB_TOKEN,
           serverUrl: config.baseUrl,
+        }),
+      ),
+    );
+
+  addGlobalFlags(program.command("check"))
+    .description("Check a package / Skill / template / AirApp directory against its contract")
+    .argument("[dir]", "directory to check, or a repo with a templates/ subdirectory", ".")
+    .option("--strict", "warnings fail too")
+    .option("--as <layer>", "judge it as this layer even if it has not declared itself one")
+    .option("--only <layer>", "report only this layer (package | skill | template | airapp)")
+    .addHelpText(
+      "after",
+      `
+Four things can be true of one directory and they are not four rungs of a ladder:
+a package installs resources, an Agent Skill is a manual an agent reads, a template
+is a directory that is both plus an explicit opt-in, and an AirApp is a node type
+that ships inside a package. Each applicable layer is reported separately.
+
+A layer that does not apply reports "-", never a tick: "not applicable" and "passed"
+must not look the same.
+
+This checks one directory. Whether a repository's catalog file is current is a
+different question, answered by \`busabase-cli index --check\`.
+
+Examples:
+  busabase-cli check .
+  busabase-cli check . --strict
+  busabase-cli check ./templates/busa-email --only airapp`,
+    )
+    .action(
+      runLocalArgAction((dir, opts, config) =>
+        runCheck(dir, {
+          strict: Boolean(opts.strict),
+          as: opts.as as CheckLayer | undefined,
+          only: opts.only as CheckLayer | undefined,
+          json: config.output === "json",
         }),
       ),
     );
@@ -1894,13 +1942,20 @@ which writes a readable, diffable package directory you can push to GitHub.`,
       `
 The archive's checksum is verified before a single row is written, and the target
 space must be EMPTY — a restore replays original ids, so it cannot merge into a
-space that already holds content.
+space that already holds content. Those ids are also unique across the whole
+database, not just the target space: restore only into a database where the
+archive's ids have never been used before (disaster recovery into a fresh
+database, or back into the space it came from after that space's own data was
+removed). Restoring into a different space while the SOURCE space is still live
+in the same database will fail — its rows already hold those ids.
 
 Examples:
   busabase-cli restore ./space.bbdump
   busabase-cli restore ./backups/acme-2026-07-19.bbdump --space-id spc_123
 
-To add content to a space that is already in use, use \`busabase-cli install\` instead.`,
+To add content to a space that is already in use, use \`busabase-cli install\` instead.
+To copy a still-live space's current content into another space, use
+\`busabase-cli export\` + \`busabase-cli install\` instead of backup/restore.`,
     )
     .action(
       runArgAction(state, (file, client, opts, config) =>
@@ -2051,7 +2106,11 @@ export async function runCli(argv: string[]): Promise<number> {
   }
   try {
     await program.parseAsync(argv, { from: "user" });
-    return 0;
+    // A command that ran fine but reached a failing verdict says so through
+    // `process.exitCode` rather than by throwing. `check` reporting findings is not an
+    // error — throwing would route it through the error envelope and, under `--json`,
+    // put a second JSON document on stdout after the findings CI came for.
+    return typeof process.exitCode === "number" ? process.exitCode : 0;
   } catch (error) {
     const json = errorOutputIsJson(state, argv);
     if (error instanceof CommanderError) {

--- a/apps/busabase-cli/tsconfig.json
+++ b/apps/busabase-cli/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "types": ["node"],
     "paths": {
-      "busabase-sdk": ["../busabase-sdk/src/index.ts"]
+      "busabase-sdk": ["../busabase-sdk/src/index.ts"],
+      "busabase-sdk/*": ["../busabase-sdk/src/*.ts"]
     }
   },
   "include": ["src/**/*.ts", "tsup.config.ts"]

--- a/apps/busabase-cli/vitest.config.ts
+++ b/apps/busabase-cli/vitest.config.ts
@@ -3,13 +3,24 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
-    alias: {
-      // The workspace `busabase-sdk` package resolves to its built `dist/`, which
-      // isn't present during a source test run. Point at the SDK source so CLI
-      // tests exercise the real client without a build step (the SDK's own deps
-      // — busabase-contract, @orpc/* — resolve to source / node_modules).
-      "busabase-sdk": path.resolve(__dirname, "../busabase-sdk/src/index.ts"),
-    },
+    // An array, and the subpath entry first, because a bare string `find` is a PREFIX
+    // match: mapping "busabase-sdk" to `src/index.ts` silently rewrote
+    // `busabase-sdk/airapp-check` to `src/index.ts/airapp-check` and failed with
+    // ENOTDIR. Every subpath the SDK exports has to resolve to its own source file.
+    alias: [
+      {
+        // The workspace `busabase-sdk` package resolves to its built `dist/`, which
+        // isn't present during a source test run. Point at the SDK source so CLI tests
+        // exercise the real client without a build step (the SDK's own deps —
+        // busabase-contract, @orpc/* — resolve to source / node_modules).
+        find: /^busabase-sdk\/(.+)$/,
+        replacement: path.resolve(__dirname, "../busabase-sdk/src/$1.ts"),
+      },
+      {
+        find: /^busabase-sdk$/,
+        replacement: path.resolve(__dirname, "../busabase-sdk/src/index.ts"),
+      },
+    ],
   },
   test: {
     environment: "node",

--- a/apps/busabase-desktop/package.json
+++ b/apps/busabase-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@busabase/desktop",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --port 3064",
@@ -20,7 +20,7 @@
     "@tauri-apps/plugin-updater": "^2.10.1",
     "busabase-core": "workspace:*",
     "kui": "workspace:*",
-    "lucide-react": "^0.556.0",
+    "lucide-react": "^1.34.0",
     "next": "16.3.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/busabase-desktop/src-tauri/Cargo.lock
+++ b/apps/busabase-desktop/src-tauri/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "busabase_desktop"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "semver",
  "serde",

--- a/apps/busabase-desktop/src-tauri/Cargo.toml
+++ b/apps/busabase-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busabase_desktop"
-version = "0.20.0"
+version = "0.21.0"
 description = "Busabase Desktop - private local-first Busabase knowledge base shell"
 authors = ["Busabase Team"]
 edition = "2021"

--- a/apps/busabase-desktop/src-tauri/tauri.conf.json
+++ b/apps/busabase-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Busabase Desktop",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "identifier": "com.busabase.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/busabase-mobile/app.json
+++ b/apps/busabase-mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Busabase",
     "slug": "busabase-mobile",
     "scheme": "busabase",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/busabase-mobile/app/index.tsx
+++ b/apps/busabase-mobile/app/index.tsx
@@ -127,7 +127,7 @@ export default function ConnectionScreen() {
             <RotatingHeroHeadline compact={isCompact} short={isShortLandscape} />
             {isShortLandscape ? null : (
               <Text style={[typography.body, styles.subtitle, { color: tokens.mutedForeground }]}>
-                Turn agent chaos into one database you can actually use.
+                Turn agent output into one database you can actually use.
               </Text>
             )}
           </View>

--- a/apps/busabase-mobile/package.json
+++ b/apps/busabase-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-mobile",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "main": "expo-router/entry",
   "private": true,
   "scripts": {

--- a/apps/busabase-sdk/package.json
+++ b/apps/busabase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-sdk",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Typed TypeScript/JavaScript SDK for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server` (or Busabase Cloud).",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-sdk",
@@ -34,6 +34,10 @@
     "./airapp-node": {
       "types": "./dist/airapp-node.d.ts",
       "default": "./dist/airapp-node.js"
+    },
+    "./airapp-check": {
+      "types": "./dist/airapp-check.d.ts",
+      "default": "./dist/airapp-check.js"
     },
     "./airapp": {
       "types": "./dist/airapp.d.ts",

--- a/apps/busabase-sdk/src/airapp-check.test.ts
+++ b/apps/busabase-sdk/src/airapp-check.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Every rule has to do two things: stay silent on a correct AirApp, and fire on the
+ * one mistake it exists for. A rule set only tested against a passing fixture is
+ * indistinguishable from `() => []`.
+ *
+ * Each case starts from the same valid sources and breaks exactly one thing.
+ */
+import { describe, expect, it } from "vitest";
+
+import { type AirAppSources, checkAirApp, scanAirAppConfig, stripComments } from "./airapp-check";
+
+const PACKAGE_JSON = JSON.stringify({
+  name: "my-desk-airapp",
+  private: true,
+  type: "module",
+  scripts: { dev: "node server.js", start: "node server.js", check: "node scripts/check.mjs" },
+  dependencies: { "@hono/node-server": "2.0.8", "busabase-sdk": "0.20.0", hono: "4.12.29" },
+});
+
+const SERVER = `
+import { serve } from "@hono/node-server";
+const airappRuntime = (process.env.BUSABASE_AIRAPP_RUNTIME || "").trim();
+app.get("/__airapp/runtime", (context) =>
+  context.json({ runtime: airappRuntime || "standalone", hosted: airappRuntime !== "" }),
+);
+serve(app);
+`;
+
+const BROWSER_LOGIC = `
+import { createBusabaseClient } from "busabase-sdk";
+const client = createBusabaseClient({ baseUrl: window.location.origin });
+export async function getRuntime() {
+  const response = await fetch("__airapp/runtime", { headers: { accept: "application/json" } });
+  return response.json();
+}
+const rows = await client.records.list({ baseId, limit: base.readLimit });
+`;
+
+const BROWSER_DOWNLOADS = `${BROWSER_LOGIC}\n<html><body><script type="module" src="js/app.js"></script></body></html>`;
+
+const CONFIG = `
+export const appConfig = {
+  appId: "my-desk",
+  airApp: { name: "My Desk", slug: "my-desk-app", resourceKey: "my-desk-app" },
+  bases: [
+    { key: "reviews", slug: "my-desk-reviews", name: "Reviews", readLimit: 50, fields: [] },
+  ],
+  drive: { slug: "my-desk-files", name: "Files" },
+};
+`;
+
+const sources = (overrides: Partial<AirAppSources> = {}): AirAppSources => ({
+  packageJson: PACKAGE_JSON,
+  server: SERVER,
+  serverLanguage: "node",
+  browserLogic: BROWSER_LOGIC,
+  browserDownloads: BROWSER_DOWNLOADS,
+  config: CONFIG,
+  shippedSlug: "my-desk-app",
+  ...overrides,
+});
+
+const rules = (input: AirAppSources, severity: "error" | "warning" = "error") =>
+  checkAirApp(input)
+    .filter((finding) => finding.severity === severity)
+    .map((finding) => finding.rule);
+
+describe("a correct AirApp", () => {
+  it("reports no errors", () => {
+    expect(rules(sources())).toEqual([]);
+  });
+
+  it("reports no warnings either, so warnings stay meaningful", () => {
+    expect(rules(sources(), "warning")).toEqual([]);
+  });
+
+  it("checks only what it was given", () => {
+    expect(checkAirApp({})).toEqual([]);
+  });
+});
+
+describe("the app can boot", () => {
+  it("catches a missing dev script", () => {
+    const packageJson = JSON.stringify({ scripts: { start: "node server.js" } });
+    expect(rules(sources({ packageJson }))).toContain("airapp/dev-script");
+  });
+
+  it("catches a start script that builds", () => {
+    const packageJson = JSON.stringify({
+      scripts: { dev: "node server.js", start: "npm run build && node server.js" },
+    });
+    expect(rules(sources({ packageJson }))).toContain("airapp/start-pure");
+  });
+
+  it("catches an SDK version range", () => {
+    const packageJson = JSON.stringify({
+      scripts: { dev: "node server.js" },
+      dependencies: { "busabase-sdk": "^0.20.0" },
+    });
+    expect(rules(sources({ packageJson }))).toContain("airapp/sdk-pin");
+  });
+
+  it("catches a framework dependency", () => {
+    const packageJson = JSON.stringify({
+      scripts: { dev: "node server.js" },
+      dependencies: { "busabase-sdk": "0.20.0", react: "19.0.0" },
+    });
+    expect(rules(sources({ packageJson }))).toContain("airapp/no-framework");
+  });
+
+  it("reports invalid JSON rather than throwing", () => {
+    expect(rules(sources({ packageJson: "{ not json" }))).toContain("airapp/package-json");
+  });
+});
+
+describe("browser code targets its own origin", () => {
+  it("catches the obsolete bridge prefix", () => {
+    const browserLogic = `${BROWSER_LOGIC}\nfetch("/__busabase_api__/v1/records");`;
+    expect(rules(sources({ browserLogic }))).toContain("airapp/legacy-bridge");
+  });
+
+  it("catches a hard-coded absolute Busabase URL", () => {
+    const browserLogic = BROWSER_LOGIC.replace(
+      "baseUrl: window.location.origin",
+      'baseUrl: "https://busabase.com"',
+    );
+    expect(rules(sources({ browserLogic }))).toContain("airapp/absolute-url");
+  });
+
+  it("catches an absolute asset path", () => {
+    const browserLogic = `${BROWSER_LOGIC}\nimport { x } from "/js/util.js";`;
+    expect(rules(sources({ browserLogic }))).toContain("airapp/absolute-asset");
+  });
+
+  it("does not flag an absolute /api/v1 call, which is not an asset", () => {
+    const browserLogic = `${BROWSER_LOGIC}\nawait fetch("/api/v1/records");`;
+    expect(rules(sources({ browserLogic }))).not.toContain("airapp/absolute-asset");
+  });
+
+  /**
+   * The real fleet shape this rule exists for: a capped loop that still fetches
+   * several pages in one call, called unconditionally at initial load. A default
+   * parameter cap does not fix the "hidden behind one loading state" violation —
+   * it only bounds how bad it gets. Observed shape: up to 20 pages x 100 records.
+   */
+  it("catches a capped loop that fetches several pages in one call", () => {
+    const browserLogic = `
+${BROWSER_LOGIC}
+async function readAllRecords(key, { maxPages = 20 } = {}) {
+  let cursor;
+  for (let page = 0; page < maxPages; page += 1) {
+    const result = await client.records.list({ baseId, limit: 100, ...(cursor ? { cursor } : {}) });
+    cursor = result.nextCursor;
+    if (!cursor) break;
+  }
+}
+`;
+    expect(rules(sources({ browserLogic }))).toContain("airapp/eager-multi-page");
+  });
+
+  /** The scaffold's own shape must never trip this: one page per call, no loop. */
+  it("does not flag a single-page read with no loop", () => {
+    const browserLogic = `
+${BROWSER_LOGIC}
+const readPage = async (client, base, cursor) => {
+  const page = await client.records.list({ baseId: base.baseId, limit: base.readLimit, ...(cursor ? { cursor } : {}) });
+  return { records: page.records, nextCursor: page.nextCursor || null };
+};
+`;
+    expect(rules(sources({ browserLogic }))).not.toContain("airapp/eager-multi-page");
+  });
+
+  /**
+   * A `while (true)` loop with cycle detection instead of an exit-when-truthy
+   * cursor check is the same unbounded shape with the condition inverted. Found
+   * in the real fleet: `while (true) { … if (!nextCursor) return …; }`.
+   */
+  it("catches a while(true) page loop that never bounds the count", () => {
+    const browserLogic = `
+${BROWSER_LOGIC}
+async function readAllPages(client, base) {
+  let cursor;
+  while (true) {
+    const page = await client.records.list({ baseId: base.baseId, ...(cursor ? { cursor } : {}) });
+    if (!page.nextCursor) return;
+    cursor = page.nextCursor;
+  }
+}
+`;
+    expect(rules(sources({ browserLogic }))).toContain("airapp/unbounded-read");
+  });
+
+  it("does not flag an unrelated while(true) loop that reads no pages", () => {
+    const browserLogic = `${BROWSER_LOGIC}\nwhile (true) { if (isReady()) break; await sleep(10); }`;
+    expect(rules(sources({ browserLogic }))).not.toContain("airapp/unbounded-read");
+  });
+
+  it("catches unbounded loading", () => {
+    const browserLogic = `${BROWSER_LOGIC}\nwhile (cursor) { page = await next(cursor); }`;
+    expect(rules(sources({ browserLogic }))).toContain("airapp/unbounded-read");
+  });
+});
+
+describe("runtime detection", () => {
+  it("catches hostname sniffing", () => {
+    const browserLogic = `${BROWSER_LOGIC}\nconst hosted = location.hostname !== "localhost";`;
+    expect(rules(sources({ browserLogic }))).toContain("airapp/runtime-hostname");
+  });
+
+  it("catches a loopback comparison", () => {
+    const browserLogic = `${BROWSER_LOGIC}\nconst local = url.includes("127.0.0.1");`;
+    expect(rules(sources({ browserLogic }))).toContain("airapp/runtime-loopback");
+  });
+
+  /**
+   * The guard that exists because prose about a rule was satisfying the rule — in
+   * both directions. A comment may name `localhost` while explaining why no code
+   * may test for it.
+   */
+  it("does not flag a comment that explains the hostname rule", () => {
+    const browserLogic = `// Never compare against localhost: both directions are wrong.\n${BROWSER_LOGIC}`;
+    const reported = rules(sources({ browserLogic }));
+    expect(reported).not.toContain("airapp/runtime-hostname");
+    expect(reported).not.toContain("airapp/runtime-loopback");
+  });
+
+  /**
+   * An app that never branches on where it is running — always calling /api/v1 on its
+   * own origin, letting its dev server proxy when standalone — has nothing to ask.
+   * Requiring a probe anyway told a correctly-designed shipped template it was broken.
+   */
+  it("does not require a probe from an app that never branches", () => {
+    const browserLogic = `
+import { createBusabaseClient } from "busabase-sdk";
+const client = createBusabaseClient({ baseUrl: window.location.origin });
+const rows = await client.records.list({ baseId, limit: base.readLimit });
+`;
+    const server = 'app.get("/api/health", (c) => c.json({ ok: true }));';
+    const reported = rules(sources({ browserLogic, server }));
+    expect(reported).not.toContain("airapp/runtime-probe");
+    expect(reported).not.toContain("airapp/runtime-env");
+    expect(reported).not.toContain("airapp/runtime-route");
+  });
+
+  it("still requires one from an app that does branch", () => {
+    const browserLogic = `
+const runtime = await getRuntime();
+if (!runtime.hosted) showConnectGate();
+`;
+    const server = 'app.get("/api/health", (c) => c.json({ ok: true }));';
+    const reported = rules(sources({ browserLogic, server }));
+    expect(reported).toContain("airapp/runtime-probe");
+    expect(reported).toContain("airapp/runtime-route");
+  });
+
+  it("catches browser code that never probes the runtime", () => {
+    const browserLogic = BROWSER_LOGIC.replace('fetch("__airapp/runtime"', 'fetch("/status"');
+    expect(rules(sources({ browserLogic }))).toContain("airapp/runtime-probe");
+  });
+
+  it("catches a runtime probe with a leading slash", () => {
+    const browserLogic = BROWSER_LOGIC.replace('"__airapp/runtime"', '"/__airapp/runtime"');
+    expect(rules(sources({ browserLogic }))).toContain("airapp/runtime-probe-relative");
+  });
+
+  it("catches a server that stopped reading the injected variable", () => {
+    const server = SERVER.replace("process.env.BUSABASE_AIRAPP_RUNTIME", '""');
+    expect(rules(sources({ server }))).toContain("airapp/runtime-env");
+  });
+
+  /**
+   * The comment-stripping guard on the server side: a `server.js` that only *mentions*
+   * the variable in prose passed this gate once, which is how it stopped being read.
+   */
+  it("is not satisfied by a comment naming the variable", () => {
+    const server = `// BUSABASE_AIRAPP_RUNTIME is injected by Busabase.\napp.get("/__airapp/runtime", handler);`;
+    expect(rules(sources({ server }))).toContain("airapp/runtime-env");
+  });
+
+  it("catches hosting decided from a hardcoded engine list", () => {
+    const server = `${SERVER}\nconst AIRAPP_HOSTED_RUNTIMES = new Set(["nodepod", "local"]);`;
+    expect(rules(sources({ server }))).toContain("airapp/runtime-engine-list");
+  });
+
+  it("catches a server that does not serve the endpoint", () => {
+    const server = SERVER.replace('"/__airapp/runtime"', '"/health"');
+    expect(rules(sources({ server }))).toContain("airapp/runtime-route");
+  });
+
+  /**
+   * An app that calls the SDK helper cannot hand-write the `hosted` line at all,
+   * which is the line that has regressed twice. The rule has to recognise it.
+   */
+  it("accepts a host that uses the SDK's describeBusabaseAirAppRuntime", () => {
+    const server = `
+import { describeBusabaseAirAppRuntime } from "busabase-sdk/airapp-node";
+app.get("/__airapp/runtime", (c) => c.json(describeBusabaseAirAppRuntime()));
+`;
+    expect(rules(sources({ server }))).toEqual([]);
+  });
+
+  it("accepts a Python host reading the variable directly", () => {
+    const server = `import os\nRUNTIME = os.environ.get("BUSABASE_AIRAPP_RUNTIME", "")\nroutes = {"/__airapp/runtime": handler}\n`;
+    expect(rules(sources({ server, serverLanguage: "python" }))).toEqual([]);
+  });
+});
+
+describe("credentials", () => {
+  it("catches an API key reference in anything the browser downloads", () => {
+    const browserDownloads = `${BROWSER_DOWNLOADS}\nconst k = BUSABASE_API_KEY;`;
+    expect(rules(sources({ browserDownloads }))).toContain("airapp/credential");
+  });
+
+  /**
+   * The wider corpus matters: a key in a string table ships to the browser exactly
+   * like one in app.js, and used to pass a gate that only read the logic files.
+   */
+  it("catches a literal token pasted into a string table", () => {
+    const browserDownloads = `${BROWSER_DOWNLOADS}\nexport const messages = { auth: "Bearer sk0000111122223333" };`;
+    expect(rules(sources({ browserDownloads }))).toContain("airapp/credential");
+  });
+
+  it("catches browser code building an Authorization header at all", () => {
+    const browserDownloads = `${BROWSER_DOWNLOADS}\nheaders.authorization = \`Bearer \${token}\`;`;
+    expect(rules(sources({ browserDownloads }))).toContain("airapp/credential");
+  });
+
+  /**
+   * Comments are deliberately NOT stripped here — a key commented out still ships to
+   * the browser verbatim. So the patterns have to be precise instead: this exact
+   * comment made a real app fail against a rule that matched the bare word.
+   */
+  it("does not flag a comment that merely names a bearer token", () => {
+    const browserDownloads = `${BROWSER_DOWNLOADS}\n// base_url + bearer token (the proxy injects the AirApp's own)`;
+    expect(rules(sources({ browserDownloads }))).not.toContain("airapp/credential");
+  });
+
+  it("still flags a key that was only commented out", () => {
+    const browserDownloads = `${BROWSER_DOWNLOADS}\n// const key = BUSABASE_API_KEY;`;
+    expect(rules(sources({ browserDownloads }))).toContain("airapp/credential");
+  });
+
+  it("catches a literal Bearer token in the server", () => {
+    const server = `${SERVER}\nheaders.set("authorization", "Bearer abcd1234efgh");`;
+    expect(rules(sources({ server }))).toContain("airapp/credential");
+  });
+
+  it("allows the server to interpolate one from the environment", () => {
+    const server = `${SERVER}\nheaders.set("authorization", \`Bearer \${process.env.TOKEN}\`);`;
+    expect(rules(sources({ server }))).not.toContain("airapp/credential");
+  });
+});
+
+describe("the app's own map of the workspace", () => {
+  it("catches a resourceKey that is not the shipped slug", () => {
+    const config = CONFIG.replace('resourceKey: "my-desk-app"', 'resourceKey: "other"');
+    expect(rules(sources({ config }))).toContain("airapp/resource-key");
+  });
+
+  /**
+   * The regression this exists for: stripping workspace ids out of config took the
+   * Base slug with them, and only the app's own provisioning door broke.
+   */
+  it("catches a config Base left without a slug", () => {
+    const config = CONFIG.replace(' slug: "my-desk-reviews",', "");
+    expect(rules(sources({ config }))).toContain("airapp/base-slug");
+  });
+
+  it("catches a drive left without a slug", () => {
+    const config = CONFIG.replace('drive: { slug: "my-desk-files", ', "drive: { ");
+    expect(rules(sources({ config }))).toContain("airapp/base-slug");
+  });
+
+  it("warns about a page budget above the documented default", () => {
+    const config = CONFIG.replace("readLimit: 50", "readLimit: 500");
+    expect(rules(sources({ config }), "warning")).toContain("airapp/read-budget");
+  });
+
+  it("errors on a non-positive page budget", () => {
+    const config = CONFIG.replace("readLimit: 50", "readLimit: 0");
+    expect(rules(sources({ config }))).toContain("airapp/read-budget");
+  });
+
+  it("catches a Vault value carried in config", () => {
+    const config = `${CONFIG}\nexport const secrets = { vaultValue: "hunter2" };`;
+    expect(rules(sources({ config }))).toContain("airapp/vault-value");
+  });
+});
+
+describe("scanAirAppConfig", () => {
+  it("does not mistake a nested object for a Base", () => {
+    const scanned = scanAirAppConfig(
+      'const c = { bases: [{ key: "a", slug: "x-a", fields: [{ slug: "note" }] }] };',
+    );
+    expect(scanned.bases).toEqual([{ key: "a", slug: "x-a" }]);
+  });
+
+  it("reads the resourceKey out of the airApp block", () => {
+    expect(scanAirAppConfig(CONFIG).resourceKey).toBe("my-desk-app");
+  });
+});
+
+describe("stripComments", () => {
+  it("removes line and block comments", () => {
+    expect(stripComments("a // gone\n/* also gone */ b").replace(/\s+/g, " ").trim()).toBe("a b");
+  });
+
+  it("leaves a protocol-relative URL alone", () => {
+    expect(stripComments('const u = "https://example.com";')).toContain("https://example.com");
+  });
+});

--- a/apps/busabase-sdk/src/airapp-check.ts
+++ b/apps/busabase-sdk/src/airapp-check.ts
@@ -1,0 +1,435 @@
+/**
+ * The AirApp runtime contract, as checkable rules.
+ *
+ * These live in the SDK for one reason: **a rule and the runtime it checks must
+ * ship together.** The rules below are about `BUSABASE_AIRAPP_RUNTIME`,
+ * `__airapp/runtime`, `createBusabaseClient` and `isBusabaseAirAppHosted` — all
+ * of which are defined a few files away. Keeping the rules anywhere else means
+ * the two drift, and drift here is not hypothetical: an engine rename from
+ * `local-node` to `local` broke 66 shipped apps whose runtime detection carried
+ * its own private copy of the truth.
+ *
+ * It also makes them *reachable*. Every AirApp already depends on `busabase-sdk`
+ * at an exact pin, so an app's `scripts/check.mjs` shrinks from dozens of
+ * hand-copied assertions to reading its files and calling one function. The
+ * previous delivery mechanism was "copy these into your check script", and it
+ * reached 4 apps out of 67.
+ *
+ * Pure by design: this module reads no files, spawns nothing, and touches no
+ * network. Callers hand it source text. That keeps it usable from a CLI, from an
+ * app's own check script, and from a test, without any of them agreeing on a
+ * filesystem layout.
+ */
+
+/** Severity split: an error breaks a user of the app; a warning is a default worth defending. */
+export type AirAppFindingSeverity = "error" | "warning";
+
+export interface AirAppFinding {
+  severity: AirAppFindingSeverity;
+  /** Stable kebab-case id, so a caller can allowlist or group without matching prose. */
+  rule: string;
+  message: string;
+}
+
+export interface AirAppSources {
+  /** Raw `package.json` text. */
+  packageJson?: string;
+  /**
+   * The host's source. **Concatenate the whole server subtree**, not just the entry
+   * file — a `server.js` that mounts `server/hono.ts` keeps the runtime route in the
+   * module, and passing only the entry reports a correct app as broken. (Observed:
+   * two shipped apps failed this way against a collector that read `server.js` alone.)
+   */
+  server?: string;
+  /**
+   * Which language the host is written in. Inferred from Python syntax when omitted.
+   *
+   * NOT the AirApp *runtime* — that is the engine Busabase spawned the process in
+   * (`nodepod`, `local`, `sandock`, …), which is a value the app reports at runtime,
+   * not a property of its source. Two different things called "runtime" in one
+   * domain is how the wrong one ends up being checked.
+   */
+  serverLanguage?: "node" | "python";
+  /**
+   * The browser files that carry **logic** — app, config, client, runtime probe,
+   * the Busabase provider. The structural rules run over this corpus and no wider.
+   *
+   * Excluding string tables and demo data is deliberate rather than an oversight:
+   * an asset-path or hostname rule false-positives on UI copy that merely *talks*
+   * about localhost or shows a path in an error message.
+   */
+  browserLogic?: string;
+  /**
+   * **Everything** the browser downloads, copy and `index.html` included.
+   *
+   * Credentials are scanned over this wider corpus, because a key pasted into a
+   * string table ships to the browser exactly like one pasted into `app.js` — and
+   * used to pass a gate that only looked at the logic files.
+   *
+   * **Exclude `app/vendor/`.** A bundled `busabase-sdk` legitimately builds an
+   * `Authorization: Bearer …` header from a resolved key, so sweeping the vendor
+   * directory in reports every app that bundles the SDK as leaking a credential.
+   * List the app's own files; never glob the whole `app/` tree.
+   */
+  browserDownloads?: string;
+  /** `app/js/config.js`, when the app declares its own resources. */
+  config?: string;
+  /** The slug the package ships this app under, for the `resourceKey` rule. */
+  shippedSlug?: string;
+}
+
+/** A `busabase-sdk` version must be exact. A range is not the app that was reviewed. */
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+/** A `start` script may start the server and nothing else. */
+const START_IS_A_BUILD =
+  /(?:&&|\|\||;|\bnpm\s+run\s+build\b|\btsc\b|\bvite\b|\bwebpack\b|\bparcel\b)/;
+
+/** An AirApp is Hono plus vanilla browser code. `esbuild` is how the SDK gets bundled. */
+const FORBIDDEN_DEPENDENCIES = [
+  "react",
+  "react-dom",
+  "preact",
+  "vite",
+  "@vitejs/plugin-react",
+  "next",
+  "webpack",
+  "parcel",
+];
+
+/**
+ * The documented interactive page budget. A higher one may be justified — say so in
+ * review — so this is a warning rather than a hard bound. A generator checking its
+ * own output is free to be stricter.
+ */
+export const AIRAPP_DEFAULT_READ_LIMIT = 50;
+
+/**
+ * Strip comments before pattern-matching source.
+ *
+ * Load-bearing, not tidiness. A file that explains a rule necessarily *names* the
+ * thing the rule forbids, and matching that prose let a server which had genuinely
+ * stopped reading `BUSABASE_AIRAPP_RUNTIME` pass its gate — the comment about the
+ * variable satisfied the check for the variable. Prose about a rule must never
+ * satisfy the rule.
+ */
+export const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/(^|[^:'"`\\])\/\/[^\n]*/g, "$1 ");
+
+/**
+ * Objects inside a `bases: [ ... ]` literal, brace-matched rather than regexed across
+ * the array, so a nested `fields:` entry is never mistaken for a Base.
+ *
+ * Reading the declaration without evaluating the module is the point: a checker must
+ * not execute the app it is checking.
+ */
+export const scanAirAppConfig = (
+  source: string,
+): {
+  bases: { key: string | null; slug: string | null }[];
+  drive: { slug: string | null } | null;
+  resourceKey: string | null;
+} => {
+  const anchor = /\bbases\s*:\s*\[/.exec(source);
+  const blocks: string[] = [];
+  if (anchor) {
+    let depth = 0;
+    let start = -1;
+    for (let index = anchor.index + anchor[0].length - 1; index < source.length; index += 1) {
+      const char = source[index];
+      if (char === "[") depth += 1;
+      else if (char === "]") {
+        depth -= 1;
+        if (depth === 0) break;
+      } else if (char === "{" && depth === 1) {
+        if (start === -1) start = index;
+        depth += 1;
+      } else if (char === "{") depth += 1;
+      else if (char === "}") {
+        depth -= 1;
+        if (depth === 1 && start !== -1) {
+          blocks.push(source.slice(start, index + 1));
+          start = -1;
+        }
+      }
+    }
+  }
+  const literal = (block: string, key: string): string | null =>
+    new RegExp(`\\b${key}\\s*:\\s*"([^"]*)"`).exec(block)?.[1] ?? null;
+  const drive = /\bdrive\s*:\s*\{([\s\S]*?)\}/.exec(source);
+  return {
+    bases: blocks.map((block) => ({ key: literal(block, "key"), slug: literal(block, "slug") })),
+    drive: drive ? { slug: literal(drive[1], "slug") } : null,
+    resourceKey: /\bairApp\s*:\s*\{[^}]*\bresourceKey\s*:\s*"([^"]*)"/.exec(source)?.[1] ?? null,
+  };
+};
+
+/**
+ * Check an AirApp against the runtime contract. Returns findings; never throws for a
+ * rule violation, so one caller can report every problem at once instead of the first.
+ */
+export const checkAirApp = (sources: AirAppSources): AirAppFinding[] => {
+  const findings: AirAppFinding[] = [];
+  const error = (rule: string, message: string) =>
+    findings.push({ severity: "error", rule, message });
+  const warn = (rule: string, message: string) =>
+    findings.push({ severity: "warning", rule, message });
+
+  // ── The app can boot, and is the app the contract allows ────────────────────
+  if (sources.packageJson !== undefined) {
+    let manifest: { scripts?: Record<string, unknown>; [key: string]: unknown } | undefined;
+    try {
+      manifest = JSON.parse(sources.packageJson) as typeof manifest;
+    } catch (cause) {
+      error("airapp/package-json", `package.json is not valid JSON (${(cause as Error).message}).`);
+    }
+    if (manifest) {
+      const scripts = (manifest.scripts ?? {}) as Record<string, unknown>;
+      if (typeof scripts.dev !== "string") {
+        error(
+          "airapp/dev-script",
+          "package.json has no `dev` script. Busabase boots an app with `npm run dev`, so it installs cleanly and then never starts.",
+        );
+      }
+      if (typeof scripts.start === "string" && START_IS_A_BUILD.test(scripts.start)) {
+        error(
+          "airapp/start-pure",
+          `\`start\` is "${scripts.start}" — a deployed start must only run the server, never build or spawn.`,
+        );
+      }
+      const dependencies = {
+        ...((manifest.dependencies ?? {}) as Record<string, unknown>),
+        ...((manifest.devDependencies ?? {}) as Record<string, unknown>),
+      };
+      const sdk = (manifest.dependencies as Record<string, unknown> | undefined)?.["busabase-sdk"];
+      if (sdk === undefined) {
+        warn("airapp/sdk", "No `busabase-sdk` dependency — the app cannot reach the workspace.");
+      } else if (!EXACT_VERSION.test(String(sdk))) {
+        error(
+          "airapp/sdk-pin",
+          `busabase-sdk is "${String(sdk)}". Pin the exact version — a range means the installed app is not the one that was reviewed.`,
+        );
+      }
+      for (const forbidden of FORBIDDEN_DEPENDENCIES) {
+        if (dependencies[forbidden] !== undefined) {
+          error(
+            "airapp/no-framework",
+            `Depends on "${forbidden}". An AirApp is Hono plus vanilla HTML/CSS/JS; its files are reviewed and then run as-is, so nothing may need compiling first.`,
+          );
+        }
+      }
+    }
+  }
+
+  // ── Browser code talks to its own origin, through the SDK ───────────────────
+  if (sources.browserLogic !== undefined) {
+    const logic = sources.browserLogic;
+    const code = stripComments(logic);
+
+    if (!logic.includes("createBusabaseClient")) {
+      warn("airapp/sdk-client", "Browser code never calls `createBusabaseClient`.");
+    }
+    if (logic.includes("__busabase_api__")) {
+      error(
+        "airapp/legacy-bridge",
+        "The obsolete `/__busabase_api__/` bridge prefix is gone. The API is same-origin `/api/v1`.",
+      );
+    }
+    if (/baseUrl\s*:\s*["'`]https?:\/\//.test(code)) {
+      error(
+        "airapp/absolute-url",
+        "A hard-coded absolute Busabase URL in browser code. Use `window.location.origin` — an absolute URL is right in exactly one deployment and wrong in the rest.",
+      );
+    }
+    // `/api/v1/...` is deliberately absolute and unaffected: an API call is not an asset.
+    if (/(?:src|href)="\/(?!\/)|from\s+["']\/(?!\/)/.test(code)) {
+      error(
+        "airapp/absolute-asset",
+        "An absolute asset path. Under the Local Node engine the app is proxied onto a sub-path of Busabase's origin, so a leading slash resolves against Busabase itself and 404s.",
+      );
+    }
+    // `while (true) { … if (!nextCursor) return …; cursor = nextCursor; }` is the same
+    // violation as `while (cursor)` with the exit condition inverted — genuinely
+    // unbounded, since cycle detection catches an infinite loop but not "very many
+    // pages". The `while (true)` half is scoped to a loop that calls a paging read,
+    // so an unrelated retry/poll loop elsewhere in the file is not swept in.
+    if (
+      /while\s*\(\s*cursor\s*\)|client\.bases\.list\s*\(/.test(code) ||
+      /while\s*\(\s*true\s*\)[\s\S]{0,400}?(?:records\.list|readPage)\s*\(/.test(code)
+    ) {
+      error(
+        "airapp/unbounded-read",
+        "Unbounded loading or runtime Base discovery. Every interactive read gets an explicit budget and fetches one page per user action.",
+      );
+    }
+    // A cap does not fix this — it only bounds how bad it gets. `for (page = 0; page <
+    // maxPages; …) records.list(…)` inside one function call is the same violation as
+    // an unbounded while(cursor) loop: several pages of a Base are fetched in one shot,
+    // hidden behind a single loading state, with no user action between pages. Real
+    // fleet shape: `readAllRecords(key, { maxPages = 20 } = {}) { for (...) { … } }`,
+    // called unconditionally at initial load — up to maxPages × readLimit records
+    // (2000 in the observed case) on every open.
+    if (/\bmax\w*pages?\w*\s*=\s*\d+[\s\S]{0,400}?(?:client\.)?records\.list\s*\(/i.test(code)) {
+      error(
+        "airapp/eager-multi-page",
+        "A capped loop fetches several pages of records in one function call. A cap bounds the damage but does not fix the shape: this still hides a multi-page scan behind one loading state instead of fetching one page per user action.",
+      );
+    }
+
+    // ── Runtime detection ─────────────────────────────────────────────────────
+    // Does this app have a hosted/standalone branch at all? A connect gate, a
+    // `getRuntime()` call, or a `hosted` flag it reads are the shapes that branch.
+    const branches =
+      /createAirAppConnectGate|getRuntime\s*\(|\bhosted\b/.test(code) ||
+      (sources.server !== undefined && /createAirAppConnectGate/.test(sources.server));
+    if (/location\s*\.\s*(?:hostname|host)\b/.test(code)) {
+      error(
+        "airapp/runtime-hostname",
+        "Hostname-based runtime detection. Both directions are wrong: a Busabase-hosted AirApp is served from `localhost` on Desktop, and a standalone `npm run dev` is reached over a LAN IP or a signed dev tunnel. Read the runtime from `__airapp/runtime`.",
+      );
+    }
+    if (
+      /(?:===|!==|==|!=)\s*["'`][^"'`]*(?:localhost|127\.0\.0\.1)|(?:includes|startsWith|endsWith|indexOf|search|match|test)\s*\(\s*\/?["'`]?[^"'`)]*(?:localhost|127\.0\.0\.1)/.test(
+        code,
+      )
+    ) {
+      error(
+        "airapp/runtime-loopback",
+        "A loopback host comparison. Runtime detection must not depend on the URL at all.",
+      );
+    }
+    // Only an app that BRANCHES on where it is running needs to know. An app that
+    // never branches — always calling `/api/v1` on its own origin and letting its dev
+    // server proxy when standalone — is not missing a probe, it has nothing to ask.
+    // Requiring one anyway told a correctly-designed template it was broken, which is
+    // how a checker stops being read.
+    if (branches && !logic.includes("__airapp/runtime")) {
+      error(
+        "airapp/runtime-probe",
+        "This app branches on where it is running but never probes `__airapp/runtime`, so that branch is deciding on something else.",
+      );
+    }
+    if (/["'`]\/__airapp\/runtime/.test(logic)) {
+      error(
+        "airapp/runtime-probe-relative",
+        "The runtime probe has a leading slash. It must be relative (`__airapp/runtime`) — a leading slash resolves against Busabase's root under the Local Node sub-path proxy.",
+      );
+    }
+  }
+
+  // ── The host reads the injected variable and re-exposes it ──────────────────
+  if (sources.server !== undefined) {
+    const server = sources.server;
+    const serverCode = stripComments(server);
+    const isPython = sources.serverLanguage
+      ? sources.serverLanguage === "python"
+      : /^\s*(?:import|from)\s+\w+|def\s+\w+\s*\(/m.test(server);
+
+    // A Node host may go through the SDK — one shared definition of "hosted" — or
+    // read the variable itself; both are correct. A Python host has no SDK to call.
+    const readsRuntimeEnv = isPython
+      ? /BUSABASE_AIRAPP_RUNTIME/.test(serverCode)
+      : /(?:read|describe)BusabaseAirAppRuntime\s*\(|process\.env\.BUSABASE_AIRAPP_RUNTIME\b/.test(
+          serverCode,
+        );
+    // Same gate as the browser probe: a host only has to expose the runtime if
+    // something is going to branch on it.
+    const clientBranches =
+      sources.browserLogic !== undefined &&
+      /createAirAppConnectGate|getRuntime\s*\(|\bhosted\b/.test(
+        stripComments(sources.browserLogic),
+      );
+    if (clientBranches && !readsRuntimeEnv) {
+      error(
+        "airapp/runtime-env",
+        "The server never reads `BUSABASE_AIRAPP_RUNTIME`, directly or through the SDK, so it has nothing to serve at `__airapp/runtime`.",
+      );
+    }
+    if (
+      /AIRAPP_HOSTED_RUNTIMES\s*=\s*new Set|hosted:\s*\w*RUNTIMES?\w*\.has\s*\(/.test(serverCode)
+    ) {
+      error(
+        "airapp/runtime-engine-list",
+        "Hosting is decided from a hardcoded list of engine names. Use presence, not membership — a private list is what broke 66 apps when `local-node` was renamed `local`.",
+      );
+    }
+    if (clientBranches && !/["'`]\/__airapp\/runtime["'`]/.test(server)) {
+      error(
+        "airapp/runtime-route",
+        "Browser code branches on the runtime but the server does not serve `/__airapp/runtime`.",
+      );
+    }
+    // The dev proxy may reference the env var; it may never carry a literal token.
+    if (/Bearer\s+(?!\$\{)[A-Za-z0-9_-]{8,}/.test(server)) {
+      error("airapp/credential", "A literal Bearer token in the server source.");
+    }
+  }
+
+  // ── Nothing the browser downloads carries a credential ──────────────────────
+  //
+  // Scanned RAW, comments included — a key commented out still ships to the browser
+  // verbatim. That rules out `stripComments` here, so the patterns have to be precise
+  // instead: matching the bare word `Bearer` reported an app whose only occurrence was
+  // a comment explaining that the dev proxy injects one. The distinguishing feature of
+  // a leak is a literal secret, never the word for it.
+  if (sources.browserDownloads !== undefined) {
+    const downloads = sources.browserDownloads;
+    if (/BUSABASE_API_KEY/i.test(downloads)) {
+      error("airapp/credential", "An API key reference in browser source.");
+    }
+    if (/Bearer\s+(?!\$\{)[A-Za-z0-9_.-]{8,}/.test(downloads)) {
+      error("airapp/credential", "A literal Bearer token in browser source.");
+    }
+    if (/["'`]\s*Bearer\s*\$\{/.test(downloads)) {
+      error(
+        "airapp/credential",
+        "Browser code builds an Authorization header. A deployed AirApp uses the viewer's ambient same-origin session and needs none.",
+      );
+    }
+  }
+
+  // ── The app's own map of the workspace ──────────────────────────────────────
+  if (sources.config !== undefined) {
+    const config = scanAirAppConfig(sources.config);
+    if (
+      sources.shippedSlug !== undefined &&
+      config.resourceKey !== null &&
+      config.resourceKey !== sources.shippedSlug
+    ) {
+      error(
+        "airapp/resource-key",
+        `Config declares resourceKey "${config.resourceKey}" but the package ships this app as "${sources.shippedSlug}". Install stamps nodes with the shipped slug, so the app would not recognise its own node.`,
+      );
+    }
+    for (const base of config.bases) {
+      if (base.slug === null) {
+        error(
+          "airapp/base-slug",
+          `Config base "${base.key ?? "(unnamed)"}" has no \`slug\`. The SDK needs it to CREATE the Base, so the app's own provisioning fails even though installing from the package succeeds — install reads base.json and never opens that door.`,
+        );
+      }
+    }
+    if (config.drive !== null && config.drive.slug === null) {
+      error("airapp/base-slug", "Config `drive` has no `slug`; provisioning it will fail.");
+    }
+    if (/vaultValue|vaultSecret\s*:\s*["'`][^"'`]/.test(sources.config)) {
+      error(
+        "airapp/vault-value",
+        "A Vault value in config. Config may reference secrets, never carry them.",
+      );
+    }
+    for (const found of sources.config.matchAll(/\breadLimit\s*:\s*(\d+)/g)) {
+      const limit = Number(found[1]);
+      if (limit < 1) {
+        error("airapp/read-budget", `readLimit is ${limit}; it must be a positive integer.`);
+      } else if (limit > AIRAPP_DEFAULT_READ_LIMIT) {
+        warn(
+          "airapp/read-budget",
+          `readLimit is ${limit}, above the ${AIRAPP_DEFAULT_READ_LIMIT}-record default page budget. Justify it in review, or page.`,
+        );
+      }
+    }
+  }
+
+  return findings;
+};

--- a/apps/busabase-sdk/src/airapp-node.test.ts
+++ b/apps/busabase-sdk/src/airapp-node.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createBusabaseAirAppLocalGateway } from "./airapp-node.js";
+import { createBusabaseAirAppLocalGateway, describeBusabaseAirAppRuntime } from "./airapp-node.js";
 import {
   loadBusabaseAirAppDynamicClientId,
   loadBusabaseAirAppOAuthCredential,
@@ -535,5 +535,47 @@ describe("local AirApp gateway proxy", () => {
     );
     expect(response.status).toBe(200);
     expect(loadBusabaseAirAppOAuthCredential(APP_ID, { rootDir })).toBeNull();
+  });
+});
+
+describe("describeBusabaseAirAppRuntime", () => {
+  it("reports standalone when nothing injected the variable", () => {
+    expect(describeBusabaseAirAppRuntime({})).toEqual({
+      runtime: "standalone",
+      knownRuntime: null,
+      hosted: false,
+      devProxy: false,
+    });
+  });
+
+  it("reports a known engine both verbatim and narrowed", () => {
+    expect(describeBusabaseAirAppRuntime({ BUSABASE_AIRAPP_RUNTIME: "nodepod" })).toMatchObject({
+      runtime: "nodepod",
+      knownRuntime: "nodepod",
+      hosted: true,
+    });
+  });
+
+  /**
+   * The whole reason `hosted` is presence and not membership. An engine this SDK
+   * predates still means Busabase spawned the process — only Busabase sets the
+   * variable at all. A list-based check answered "standalone" here, and that is
+   * what broke 66 shipped apps when `local-node` became `local`.
+   */
+  it("treats an engine it has never heard of as hosted, with knownRuntime null", () => {
+    expect(
+      describeBusabaseAirAppRuntime({ BUSABASE_AIRAPP_RUNTIME: "an-engine-from-2027" }),
+    ).toMatchObject({ runtime: "an-engine-from-2027", knownRuntime: null, hosted: true });
+  });
+
+  it("gets the renamed and newer engines right, which the old list did not", () => {
+    expect(describeBusabaseAirAppRuntime({ BUSABASE_AIRAPP_RUNTIME: "local" }).hosted).toBe(true);
+    expect(describeBusabaseAirAppRuntime({ BUSABASE_AIRAPP_RUNTIME: "sandock" }).hosted).toBe(true);
+  });
+
+  it("keeps devProxy as a separate axis from hosting", () => {
+    const report = describeBusabaseAirAppRuntime({ BUSABASE_BASE_URL: "http://localhost:15419" });
+    expect(report.hosted).toBe(false);
+    expect(report.devProxy).toBe(true);
   });
 });

--- a/apps/busabase-sdk/src/airapp-node.ts
+++ b/apps/busabase-sdk/src/airapp-node.ts
@@ -80,6 +80,51 @@ export const asKnownBusabaseAirAppRuntime = (runtime: string): BusabaseAirAppRun
     ? (runtime as BusabaseAirAppRuntime)
     : null;
 
+/** The body every AirApp serves at `__airapp/runtime`. */
+export interface BusabaseAirAppRuntimeReport {
+  /**
+   * The engine name verbatim, or `"standalone"` when nothing hosted this process.
+   *
+   * Deliberately a plain string and not the enum: a newer Busabase naming an engine
+   * this SDK predates must still round-trip, and narrowing here would erase it.
+   */
+  runtime: string;
+  /**
+   * The same value narrowed to what this SDK knows, or `null` for an engine it has
+   * never heard of. This is the field to branch on when behaviour genuinely differs
+   * per engine — and `null` is a normal answer, not an error.
+   */
+  knownRuntime: BusabaseAirAppRuntime | null;
+  /** Presence of the injected variable. Never membership of {@link BUSABASE_AIRAPP_RUNTIMES}. */
+  hosted: boolean;
+  /** Whether a standalone run is proxying to a Busabase base URL. A separate axis. */
+  devProxy: boolean;
+}
+
+/**
+ * Build the `__airapp/runtime` body.
+ *
+ * This exists because the one line it replaces — `hosted: …` — has now regressed
+ * twice. Both times a correct app was copied from an older source and came back
+ * deciding hosting from a hardcoded list of engine names, and both times every test
+ * stayed green, because nothing asserted the shape of that decision.
+ *
+ * An app that calls this cannot get it wrong: `hosted` is presence by construction,
+ * and the engine name is reported both verbatim (so an unknown one survives) and
+ * narrowed (so code that wants to branch on a specific engine has a type).
+ */
+export const describeBusabaseAirAppRuntime = (
+  env: Record<string, string | undefined> = process.env,
+): BusabaseAirAppRuntimeReport => {
+  const runtime = readBusabaseAirAppRuntime(env);
+  return {
+    runtime: runtime || "standalone",
+    knownRuntime: asKnownBusabaseAirAppRuntime(runtime),
+    hosted: isBusabaseAirAppHosted(runtime),
+    devProxy: (env.BUSABASE_BASE_URL || "").trim() !== "",
+  };
+};
+
 export const BUSABASE_AIRAPP_GATEWAY_REASONS = {
   authRequired: "AUTH_REQUIRED",
   authUnavailable: "AUTH_UNAVAILABLE",

--- a/apps/busabase-sdk/tsdown.config.ts
+++ b/apps/busabase-sdk/tsdown.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     oauth: "src/oauth.ts",
     "oauth-node": "src/oauth-node.ts",
     "airapp-node": "src/airapp-node.ts",
+    "airapp-check": "src/airapp-check.ts",
     airapp: "src/airapp.ts",
     "airapp-gate": "src/airapp-gate.ts",
   },

--- a/apps/busabase/AGENTS.md
+++ b/apps/busabase/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/busabase/CLAUDE.md
+++ b/apps/busabase/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/busabase/next.config.mjs
+++ b/apps/busabase/next.config.mjs
@@ -125,6 +125,16 @@ const config = {
   experimental: {
     // Prevent header-based RSC responses from sharing a URL cache key with HTML.
     validateRSCRequestHeaders: true,
+    // The proxy.ts middleware layer enforces its own body-size cap ahead of
+    // any Route Handler, defaulting to 10MB — `busabase-cli restore` batches
+    // `dump.import.tables` rows by both count AND bytes, but a single
+    // attachment's base64-encoded bytes can still exceed that on its own
+    // (observed live against a real production space: individual files
+    // large enough to push even a same-request batch of one over 10MB),
+    // and the server rejected it as a generic "malformed request" with no
+    // indication of the real cause. Match the export side's own tolerance
+    // for large single files.
+    proxyClientMaxBodySize: "100mb",
   },
   turbopack: {
     root: monorepoRoot,
@@ -146,7 +156,7 @@ const config = {
     "@aws-sdk/client-s3",
     "@aws-sdk/s3-request-presigner",
   ],
-  allowedDevOrigins: ["hkt1.bika.ltd"],
+  allowedDevOrigins: ["*.bika.ltd"],
   transpilePackages: ["busabase-contract", "busabase-core"],
   async headers() {
     return [

--- a/apps/busabase/package.json
+++ b/apps/busabase/package.json
@@ -18,7 +18,7 @@
     "pglite",
     "cli"
   ],
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase",
@@ -108,7 +108,7 @@
     "fumadocs-core": "16.14.5",
     "fumadocs-ui": "16.14.5",
     "kui": "workspace:*",
-    "lucide-react": "^0.556.0",
+    "lucide-react": "^1.34.0",
     "next": "16.3.3",
     "next-themes": "^0.4.6",
     "openlib": "workspace:*",

--- a/apps/busabase/src/components/dashboard/busabase-dashboard-shell.tsx
+++ b/apps/busabase/src/components/dashboard/busabase-dashboard-shell.tsx
@@ -3,6 +3,7 @@
 import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
 import type { NodeVO } from "busabase-contract/types";
 import { BusabaseAgentSkillButton } from "busabase-core/dashboard/agent-skill-button";
+import { GithubIcon } from "busabase-core/dashboard/brand-icons";
 import {
   type BusabaseDashboardChrome,
   BusabaseDashboardShell as CoreDashboardShell,
@@ -10,17 +11,7 @@ import {
 import type { MoveNodePayload } from "busabase-core/dashboard/use-move-node";
 import { useCoreI18n } from "busabase-core/i18n";
 import { DropdownMenuItem, DropdownMenuSeparator } from "kui/dropdown-menu";
-import {
-  Activity,
-  Archive,
-  Bot,
-  Github,
-  Images,
-  Inbox,
-  LayoutGrid,
-  Network,
-  Sparkles,
-} from "lucide-react";
+import { Activity, Archive, Bot, Images, Inbox, LayoutGrid, Network, Shapes } from "lucide-react";
 import { useAddDemoParam } from "openlib/ui/dashboard";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
@@ -194,12 +185,12 @@ export function BusabaseDashboardShell({
           onSelect={() => navigate(addDemoParam("/templates"))}
           className={currentPath.startsWith("/templates") ? "bg-accent" : undefined}
         >
-          <Sparkles />
+          <Shapes />
           <span>{coreMessages.nav.templates}</span>
         </DropdownMenuItem>
         {onInstallClick ? (
           <DropdownMenuItem onSelect={onInstallClick}>
-            <Github />
+            <GithubIcon />
             <span>{coreMessages.nav.installFromGithub}</span>
           </DropdownMenuItem>
         ) : null}

--- a/apps/busabase/src/db/migrations/0023_lush_amphibian.sql
+++ b/apps/busabase/src/db/migrations/0023_lush_amphibian.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "busabase_node_content_search" (
+	"node_id" text PRIMARY KEY NOT NULL,
+	"space_id" text NOT NULL,
+	"node_type" text NOT NULL,
+	"content_text" text,
+	"content_hash" text,
+	"truncated" boolean DEFAULT false NOT NULL,
+	"indexed_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "busabase_node_content_search" ADD CONSTRAINT "busabase_node_content_search_node_id_busabase_nodes_id_fk" FOREIGN KEY ("node_id") REFERENCES "public"."busabase_nodes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "busabase_node_content_search_fts_idx" ON "busabase_node_content_search" USING gin (to_tsvector('simple', coalesce("content_text", '')));--> statement-breakpoint
+CREATE INDEX "busabase_node_content_search_trgm_idx" ON "busabase_node_content_search" USING gin ("content_text" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "busabase_node_content_search_space_idx" ON "busabase_node_content_search" USING btree ("space_id");

--- a/apps/busabase/src/db/migrations/meta/0023_snapshot.json
+++ b/apps/busabase/src/db/migrations/meta/0023_snapshot.json
@@ -1,0 +1,4997 @@
+{
+  "id": "8682dfc7-dbe4-4148-9aba-435f2aa76315",
+  "prevId": "57ef5a93-0b55-4edf-bf29-fdd38b94e639",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.busabase_audit_events": {
+      "name": "busabase_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_audit_events_space_created_id_idx": {
+          "name": "busabase_audit_events_space_created_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_audit_events_action_created_idx": {
+          "name": "busabase_audit_events_action_created_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_audit_events_record_created_idx": {
+          "name": "busabase_audit_events_record_created_idx",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_audit_events_base_created_idx": {
+          "name": "busabase_audit_events_base_created_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_audit_events_base_id_busabase_bases_id_fk": {
+          "name": "busabase_audit_events_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_audit_events_record_id_busabase_records_id_fk": {
+          "name": "busabase_audit_events_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_audit_events_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_audit_events_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_audit_events_operation_id_busabase_operations_id_fk": {
+          "name": "busabase_audit_events_operation_id_busabase_operations_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_operations",
+          "columnsFrom": ["operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_audit_events_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_audit_events_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_audit_events",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_change_requests": {
+      "name": "busabase_change_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "busabase_change_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_review'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_meta": {
+          "name": "source_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "review_policy_snapshot": {
+          "name": "review_policy_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "merge_summary": {
+          "name": "merge_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rejected_reason": {
+          "name": "rejected_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_change_requests_space_created_id_idx": {
+          "name": "busabase_change_requests_space_created_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_change_requests_base_created_idx": {
+          "name": "busabase_change_requests_base_created_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_change_requests_node_created_idx": {
+          "name": "busabase_change_requests_node_created_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_change_requests_status_created_idx": {
+          "name": "busabase_change_requests_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_change_requests_idempotency_uniq": {
+          "name": "busabase_change_requests_idempotency_uniq",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_change_requests\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_change_requests_base_id_busabase_bases_id_fk": {
+          "name": "busabase_change_requests_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_change_requests",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_change_requests_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_change_requests_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_change_requests",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_comments": {
+      "name": "busabase_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "busabase_comment_subject",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentions_ai": {
+          "name": "mentions_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_comments_subject_created_idx": {
+          "name": "busabase_comments_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_comments_record_created_idx": {
+          "name": "busabase_comments_record_created_idx",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_comments_change_request_created_idx": {
+          "name": "busabase_comments_change_request_created_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_comments_operation_created_idx": {
+          "name": "busabase_comments_operation_created_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_comments_commit_created_idx": {
+          "name": "busabase_comments_commit_created_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_comments_record_id_busabase_records_id_fk": {
+          "name": "busabase_comments_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_comments",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_comments_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_comments_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_comments",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_comments_operation_id_busabase_operations_id_fk": {
+          "name": "busabase_comments_operation_id_busabase_operations_id_fk",
+          "tableFrom": "busabase_comments",
+          "tableTo": "busabase_operations",
+          "columnsFrom": ["operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_comments_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_comments_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_comments",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_commits": {
+      "name": "busabase_commits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_commit_id": {
+          "name": "parent_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "busabase_operation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'record_create'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_commits_base_created_idx": {
+          "name": "busabase_commits_base_created_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_commits_node_created_idx": {
+          "name": "busabase_commits_node_created_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_commits_operation_idx": {
+          "name": "busabase_commits_operation_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_commits_created_idx": {
+          "name": "busabase_commits_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_commits_base_id_busabase_bases_id_fk": {
+          "name": "busabase_commits_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_commits",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "busabase_commits_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_commits_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_commits",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_favorites": {
+      "name": "busabase_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_favorites_node_actor_uniq": {
+          "name": "busabase_favorites_node_actor_uniq",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_favorites_actor_idx": {
+          "name": "busabase_favorites_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_favorites_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_favorites_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_favorites",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_node_content_search": {
+      "name": "busabase_node_content_search",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_node_content_search_fts_idx": {
+          "name": "busabase_node_content_search_fts_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', coalesce(\"content_text\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "busabase_node_content_search_trgm_idx": {
+          "name": "busabase_node_content_search_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"content_text\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "busabase_node_content_search_space_idx": {
+          "name": "busabase_node_content_search_space_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_node_content_search_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_node_content_search_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_node_content_search",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_node_principals": {
+      "name": "busabase_node_principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_node_principals_node_principal_source_uniq": {
+          "name": "busabase_node_principals_node_principal_source_uniq",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_node_principals_node_idx": {
+          "name": "busabase_node_principals_node_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_node_principals_principal_idx": {
+          "name": "busabase_node_principals_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_node_principals_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_node_principals_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_node_principals",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_node_principals_source_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_node_principals_source_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_node_principals",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["source_node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_node_shares": {
+      "name": "busabase_node_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_node_shares_space_scope_idx": {
+          "name": "busabase_node_shares_space_scope_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_node_shares_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_node_shares_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_node_shares",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "busabase_node_shares_node_id_unique": {
+          "name": "busabase_node_shares_node_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["node_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_nodes": {
+      "name": "busabase_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "explicit_visibility": {
+          "name": "explicit_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_visibility": {
+          "name": "effective_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_public_scope": {
+          "name": "effective_public_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_public_requires_password": {
+          "name": "effective_public_requires_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_nodes_space_type_slug_uniq": {
+          "name": "busabase_nodes_space_type_slug_uniq",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_nodes\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_nodes_parent_position_idx": {
+          "name": "busabase_nodes_parent_position_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_nodes_effective_visibility_idx": {
+          "name": "busabase_nodes_effective_visibility_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_nodes_effective_public_scope_idx": {
+          "name": "busabase_nodes_effective_public_scope_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_public_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_nodes_parent_id_busabase_nodes_id_fk": {
+          "name": "busabase_nodes_parent_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_nodes",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_operations": {
+      "name": "busabase_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "busabase_operation_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "target_record_id": {
+          "name": "target_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_view_id": {
+          "name": "target_view_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_commit_id": {
+          "name": "source_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_commit_id": {
+          "name": "base_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_commit_id": {
+          "name": "head_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delete_mode": {
+          "name": "delete_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'archive'"
+        },
+        "merged_record_id": {
+          "name": "merged_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_view_id": {
+          "name": "merged_view_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_operations_change_request_position_idx": {
+          "name": "busabase_operations_change_request_position_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_operations_node_file_idx": {
+          "name": "busabase_operations_node_file_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_operations_target_record_idx": {
+          "name": "busabase_operations_target_record_idx",
+          "columns": [
+            {
+              "expression": "target_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_operations_target_view_idx": {
+          "name": "busabase_operations_target_view_idx",
+          "columns": [
+            {
+              "expression": "target_view_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_operations_head_commit_idx": {
+          "name": "busabase_operations_head_commit_idx",
+          "columns": [
+            {
+              "expression": "head_commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_operations_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_operations_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_base_id_busabase_bases_id_fk": {
+          "name": "busabase_operations_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_operations_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_target_view_id_busabase_views_id_fk": {
+          "name": "busabase_operations_target_view_id_busabase_views_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_views",
+          "columnsFrom": ["target_view_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_head_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_operations_head_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["head_commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "busabase_operations_merged_view_id_busabase_views_id_fk": {
+          "name": "busabase_operations_merged_view_id_busabase_views_id_fk",
+          "tableFrom": "busabase_operations",
+          "tableTo": "busabase_views",
+          "columnsFrom": ["merged_view_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_reviews": {
+      "name": "busabase_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "busabase_review_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_operation_heads": {
+          "name": "visible_operation_heads",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_reviews_one_vote_per_change_request": {
+          "name": "busabase_reviews_one_vote_per_change_request",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_reviews_change_request_created_idx": {
+          "name": "busabase_reviews_change_request_created_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_reviews_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_reviews_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_reviews",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_user_id_idx": {
+          "name": "attachments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_space_id_idx": {
+          "name": "attachments_space_id_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_context_idx": {
+          "name": "attachments_context_idx",
+          "columns": [
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_created_at_idx": {
+          "name": "attachments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_storage_key_idx": {
+          "name": "attachments_storage_key_idx",
+          "columns": [
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_content_hash_idx": {
+          "name": "attachments_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_agent_session_events": {
+      "name": "busabase_agent_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_agent_session_events_session_seq_idx": {
+          "name": "busabase_agent_session_events_session_seq_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_agent_session_events_at_idx": {
+          "name": "busabase_agent_session_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_agent_session_events_session_id_busabase_agent_sessions_id_fk": {
+          "name": "busabase_agent_session_events_session_id_busabase_agent_sessions_id_fk",
+          "tableFrom": "busabase_agent_session_events",
+          "tableTo": "busabase_agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_agent_sessions": {
+      "name": "busabase_agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acp_session_id": {
+          "name": "acp_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "busabase_agent_sessions_space_activity_idx": {
+          "name": "busabase_agent_sessions_space_activity_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_asset_texts": {
+      "name": "busabase_asset_texts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "text_storage_key": {
+          "name": "text_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_content_hash": {
+          "name": "text_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "written_by": {
+          "name": "written_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "line_count": {
+          "name": "line_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "byte_count": {
+          "name": "byte_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "line_checkpoints": {
+          "name": "line_checkpoints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "stats_computed_at": {
+          "name": "stats_computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_asset_texts_asset_uniq": {
+          "name": "busabase_asset_texts_asset_uniq",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_texts_space_status_idx": {
+          "name": "busabase_asset_texts_space_status_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_texts_content_hash_idx": {
+          "name": "busabase_asset_texts_content_hash_idx",
+          "columns": [
+            {
+              "expression": "text_content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_asset_texts_asset_id_busabase_assets_id_fk": {
+          "name": "busabase_asset_texts_asset_id_busabase_assets_id_fk",
+          "tableFrom": "busabase_asset_texts",
+          "tableTo": "busabase_assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_asset_usages": {
+      "name": "busabase_asset_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "field_slug": {
+          "name": "field_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_asset_usages_asset_idx": {
+          "name": "busabase_asset_usages_asset_idx",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_usages_node_idx": {
+          "name": "busabase_asset_usages_node_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_usages_node_path_idx": {
+          "name": "busabase_asset_usages_node_path_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_asset_usages_uniq": {
+          "name": "busabase_asset_usages_uniq",
+          "columns": [
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_asset_usages_asset_id_busabase_assets_id_fk": {
+          "name": "busabase_asset_usages_asset_id_busabase_assets_id_fk",
+          "tableFrom": "busabase_asset_usages",
+          "tableTo": "busabase_assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_asset_usages_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_asset_usages_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_asset_usages",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_assets": {
+      "name": "busabase_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'binary'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local-producer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_assets_space_idx": {
+          "name": "busabase_assets_space_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_assets_space_attachment_idx": {
+          "name": "busabase_assets_space_attachment_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_base_fields": {
+      "name": "busabase_base_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "busabase_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "busabase_fields_base_slug_uniq": {
+          "name": "busabase_fields_base_slug_uniq",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_base_fields\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_base_fields_base_id_busabase_bases_id_fk": {
+          "name": "busabase_base_fields_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_base_fields",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_bases": {
+      "name": "busabase_bases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "review_policy": {
+          "name": "review_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"kind\":\"single\",\"requiredApprovals\":1}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "busabase_bases_node_uniq": {
+          "name": "busabase_bases_node_uniq",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_bases_space_slug_uniq": {
+          "name": "busabase_bases_space_slug_uniq",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_bases\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_bases_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_bases_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_bases",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_field_values": {
+      "name": "busabase_field_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_request_id": {
+          "name": "change_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_slug": {
+          "name": "field_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "busabase_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_bool": {
+          "name": "value_bool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_hash": {
+          "name": "value_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_field_values_base_field_idx": {
+          "name": "busabase_field_values_base_field_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_text_fts_idx": {
+          "name": "busabase_field_values_text_fts_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', coalesce(\"value_text\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "busabase_field_values_text_trgm_idx": {
+          "name": "busabase_field_values_text_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"value_text\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "busabase_field_values_slug_trgm_idx": {
+          "name": "busabase_field_values_slug_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"field_slug\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "busabase_field_values_base_field_number_idx": {
+          "name": "busabase_field_values_base_field_number_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_base_field_date_idx": {
+          "name": "busabase_field_values_base_field_date_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_record_idx": {
+          "name": "busabase_field_values_record_idx",
+          "columns": [
+            {
+              "expression": "record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_change_request_idx": {
+          "name": "busabase_field_values_change_request_idx",
+          "columns": [
+            {
+              "expression": "change_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_operation_idx": {
+          "name": "busabase_field_values_operation_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_field_values_commit_idx": {
+          "name": "busabase_field_values_commit_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_field_values_base_id_busabase_bases_id_fk": {
+          "name": "busabase_field_values_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_field_values_record_id_busabase_records_id_fk": {
+          "name": "busabase_field_values_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_field_values_change_request_id_busabase_change_requests_id_fk": {
+          "name": "busabase_field_values_change_request_id_busabase_change_requests_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_change_requests",
+          "columnsFrom": ["change_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_field_values_operation_id_busabase_operations_id_fk": {
+          "name": "busabase_field_values_operation_id_busabase_operations_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_operations",
+          "columnsFrom": ["operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_field_values_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_field_values_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_field_values",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_record_links": {
+      "name": "busabase_record_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_slug": {
+          "name": "field_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_base_id": {
+          "name": "target_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_record_id": {
+          "name": "target_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_record_links_source_field_target_uniq": {
+          "name": "busabase_record_links_source_field_target_uniq",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_record_links_source_field_idx": {
+          "name": "busabase_record_links_source_field_idx",
+          "columns": [
+            {
+              "expression": "source_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_record_links_target_idx": {
+          "name": "busabase_record_links_target_idx",
+          "columns": [
+            {
+              "expression": "target_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_record_links_base_field_idx": {
+          "name": "busabase_record_links_base_field_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_record_links_base_id_busabase_bases_id_fk": {
+          "name": "busabase_record_links_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_field_id_busabase_base_fields_id_fk": {
+          "name": "busabase_record_links_field_id_busabase_base_fields_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_base_fields",
+          "columnsFrom": ["field_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_source_record_id_busabase_records_id_fk": {
+          "name": "busabase_record_links_source_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["source_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_target_base_id_busabase_bases_id_fk": {
+          "name": "busabase_record_links_target_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["target_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_target_record_id_busabase_records_id_fk": {
+          "name": "busabase_record_links_target_record_id_busabase_records_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_records",
+          "columnsFrom": ["target_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_record_links_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_record_links_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_record_links",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_records": {
+      "name": "busabase_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_commit_id": {
+          "name": "head_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_record_id": {
+          "name": "parent_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_commit_id": {
+          "name": "parent_commit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_records_base_created_idx": {
+          "name": "busabase_records_base_created_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_records_status_created_idx": {
+          "name": "busabase_records_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_records_head_commit_idx": {
+          "name": "busabase_records_head_commit_idx",
+          "columns": [
+            {
+              "expression": "head_commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_records_base_id_busabase_bases_id_fk": {
+          "name": "busabase_records_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_records",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_records_head_commit_id_busabase_commits_id_fk": {
+          "name": "busabase_records_head_commit_id_busabase_commits_id_fk",
+          "tableFrom": "busabase_records",
+          "tableTo": "busabase_commits",
+          "columnsFrom": ["head_commit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_views": {
+      "name": "busabase_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'table'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_views_base_slug_uniq": {
+          "name": "busabase_views_base_slug_uniq",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"busabase_views\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_views_base_status_position_idx": {
+          "name": "busabase_views_base_status_position_idx",
+          "columns": [
+            {
+              "expression": "base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_views_base_id_busabase_bases_id_fk": {
+          "name": "busabase_views_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_views",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_embed_links": {
+      "name": "busabase_embed_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_api_key_id": {
+          "name": "created_by_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_mode": {
+          "name": "frame_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'top-level-only'"
+        },
+        "allowed_origins": {
+          "name": "allowed_origins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_embed_links_secret_hash_uniq": {
+          "name": "busabase_embed_links_secret_hash_uniq",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_embed_links_space_target_idx": {
+          "name": "busabase_embed_links_space_target_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_embed_links_expires_at_idx": {
+          "name": "busabase_embed_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_forms": {
+      "name": "busabase_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_base_id": {
+          "name": "target_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bindings": {
+          "name": "bindings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "page": {
+          "name": "page",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "share": {
+          "name": "share",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"isPublic\":false,\"anonymousSubmit\":false}'::jsonb"
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_forms_node_idx": {
+          "name": "busabase_forms_node_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_forms_target_base_idx": {
+          "name": "busabase_forms_target_base_idx",
+          "columns": [
+            {
+              "expression": "target_base_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_forms_space_status_idx": {
+          "name": "busabase_forms_space_status_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "busabase_forms_node_id_busabase_nodes_id_fk": {
+          "name": "busabase_forms_node_id_busabase_nodes_id_fk",
+          "tableFrom": "busabase_forms",
+          "tableTo": "busabase_nodes",
+          "columnsFrom": ["node_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "busabase_forms_target_base_id_busabase_bases_id_fk": {
+          "name": "busabase_forms_target_base_id_busabase_bases_id_fk",
+          "tableFrom": "busabase_forms",
+          "tableTo": "busabase_bases",
+          "columnsFrom": ["target_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_vault_items": {
+      "name": "busabase_vault_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_payload": {
+          "name": "value_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "access": {
+          "name": "access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"runtime\":true,\"reveal\":true,\"edit\":true,\"share\":false}'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_vault_items_user_updated_idx": {
+          "name": "busabase_vault_items_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_vault_items_user_kind_idx": {
+          "name": "busabase_vault_items_user_kind_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "busabase_vault_items_user_key_idx": {
+          "name": "busabase_vault_items_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_webhook_deliveries": {
+      "name": "busabase_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "busabase_webhook_deliveries_rule_created_idx": {
+          "name": "busabase_webhook_deliveries_rule_created_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_webhook_rules": {
+      "name": "busabase_webhook_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_kind": {
+          "name": "action_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "busabase_webhook_rules_space_event_enabled_idx": {
+          "name": "busabase_webhook_rules_space_event_enabled_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_app_branding": {
+      "name": "busabase_app_branding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.busabase_cloud_connect": {
+      "name": "busabase_cloud_connect",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cloud_url": {
+          "name": "cloud_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oss_origin": {
+          "name": "oss_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_token": {
+          "name": "credential_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_refresh_token": {
+          "name": "credential_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_expires_at": {
+          "name": "credential_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.busabase_change_request_status": {
+      "name": "busabase_change_request_status",
+      "schema": "public",
+      "values": [
+        "in_review",
+        "changes_requested",
+        "approved",
+        "rejected",
+        "merged",
+        "abandoned",
+        "conflict"
+      ]
+    },
+    "public.busabase_comment_subject": {
+      "name": "busabase_comment_subject",
+      "schema": "public",
+      "values": ["record", "change_request", "operation", "commit"]
+    },
+    "public.busabase_operation_kind": {
+      "name": "busabase_operation_kind",
+      "schema": "public",
+      "values": [
+        "record_create",
+        "record_update",
+        "record_delete",
+        "record_variant",
+        "view_create",
+        "view_update",
+        "view_delete",
+        "view_restore",
+        "node_create",
+        "node_rename",
+        "node_delete",
+        "node_restore",
+        "node_move",
+        "skill_file_create",
+        "skill_file_update",
+        "skill_file_delete",
+        "skill_metadata_update",
+        "drive_file_create",
+        "drive_file_update",
+        "drive_file_delete",
+        "drive_metadata_update",
+        "airapp_file_create",
+        "airapp_file_update",
+        "airapp_file_delete",
+        "airapp_metadata_update",
+        "doc_update",
+        "whiteboard_document_update",
+        "workflow_document_update",
+        "html_document_update",
+        "base_add_field",
+        "base_delete_field",
+        "base_update_field",
+        "base_convert_field",
+        "base_reorder_fields",
+        "base_restore_field",
+        "base_archive",
+        "base_restore",
+        "record_restore"
+      ]
+    },
+    "public.busabase_review_verdict": {
+      "name": "busabase_review_verdict",
+      "schema": "public",
+      "values": ["approved", "rejected"]
+    },
+    "public.busabase_field_type": {
+      "name": "busabase_field_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "longtext",
+        "markdown",
+        "html",
+        "attachment",
+        "relation",
+        "number",
+        "date",
+        "checkbox",
+        "select",
+        "multiselect",
+        "url",
+        "embed",
+        "email",
+        "phone",
+        "created_time",
+        "updated_time",
+        "created_by",
+        "updated_by",
+        "auto_number",
+        "ai_summary",
+        "ai_tags",
+        "code",
+        "json",
+        "yaml",
+        "formula",
+        "lookup",
+        "whiteboard"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/busabase/src/db/migrations/meta/_journal.json
+++ b/apps/busabase/src/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1787739668157,
       "tag": "0022_chunky_energizer",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1787886281324,
+      "tag": "0023_lush_amphibian",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/busabase/tests/e2e/recent-node-history.spec.ts
+++ b/apps/busabase/tests/e2e/recent-node-history.spec.ts
@@ -85,7 +85,15 @@ test("a cold direct URL records a deep node omitted from the sidebar prefetch", 
     await expect(page.getByRole("heading", { name: docName })).toBeVisible({
       timeout: RENDER_TIMEOUT,
     });
-    await expect(page.getByRole("link", { name: docName, exact: true })).toHaveCount(0);
+    // The sidebar now expands to a cold-loaded deep node's ancestor chain and
+    // lazily fetches each folder's children as it unrolls, so this doc's own
+    // parent folder ends up expanded too and renders the doc as a sidebar
+    // link. That is intentional: a cold direct URL used to leave the sidebar
+    // fully collapsed with nothing highlighted. The doc's initial PREFETCH
+    // still never reached this deep, which is the setup this test actually
+    // needs -- the search hit below still has to come from Recent visits,
+    // not from an ordinary always-rendered link.
+    await expect(page.getByRole("link", { name: docName, exact: true })).toHaveCount(1);
 
     await page.getByRole("button", { name: "Search", exact: true }).click();
     const dialog = page.getByRole("dialog");

--- a/apps/busabase/tests/e2e/sidebar-lazy-expand.spec.ts
+++ b/apps/busabase/tests/e2e/sidebar-lazy-expand.spec.ts
@@ -1,0 +1,362 @@
+import { expect, type Page, test } from "./_fixtures";
+
+const RENDER_TIMEOUT = 45_000;
+test.setTimeout(120_000);
+
+/**
+ * Regression cover for the sidebar's lazy per-folder expand.
+ *
+ * The tree is fetched depth-bounded (`nodes.list({ parentId: null, depth: 2 })`
+ * = root + 2 levels); anything deeper only arrives when the sidebar asks for a
+ * specific folder's children. It used to ask ONLY from the collapsible's
+ * `onOpenChange`, i.e. only when the chevron was toggled — but a folder row
+ * also opens with no toggle event at all, because it is open whenever it (or a
+ * descendant) is the active route. So CLICKING a folder's name, which is what
+ * everyone actually does, navigated into it, expanded its row, and then
+ * rendered nothing underneath: the fetch was never kicked off. Its own detail
+ * page listed the children the whole time, which is what made it read as "the
+ * sidebar is lying" rather than "nothing loaded".
+ *
+ * Only folders past the prefetch depth could show it, and the seeded demo tree
+ * was one level deep everywhere, so this needs its own deep chain. Five levels,
+ * not three: expanding L2 eagerly carries two levels with it (L3 + L4), so L4
+ * is the first folder that needs a SECOND lazy fetch — which is the only way to
+ * cover merging a lazily-fetched subtree into an already-lazily-fetched one.
+ */
+
+interface CreatedNode {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+const uniqueSuffix = () => `${Date.now()}-${Math.floor(Math.random() * 100_000)}`;
+
+/**
+ * Create a node through the public REST API. Node creation is a reviewable
+ * operation, so this posts a ChangeRequest with `autoMerge`; the new id comes
+ * back in `mergeSummary.mergedNodeIds`, not in the (null) `node` field.
+ */
+const createNode = async (
+  request: Parameters<Parameters<typeof test>[2]>[0]["request"],
+  node: { nodeType: string; name: string; slug: string; parentNodeId?: string },
+): Promise<CreatedNode> => {
+  const response = await request.post("/api/v1/nodes/change-requests", {
+    data: {
+      message: `Create ${node.name}`,
+      autoMerge: true,
+      operations: [{ kind: "create", ...node }],
+    },
+  });
+  expect(response.ok(), `create ${node.name} → ${response.status()}`).toBe(true);
+  const payload = (await response.json()) as {
+    status: string;
+    mergeSummary?: { mergedNodeIds?: string[] };
+  };
+  expect(payload.status, `create ${node.name} did not merge`).toBe("merged");
+  const id = payload.mergeSummary?.mergedNodeIds?.[0];
+  expect(id, `create ${node.name} returned no node id`).toBeTruthy();
+  return { id: id as string, name: node.name, slug: node.slug };
+};
+
+const workspaceRow = (page: Page, name: string) =>
+  page
+    .locator('[data-sidebar="group"]')
+    .filter({ hasText: /^Workspace/ })
+    .locator("li")
+    .filter({ has: page.getByRole("link", { name, exact: true }) })
+    .last();
+
+/** Click a sidebar folder's NAME (navigate into it), not its chevron. */
+const openFolderByName = async (page: Page, name: string) => {
+  await workspaceRow(page, name).getByRole("link", { name, exact: true }).first().click();
+};
+
+test("navigating into a folder loads its children in the sidebar, at any depth", async ({
+  page,
+  request,
+}) => {
+  const suffix = uniqueSuffix();
+  const chain: CreatedNode[] = [];
+  let parentNodeId: string | undefined;
+  for (const level of [1, 2, 3, 4]) {
+    const node = await createNode(request, {
+      nodeType: "folder",
+      name: `Lazy L${level} ${suffix}`,
+      slug: `lazy-l${level}-${suffix}`,
+      parentNodeId,
+    });
+    chain.push(node);
+    parentNodeId = node.id;
+  }
+  const [level1, level2, level3, level4] = chain;
+  const leaf = await createNode(request, {
+    nodeType: "doc",
+    name: `Lazy Leaf ${suffix}`,
+    slug: `lazy-leaf-${suffix}`,
+    parentNodeId,
+  });
+
+  await page.goto("/dashboard/local/home");
+
+  // The eager prefetch reaches L2 and stops. L1's children are already loaded,
+  // so opening it is a pure UI toggle and proves nothing about lazy loading —
+  // it is only how L2's row gets on screen.
+  const level1Row = workspaceRow(page, level1.name);
+  await expect(level1Row).toBeVisible({ timeout: RENDER_TIMEOUT });
+  await level1Row.locator('button[title="Toggle"]').first().click();
+  await expect(workspaceRow(page, level2.name)).toBeVisible({ timeout: RENDER_TIMEOUT });
+  // Nothing below the prefetch boundary is in the tree yet.
+  await expect(workspaceRow(page, level3.name)).toHaveCount(0);
+
+  // The regression: navigate into L2 by its name. Its row opens because it is
+  // now the active route — never because of a toggle event — and its children
+  // still have to load.
+  await openFolderByName(page, level2.name);
+  await expect(workspaceRow(page, level3.name)).toBeVisible({ timeout: RENDER_TIMEOUT });
+
+  // L4 rode along with that same fetch (two levels per expand), so opening L3
+  // needs no fetch at all — but L4's own child was NOT part of it.
+  await openFolderByName(page, level3.name);
+  await expect(workspaceRow(page, level4.name)).toBeVisible({ timeout: RENDER_TIMEOUT });
+  await expect(workspaceRow(page, leaf.name)).toHaveCount(0);
+
+  // Second lazy fetch, merged into a subtree that itself arrived lazily.
+  await openFolderByName(page, level4.name);
+  await expect(workspaceRow(page, leaf.name)).toBeVisible({ timeout: RENDER_TIMEOUT });
+});
+
+/**
+ * The other half of the same deadlock, and the one a URL bar hits directly.
+ *
+ * Clicking down the tree works because each folder you click becomes the
+ * active route itself. LANDING on a deep url does not: a refresh, a bookmark,
+ * a shared link or a "recently visited" jump renders the sidebar with only its
+ * depth-bounded prefetch, so the active node's ancestors have never been
+ * fetched — and an ancestor that has not been fetched cannot be recognised as
+ * one. Nothing expands, so nothing loads, so nothing can ever expand, and the
+ * sidebar sits fully collapsed while the page it is supposedly reflecting is
+ * four levels down. `nodes.ancestors` is what breaks it.
+ */
+test("landing directly on a deep url expands the sidebar down to it", async ({ page, request }) => {
+  const suffix = uniqueSuffix();
+  const chain: CreatedNode[] = [];
+  let parentNodeId: string | undefined;
+  for (const level of [1, 2, 3, 4]) {
+    const node = await createNode(request, {
+      nodeType: "folder",
+      name: `Deep L${level} ${suffix}`,
+      slug: `deep-l${level}-${suffix}`,
+      parentNodeId,
+    });
+    chain.push(node);
+    parentNodeId = node.id;
+  }
+  const [level1, level2, level3, level4] = chain;
+  // A doc at the bottom, so this covers the shape a shared link usually has —
+  // a document deep inside a folder tree — and so the active assertion below
+  // can read `data-active`, which only leaf rows carry (a folder row shows its
+  // active state through a background class instead).
+  const leaf = await createNode(request, {
+    nodeType: "doc",
+    name: `Deep Leaf ${suffix}`,
+    slug: `deep-leaf-${suffix}`,
+    parentNodeId,
+  });
+
+  // A COLD load straight at the leaf — no prior sidebar interaction, so
+  // nothing below the prefetch boundary is in any cache.
+  await page.goto(`/dashboard/local/doc/${leaf.slug}`);
+
+  // Every ancestor opened, all four levels of them...
+  const leafRow = workspaceRow(page, leaf.name);
+  await expect(leafRow).toBeVisible({ timeout: RENDER_TIMEOUT });
+  for (const ancestor of [level1, level2, level3, level4]) {
+    await expect(workspaceRow(page, ancestor.name)).toBeVisible();
+  }
+  // ...and the row we actually navigated to is the highlighted one, not merely
+  // present — "expanded but nothing selected" would still leave the user lost.
+  await expect(leafRow.locator("[data-active='true']")).toBeVisible({
+    timeout: RENDER_TIMEOUT,
+  });
+});
+
+/**
+ * Regression cover for the sidebar chevron on the folder you are currently
+ * inside — a DIFFERENT bug from the two above, though it lives in the same
+ * "the sidebar can't tell what to do with the active route" family.
+ *
+ * A folder on the active route is pinned open by `isActiveTree`, so Radix's
+ * `onOpenChange(!open)` always sends `false` (`open` is always `true`) and
+ * clicking the chevron did nothing — not slow, not broken-looking, just
+ * completely inert. The fix is a manual override that beats the route-derived
+ * default, but ONLY while you stay on the page you collapsed it from: an
+ * override that survived navigation would re-hide the very folder you just
+ * navigated into, recreating a milder version of the same deadlock.
+ *
+ * That expiry is the part with a real failure mode of its own — comparing the
+ * override's saved location against the CURRENT location, instead of pruning
+ * it the moment location changes, cannot tell "never left" from "left and
+ * came back to the identical path" (2026 Launch -> Launch Assets -> Brand
+ * Kit is exactly that path every time). The second half of this test is
+ * exactly that round trip.
+ */
+test("the chevron on your current folder actually collapses it, and stops mattering once you leave", async ({
+  page,
+  request,
+}) => {
+  const suffix = uniqueSuffix();
+  const chain: CreatedNode[] = [];
+  let parentNodeId: string | undefined;
+  for (const level of [1, 2, 3]) {
+    const node = await createNode(request, {
+      nodeType: "folder",
+      name: `Chevron L${level} ${suffix}`,
+      slug: `chevron-l${level}-${suffix}`,
+      parentNodeId,
+    });
+    chain.push(node);
+    parentNodeId = node.id;
+  }
+  const [level1, level2, level3] = chain;
+  const leaf = await createNode(request, {
+    nodeType: "doc",
+    name: `Chevron Leaf ${suffix}`,
+    slug: `chevron-leaf-${suffix}`,
+    parentNodeId,
+  });
+
+  await page.goto(`/dashboard/local/folder/${level3.slug}`);
+  const leafRow = workspaceRow(page, leaf.name);
+  await expect(leafRow).toBeVisible({ timeout: RENDER_TIMEOUT });
+
+  // The folder we are standing inside — collapsing it must actually hide its
+  // own children, not silently do nothing.
+  const level3Row = workspaceRow(page, level3.name);
+  const toggle = level3Row.locator('button[title="Toggle"]').first();
+  await expect(level3Row).toHaveAttribute("data-state", "open");
+  await toggle.click();
+  await expect(level3Row).toHaveAttribute("data-state", "closed");
+  await expect(leafRow).toHaveCount(0);
+
+  // Re-expanding, still on the same page, must work too.
+  await toggle.click();
+  await expect(level3Row).toHaveAttribute("data-state", "open");
+  await expect(leafRow).toBeVisible({ timeout: RENDER_TIMEOUT });
+
+  // Collapse it again, then leave the page entirely.
+  await toggle.click();
+  await expect(level3Row).toHaveAttribute("data-state", "closed");
+  await page
+    .locator('[data-sidebar="sidebar"], [data-slot="sidebar-container"]')
+    .first()
+    .getByRole("link", { name: "Home", exact: true })
+    .first()
+    .click();
+
+  // Click all the way back down through the SAME path — landing on the exact
+  // url the collapse was recorded against.
+  await workspaceRow(page, level1.name)
+    .getByRole("link", { name: level1.name, exact: true })
+    .first()
+    .click();
+  await expect(workspaceRow(page, level2.name)).toBeVisible({ timeout: RENDER_TIMEOUT });
+  await workspaceRow(page, level2.name)
+    .getByRole("link", { name: level2.name, exact: true })
+    .first()
+    .click();
+  await expect(workspaceRow(page, level3.name)).toBeVisible({ timeout: RENDER_TIMEOUT });
+  await workspaceRow(page, level3.name)
+    .getByRole("link", { name: level3.name, exact: true })
+    .first()
+    .click();
+
+  // The stale collapse must not have followed us back: the folder — and the
+  // leaf it hid — must be visible again.
+  await expect(workspaceRow(page, level3.name)).toHaveAttribute("data-state", "open", {
+    timeout: RENDER_TIMEOUT,
+  });
+  await expect(workspaceRow(page, leaf.name)).toBeVisible({ timeout: RENDER_TIMEOUT });
+});
+
+/**
+ * Regression cover for a THIRD, separate bug in the same family: even once a
+ * deep node's row correctly loads and highlights (the two fixes above), a
+ * sidebar tall enough to need scrolling can still land that row somewhere the
+ * user never sees — past the visible fold entirely, or sitting exactly behind
+ * a fixed sidebar footer (a host-supplied element like "Agent Skills"),
+ * which PAINTS OVER the row rather than clipping it out of the layout. Either
+ * way it looks, to a user, exactly like the original bug: "I navigated here,
+ * the sidebar shows nothing for it."
+ *
+ * Checks a LEAF node specifically (not a folder): a folder's own `<li>` wraps
+ * its header AND its expanded children as one combined box, so testing
+ * "what's at its center point" is meaningless once it has visible children —
+ * a leaf's `<li>` is exactly its own row, so the center-point occlusion check
+ * below is actually asking the right question.
+ */
+test("a deep node scrolls itself clear of a fixed sidebar footer, without disturbing an already-visible click", async ({
+  page,
+  request,
+}) => {
+  const suffix = uniqueSuffix();
+  const chain: CreatedNode[] = [];
+  let parentNodeId: string | undefined;
+  // Deep enough that its own row lands in (or past) a real sidebar footer's
+  // band on an ordinary viewport — shallower chains never reach it.
+  for (const level of [1, 2, 3, 4] as const) {
+    const node = await createNode(request, {
+      nodeType: "folder",
+      name: `Footer L${level} ${suffix}`,
+      slug: `footer-l${level}-${suffix}`,
+      parentNodeId,
+    });
+    chain.push(node);
+    parentNodeId = node.id;
+  }
+  const leaf = await createNode(request, {
+    nodeType: "doc",
+    name: `Footer Leaf ${suffix}`,
+    slug: `footer-leaf-${suffix}`,
+    parentNodeId,
+  });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(`/dashboard/local/doc/${leaf.slug}`);
+
+  const leafRow = workspaceRow(page, leaf.name);
+  await expect(leafRow).toBeVisible({ timeout: RENDER_TIMEOUT });
+
+  await expect(async () => {
+    const occluded = await leafRow.evaluate((li) => {
+      const r = li.getBoundingClientRect();
+      const top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+      const inViewport = r.top >= 0 && r.bottom <= window.innerHeight;
+      return !inViewport || !top || !li.contains(top);
+    });
+    expect(occluded).toBe(false);
+  }).toPass({ timeout: RENDER_TIMEOUT });
+
+  // An ordinary click on a row that is ALREADY fully visible must not yank
+  // the sidebar's scroll position to re-center it underneath the user — that
+  // would be its own, milder version of "the sidebar moves on its own".
+  //
+  // Re-clicks the leaf's OWN row (not a navigation to a different page) on
+  // purpose, to isolate this from a real confound: navigating AWAY to a page
+  // with nothing on this chain's active path collapses the whole expanded
+  // chain (nothing keeps it open anymore), which shrinks the list — and a
+  // shrunk list legitimately reflows `scrollTop` via ordinary browser
+  // clamping (`scrollHeight - scrollTop` staying pinned to `clientHeight`
+  // both before and after), independent of anything this fix does. Clicking
+  // the same already-active row changes neither the route nor the tree
+  // shape, so it isolates exactly the thing being tested.
+  const scrollTopBefore = await page.evaluate(
+    () => document.querySelector("[data-busabase-sidebar-nav]")?.scrollTop ?? null,
+  );
+  await leafRow.getByRole("link", { name: leaf.name, exact: true }).first().click();
+  await page.waitForTimeout(500);
+  const scrollTopAfter = await page.evaluate(
+    () => document.querySelector("[data-busabase-sidebar-nav]")?.scrollTop ?? null,
+  );
+  expect(scrollTopAfter).toBe(scrollTopBefore);
+});

--- a/apps/busabase/tsconfig.json
+++ b/apps/busabase/tsconfig.json
@@ -27,6 +27,7 @@
       "busabase-core/*": ["../../packages/busabase-core/src/*"],
       "busabase-cli": ["../busabase-cli/src/index.ts"],
       "busabase-sdk": ["../busabase-sdk/src/index.ts"],
+      "busabase-sdk/*": ["../busabase-sdk/src/*.ts"],
       "share-domains/*": ["../../packages/share-domains/*"],
       "billing": ["../../packages/billing/index.ts"],
       "billing/*": ["../../packages/billing/*"],

--- a/apps/busabase/vitest.config.ts
+++ b/apps/busabase/vitest.config.ts
@@ -3,23 +3,47 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
-    alias: {
-      "~": path.resolve(__dirname, "./src"),
-      // `busabase-cli` / `busabase-sdk` resolve to their built `dist/` via package
-      // exports; point at source so the CLI golden-path e2e runs without a build.
-      "busabase-cli": path.resolve(__dirname, "../busabase-cli/src/index.ts"),
-      "busabase-sdk": path.resolve(__dirname, "../busabase-sdk/src/index.ts"),
-      "busabase-contract/api-client": path.resolve(
-        __dirname,
-        "../../packages/busabase-contract/src/api-client/index.ts",
-      ),
-      "busabase-core/logic/store": path.resolve(
-        __dirname,
-        "../../packages/busabase-core/src/logic/store.ts",
-      ),
-      "server-only": path.resolve(__dirname, "./tests/mocks/server-only.ts"),
-      "sharelib/storage": path.resolve(__dirname, "../../packages/openlib/storage/index.ts"),
-    },
+    // An array, not an object: a plain-object string key is matched by PREFIX, and
+    // `busabase-sdk` now has a subpath (`airapp-check`) that a bare-string alias
+    // silently rewrote to `.../src/index.ts/airapp-check` — ENOTDIR, and it crashed
+    // at module load, before either cli-template test ran, since busabase-cli's
+    // run.ts now imports it at the top level for every command, not just `check`.
+    // Same fix as apps/busabase-cli/vitest.config.ts; keep the two in sync if the
+    // SDK gains more subpaths.
+    alias: [
+      { find: "~", replacement: path.resolve(__dirname, "./src") },
+      // `busabase-cli` has only its bare `.` export today, so a plain string is
+      // still correct here — but see the busabase-sdk entries below for what
+      // breaks the moment that stops being true.
+      {
+        find: "busabase-cli",
+        replacement: path.resolve(__dirname, "../busabase-cli/src/index.ts"),
+      },
+      {
+        find: /^busabase-sdk\/(.+)$/,
+        replacement: path.resolve(__dirname, "../busabase-sdk/src/$1.ts"),
+      },
+      {
+        find: /^busabase-sdk$/,
+        replacement: path.resolve(__dirname, "../busabase-sdk/src/index.ts"),
+      },
+      {
+        find: "busabase-contract/api-client",
+        replacement: path.resolve(
+          __dirname,
+          "../../packages/busabase-contract/src/api-client/index.ts",
+        ),
+      },
+      {
+        find: "busabase-core/logic/store",
+        replacement: path.resolve(__dirname, "../../packages/busabase-core/src/logic/store.ts"),
+      },
+      { find: "server-only", replacement: path.resolve(__dirname, "./tests/mocks/server-only.ts") },
+      {
+        find: "sharelib/storage",
+        replacement: path.resolve(__dirname, "../../packages/openlib/storage/index.ts"),
+      },
+    ],
   },
   test: {
     environment: "node",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-repo",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "packageManager": "pnpm@10.15.1",
   "workspaces": [
     "apps/*",

--- a/packages/@acp-ui/core/src/prompt/attachment-media.test.ts
+++ b/packages/@acp-ui/core/src/prompt/attachment-media.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  attachmentText,
+  attachmentToContentBlock,
+  attachmentUri,
+  classifyMimeType,
+  decodeBase64,
+  decodeUtf8Text,
+} from "./attachment-media";
+
+const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+const bytesB64 = (...bytes: number[]) => Buffer.from(bytes).toString("base64");
+
+describe("classifyMimeType", () => {
+  it("recognises text/* and the textual application/* types", () => {
+    for (const type of [
+      "text/plain",
+      "text/markdown",
+      "text/csv",
+      "TEXT/HTML",
+      "text/plain; charset=utf-8",
+      "application/json",
+      "application/yaml",
+      "application/x-sh",
+      "application/vnd.api+json",
+      "image/svg+xml",
+    ]) {
+      expect(classifyMimeType(type), type).not.toBe(false);
+    }
+    expect(classifyMimeType("application/json")).toBe(true);
+    expect(classifyMimeType("application/vnd.api+json")).toBe(true);
+  });
+
+  it("recognises the obviously binary families", () => {
+    expect(classifyMimeType("image/png")).toBe(false);
+    expect(classifyMimeType("audio/wav")).toBe(false);
+    expect(classifyMimeType("video/mp4")).toBe(false);
+    expect(classifyMimeType("application/pdf")).toBe(false);
+    expect(classifyMimeType("application/zip")).toBe(false);
+  });
+
+  it("stays undecided where the browser is unreliable", () => {
+    // Browsers report "" for extensions they don't know, and `video/mp2t`
+    // for `.ts` — deferring to byte sniffing is the whole point.
+    expect(classifyMimeType("")).toBeUndefined();
+    expect(classifyMimeType("   ")).toBeUndefined();
+    expect(classifyMimeType("video/mp2t")).toBeUndefined();
+    expect(classifyMimeType("application/octet-stream")).toBeUndefined();
+  });
+});
+
+describe("decodeBase64 / decodeUtf8Text", () => {
+  it("round-trips UTF-8, including multi-byte characters", () => {
+    const bytes = decodeBase64(b64("héllo 世界"));
+    expect(bytes).not.toBeNull();
+    expect(decodeUtf8Text(bytes as Uint8Array)).toBe("héllo 世界");
+  });
+
+  it("returns null for input that is not base64 at all", () => {
+    expect(decodeBase64("not base64!!!")).toBeNull();
+  });
+
+  it("rejects a NUL byte even though it is valid UTF-8", () => {
+    expect(decodeUtf8Text(new Uint8Array([0x68, 0x00, 0x69]))).toBeNull();
+  });
+
+  it("rejects invalid UTF-8 rather than returning replacement characters", () => {
+    // 0xFF is never valid in UTF-8. A lenient decoder would hand back "�",
+    // which reads as plausible text and is exactly the bug this guards.
+    expect(decodeUtf8Text(new Uint8Array([0xff, 0xfe, 0xfd]))).toBeNull();
+  });
+});
+
+describe("attachmentText", () => {
+  it("returns the decoded text for a textual payload", () => {
+    expect(attachmentText("text/markdown", b64("# hi"))).toBe("# hi");
+  });
+
+  it("returns null for a declared-binary type without even decoding", () => {
+    expect(attachmentText("application/pdf", b64("this is actually text"))).toBeNull();
+  });
+
+  it("sniffs an unknown type by its bytes", () => {
+    expect(attachmentText("", b64("plain words"))).toBe("plain words");
+    expect(attachmentText("", bytesB64(0xff, 0xd8, 0xff, 0xe0))).toBeNull();
+  });
+
+  it("treats empty content as text only when the MIME type is confident", () => {
+    expect(attachmentText("text/plain", "")).toBe("");
+    expect(attachmentText("", "")).toBeNull();
+  });
+});
+
+describe("attachmentUri", () => {
+  it("percent-encodes the filename under an opaque scheme", () => {
+    expect(attachmentUri("my report.pdf")).toBe("attachment:///my%20report.pdf");
+    expect(attachmentUri("报告.pdf")).toBe("attachment:///%E6%8A%A5%E5%91%8A.pdf");
+  });
+
+  it("falls back to a stable label when there is no filename", () => {
+    expect(attachmentUri(undefined)).toBe("attachment:///attachment");
+    expect(attachmentUri("   ")).toBe("attachment:///attachment");
+  });
+});
+
+describe("attachmentToContentBlock", () => {
+  it("passes image and audio through unchanged", () => {
+    expect(
+      attachmentToContentBlock({ kind: "image", data: "aW1n", mimeType: "image/png" }),
+    ).toEqual({ type: "image", data: "aW1n", mimeType: "image/png" });
+  });
+
+  it("builds a text resource for text and a blob resource for bytes", () => {
+    expect(
+      attachmentToContentBlock({
+        kind: "file",
+        data: b64("hi"),
+        mimeType: "text/plain",
+        filename: "a.txt",
+      }),
+    ).toEqual({
+      type: "resource",
+      resource: { uri: "attachment:///a.txt", mimeType: "text/plain", text: "hi" },
+    });
+
+    const blob = bytesB64(0x00, 0x01, 0x02);
+    expect(
+      attachmentToContentBlock({
+        kind: "file",
+        data: blob,
+        mimeType: "application/pdf",
+        filename: "a.pdf",
+      }),
+    ).toEqual({
+      type: "resource",
+      resource: { uri: "attachment:///a.pdf", mimeType: "application/pdf", blob },
+    });
+  });
+});

--- a/packages/@acp-ui/core/src/prompt/attachment-media.ts
+++ b/packages/@acp-ui/core/src/prompt/attachment-media.ts
@@ -1,0 +1,163 @@
+/**
+ * Deciding whether an attachment travels as *text* or as *bytes*.
+ *
+ * ACP's `EmbeddedResource` carries either `TextResourceContents` (a `text`
+ * field) or `BlobResourceContents` (a base64 `blob`), and the protocol says
+ * nothing about which to use for a given file — that choice is left to the
+ * client. It matters more than it looks: a Markdown file sent as a blob
+ * reaches the agent as base64 it has to decode before it can read a word,
+ * while the same file sent as text is immediately usable. Getting it wrong
+ * costs the user an unusable attachment, not just an inelegant one.
+ *
+ * The wire shape stays uniform on purpose — `AcpAttachment.data` is ALWAYS
+ * base64, for every kind — so the browser never has to guess an encoding and
+ * binary payloads can't be corrupted in transit. This module is what turns
+ * that uniform payload back into the right ACP shape at the point of send.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+import type { AcpAttachment } from "../reduce";
+
+/** MIME types that are text despite not living under `text/`. */
+const TEXTUAL_APPLICATION_TYPES = new Set([
+  "application/json",
+  "application/ld+json",
+  "application/xml",
+  "application/xhtml+xml",
+  "application/javascript",
+  "application/ecmascript",
+  "application/typescript",
+  "application/sql",
+  "application/graphql",
+  "application/yaml",
+  "application/x-yaml",
+  "application/toml",
+  "application/x-sh",
+  "application/x-shellscript",
+  "application/x-httpd-php",
+  "application/x-latex",
+  "application/x-tex",
+]);
+
+/** Binary families worth short-circuiting before any byte sniffing. */
+const BINARY_PREFIXES = ["image/", "audio/", "video/", "font/"];
+
+/**
+ * `true` textual, `false` binary, `undefined` when the MIME type alone can't
+ * say. Browsers report `""` for extensions they don't know (very common for
+ * source files) and actively *mislabel* some — a `.ts` file is reported as
+ * `video/mp2t`, an MPEG transport stream, which is why the caller falls back
+ * to sniffing the bytes rather than trusting this answer when it is
+ * `undefined` — and why `video/` is NOT treated as a confident `false`.
+ */
+export function classifyMimeType(mimeType: string): boolean | undefined {
+  const type = mimeType.trim().toLowerCase().split(";")[0] ?? "";
+  if (type === "") return undefined;
+  if (type.startsWith("text/")) return true;
+  if (TEXTUAL_APPLICATION_TYPES.has(type)) return true;
+  // Structured syntax suffixes are text wherever they appear, which includes
+  // `image/svg+xml` — an SVG is markup an agent can read and edit, so it is
+  // checked before the `image/` prefix below would call it binary.
+  if (type.endsWith("+json") || type.endsWith("+xml")) return true;
+  // `video/mp2t` is excluded deliberately: it is what browsers report for
+  // `.ts` TypeScript files far more often than for real transport streams.
+  if (type === "video/mp2t") return undefined;
+  if (BINARY_PREFIXES.some((prefix) => type.startsWith(prefix))) return false;
+  if (type === "application/octet-stream") return undefined;
+  if (type.startsWith("application/")) return false;
+  return undefined;
+}
+
+/** Base64 → bytes. `null` when `data` isn't valid base64 at all. */
+export function decodeBase64(data: string): Uint8Array | null {
+  try {
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Bytes → string, but only if they really are text.
+ *
+ * `fatal: true` makes the decoder reject invalid UTF-8 instead of silently
+ * scattering U+FFFD replacement characters through a binary file — which is
+ * exactly the failure this guards against, since a PDF decoded that way looks
+ * like plausible text right up until the agent tries to use it. A NUL byte is
+ * treated as binary regardless: it decodes as valid UTF-8, but no real text
+ * file contains one.
+ */
+export function decodeUtf8Text(bytes: Uint8Array): string | null {
+  if (bytes.includes(0)) return null;
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The text of an attachment whose payload is genuinely text, or `null` when it
+ * is binary (or undecodable).
+ *
+ * MIME decides when it is confident; the bytes themselves decide when it is
+ * not. Sniffing rather than guessing from the file extension is what makes an
+ * extensionless `Dockerfile` or a browser-mislabelled `.ts` land as text
+ * without also mistaking a real `.ts` transport stream for one.
+ */
+export function attachmentText(mimeType: string, data: string): string | null {
+  const classified = classifyMimeType(mimeType);
+  if (classified === false) return null;
+  const bytes = decodeBase64(data);
+  if (bytes === null) return null;
+  const text = decodeUtf8Text(bytes);
+  if (text === null) return null;
+  // A confident textual MIME type is trusted even for empty content; an
+  // unknown one has only the bytes to go on, and empty bytes say nothing.
+  if (classified === undefined && text.length === 0) return null;
+  return text;
+}
+
+/**
+ * The `uri` every embedded resource must carry.
+ *
+ * ACP requires the field but says nothing about its scheme, and there is no
+ * real one to report: the file was uploaded from a browser and exists nowhere
+ * the agent can reach. `file:///` was rejected for exactly that reason — it
+ * invites an agent to try opening a path that does not exist, turning a
+ * working attachment into a confusing "no such file". An opaque
+ * `attachment:///` scheme is honest about what this is: a label for content
+ * that is already embedded in the message and needs no fetching.
+ */
+export function attachmentUri(filename: string | undefined): string {
+  return `attachment:///${encodeURIComponent(filename?.trim() || "attachment")}`;
+}
+
+/**
+ * One `AcpAttachment` → the ACP content block that carries it.
+ *
+ * Shared by the real send path (`buildPromptContent`) and by the local echo a
+ * host without a server-side prompt echo renders optimistically, so the
+ * message a user sees is built from the same rules as the message the agent
+ * receives — rather than the echo hand-rolling a `{ type: attachment.kind }`
+ * object that is not a valid content block at all for a `file`.
+ */
+export function attachmentToContentBlock(attachment: AcpAttachment): acp.ContentBlock {
+  if (attachment.kind === "image" || attachment.kind === "audio") {
+    return { type: attachment.kind, data: attachment.data, mimeType: attachment.mimeType };
+  }
+  const uri = attachmentUri(attachment.filename);
+  const text = attachmentText(attachment.mimeType, attachment.data);
+  return {
+    type: "resource",
+    resource:
+      text === null
+        ? { uri, mimeType: attachment.mimeType, blob: attachment.data }
+        : { uri, mimeType: attachment.mimeType, text },
+  };
+}

--- a/packages/@acp-ui/core/src/prompt/build-prompt-content.test.ts
+++ b/packages/@acp-ui/core/src/prompt/build-prompt-content.test.ts
@@ -2,10 +2,19 @@ import { describe, expect, it } from "vitest";
 import type { AcpAttachment } from "../reduce";
 import { buildPromptContent } from "./build-prompt-content";
 
+/** base64 of a UTF-8 string — the shape the browser always sends. */
+const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+
 describe("buildPromptContent", () => {
   it("wraps bare text as a single text block when there are no attachments", () => {
-    expect(buildPromptContent("hello", undefined)).toEqual([{ type: "text", text: "hello" }]);
-    expect(buildPromptContent("hello", [])).toEqual([{ type: "text", text: "hello" }]);
+    expect(buildPromptContent("hello", undefined)).toEqual({
+      prompt: [{ type: "text", text: "hello" }],
+      notes: [],
+    });
+    expect(buildPromptContent("hello", [])).toEqual({
+      prompt: [{ type: "text", text: "hello" }],
+      notes: [],
+    });
   });
 
   it("appends image and audio attachments after the text block, in order", () => {
@@ -14,19 +23,193 @@ describe("buildPromptContent", () => {
       { kind: "audio", data: "YXVk", mimeType: "audio/wav" },
     ];
 
-    expect(buildPromptContent("caption", attachments)).toEqual([
-      { type: "text", text: "caption" },
-      { type: "image", data: "aW1n", mimeType: "image/png" },
-      { type: "audio", data: "YXVk", mimeType: "audio/wav" },
-    ]);
+    expect(buildPromptContent("caption", attachments)).toEqual({
+      prompt: [
+        { type: "text", text: "caption" },
+        { type: "image", data: "aW1n", mimeType: "image/png" },
+        { type: "audio", data: "YXVk", mimeType: "audio/wav" },
+      ],
+      notes: [],
+    });
   });
 
   it("allows an empty text with attachments (caption-less send)", () => {
     const attachments: AcpAttachment[] = [{ kind: "image", data: "aW1n", mimeType: "image/png" }];
 
-    expect(buildPromptContent("", attachments)).toEqual([
-      { type: "text", text: "" },
-      { type: "image", data: "aW1n", mimeType: "image/png" },
-    ]);
+    expect(buildPromptContent("", attachments)).toEqual({
+      prompt: [
+        { type: "text", text: "" },
+        { type: "image", data: "aW1n", mimeType: "image/png" },
+      ],
+      notes: [],
+    });
+  });
+
+  describe("file attachments → embedded resource", () => {
+    it("sends a textual file as ACP TextResourceContents, decoded", () => {
+      const attachments: AcpAttachment[] = [
+        {
+          kind: "file",
+          data: b64("# Title\n\n你好"),
+          mimeType: "text/markdown",
+          filename: "a b.md",
+        },
+      ];
+
+      expect(buildPromptContent("read this", attachments, { embeddedContext: true })).toEqual({
+        prompt: [
+          { type: "text", text: "read this" },
+          {
+            type: "resource",
+            resource: {
+              uri: "attachment:///a%20b.md",
+              mimeType: "text/markdown",
+              text: "# Title\n\n你好",
+            },
+          },
+        ],
+        notes: [],
+      });
+    });
+
+    it("sends a binary file as ACP BlobResourceContents, base64 untouched", () => {
+      // A PDF header followed by a NUL byte — valid base64, but not text.
+      const data = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x00, 0xff]).toString("base64");
+      const attachments: AcpAttachment[] = [
+        { kind: "file", data, mimeType: "application/pdf", filename: "report.pdf" },
+      ];
+
+      expect(buildPromptContent("", attachments, { embeddedContext: true })).toEqual({
+        prompt: [
+          { type: "text", text: "" },
+          {
+            type: "resource",
+            resource: { uri: "attachment:///report.pdf", mimeType: "application/pdf", blob: data },
+          },
+        ],
+        notes: [],
+      });
+    });
+
+    it("treats a browser-mislabelled .ts source file as text, not an MPEG stream", () => {
+      // Browsers report `video/mp2t` for `.ts`. Sniffing the bytes is what
+      // keeps a TypeScript file from being shipped as an opaque blob.
+      const attachments: AcpAttachment[] = [
+        {
+          kind: "file",
+          data: b64("export const a = 1;\n"),
+          mimeType: "video/mp2t",
+          filename: "a.ts",
+        },
+      ];
+
+      const { prompt } = buildPromptContent("", attachments, { embeddedContext: true });
+      expect(prompt[1]).toEqual({
+        type: "resource",
+        resource: {
+          uri: "attachment:///a.ts",
+          mimeType: "video/mp2t",
+          text: "export const a = 1;\n",
+        },
+      });
+    });
+
+    it("keeps a real binary payload with an unknown MIME type as a blob", () => {
+      const data = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]).toString("base64");
+      const attachments: AcpAttachment[] = [
+        { kind: "file", data, mimeType: "", filename: "mystery.bin" },
+      ];
+
+      const { prompt } = buildPromptContent("", attachments, { embeddedContext: true });
+      expect(prompt[1]).toMatchObject({ type: "resource", resource: { blob: data } });
+    });
+  });
+
+  describe("capability negotiation", () => {
+    it("sends everything when no capabilities are supplied (un-negotiated host)", () => {
+      const attachments: AcpAttachment[] = [
+        { kind: "image", data: "aW1n", mimeType: "image/png" },
+        { kind: "file", data: b64("hi"), mimeType: "text/plain", filename: "n.txt" },
+      ];
+
+      const { prompt, notes } = buildPromptContent("x", attachments);
+      expect(prompt.map((block) => block.type)).toEqual(["text", "image", "resource"]);
+      expect(notes).toEqual([]);
+    });
+
+    it("treats an omitted capability as unsupported, per ACP", () => {
+      const attachments: AcpAttachment[] = [{ kind: "image", data: "aW1n", mimeType: "image/png" }];
+
+      const { prompt, notes } = buildPromptContent("x", attachments, {});
+      expect(prompt).toEqual([{ type: "text", text: "x" }]);
+      expect(notes).toEqual(["This agent does not accept image attachments, so it was not sent."]);
+    });
+
+    it("still sends an image when the agent explicitly advertises it", () => {
+      const attachments: AcpAttachment[] = [{ kind: "image", data: "aW1n", mimeType: "image/png" }];
+
+      const { prompt, notes } = buildPromptContent("x", attachments, { image: true });
+      expect(prompt.map((block) => block.type)).toEqual(["text", "image"]);
+      expect(notes).toEqual([]);
+    });
+  });
+
+  describe("fallback when embeddedContext is unsupported", () => {
+    it("inlines a textual file into the text block and says so", () => {
+      const attachments: AcpAttachment[] = [
+        { kind: "file", data: b64("a,b\n1,2"), mimeType: "text/csv", filename: "data.csv" },
+      ];
+
+      const { prompt, notes } = buildPromptContent("summarise", attachments, {});
+      expect(prompt).toEqual([
+        {
+          type: "text",
+          text: "summarise\n\n--- Attached file: data.csv ---\na,b\n1,2\n--- End of attached file: data.csv ---",
+        },
+      ]);
+      expect(notes).toEqual([
+        "This agent does not accept file attachments, so data.csv was included as plain text instead.",
+      ]);
+    });
+
+    it("drops a binary file it cannot inline, and explains why", () => {
+      const data = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x00]).toString("base64");
+      const attachments: AcpAttachment[] = [
+        { kind: "file", data, mimeType: "application/pdf", filename: "report.pdf" },
+      ];
+
+      const { prompt, notes } = buildPromptContent("read it", attachments, {});
+      expect(prompt).toEqual([{ type: "text", text: "read it" }]);
+      expect(notes).toEqual([
+        "This agent does not accept file attachments, and report.pdf is not text, so it was not sent.",
+      ]);
+    });
+
+    it("inlines a text-only prompt's file even when the user wrote nothing", () => {
+      const attachments: AcpAttachment[] = [
+        { kind: "file", data: b64("hello"), mimeType: "text/plain", filename: "n.txt" },
+      ];
+
+      const { prompt } = buildPromptContent("", attachments, {});
+      expect(prompt).toEqual([
+        {
+          type: "text",
+          text: "--- Attached file: n.txt ---\nhello\n--- End of attached file: n.txt ---",
+        },
+      ]);
+    });
+
+    it("lists several degraded files in one note", () => {
+      const attachments: AcpAttachment[] = [
+        { kind: "file", data: b64("1"), mimeType: "text/plain", filename: "a.txt" },
+        { kind: "file", data: b64("2"), mimeType: "text/plain", filename: "b.txt" },
+        { kind: "file", data: b64("3"), mimeType: "text/plain", filename: "c.txt" },
+      ];
+
+      const { notes } = buildPromptContent("", attachments, {});
+      expect(notes).toEqual([
+        "This agent does not accept file attachments, so a.txt, b.txt, and c.txt were included as plain text instead.",
+      ]);
+    });
   });
 });

--- a/packages/@acp-ui/core/src/prompt/build-prompt-content.ts
+++ b/packages/@acp-ui/core/src/prompt/build-prompt-content.ts
@@ -1,26 +1,118 @@
 import type * as acp from "@agentclientprotocol/sdk";
 import type { AcpAttachment } from "../reduce";
+import { attachmentText, attachmentToContentBlock } from "./attachment-media";
+
+/**
+ * The prompt to send, plus anything the user needs told about it.
+ *
+ * `notes` exists because silence is the wrong failure mode here. ACP makes
+ * `image`, `audio` and `embeddedContext` opt-in capabilities an agent must
+ * advertise, so an attachment can be perfectly valid and still be
+ * unsendable to *this* agent. Dropping it quietly leaves the user staring at
+ * a reply that ignores the PDF they attached with no way to know why. Each
+ * note is a plain sentence a host can surface the same way busabase already
+ * surfaces its `mcpCapabilities.http` note.
+ */
+export interface BuiltPrompt {
+  prompt: acp.ContentBlock[];
+  notes: string[];
+}
 
 /**
  * Text + staged attachments → ACP's `PromptRequest.prompt` content-block
- * array. Was duplicated verbatim in both acprouter's and busabase's `logic/`
- * (same body, byte-for-byte) since each app's `PromptAttachmentInput` DTO is
- * already `AcpAttachment`'s shape (`{ kind: "image"|"audio", data, mimeType }`
- * — ACP's own `ImageContent`/`AudioContent` shape verbatim), so there was
- * nothing app-specific left to justify two copies.
+ * array, negotiated against what the agent actually said it can accept.
+ *
+ * ACP's baseline is narrow and explicit: "Baseline agent functionality
+ * requires support for `ContentBlock::Text` and `ContentBlock::ResourceLink`.
+ * Other variants must be explicitly opted in to." Images, audio and embedded
+ * resources are all opt-in, so sending them blind is a protocol violation that
+ * happens to work only because the popular agents happen to support them.
+ *
+ * `capabilities` is what makes this compliant:
+ * - `undefined`/`null` → no negotiation available; send everything, which is
+ *   this function's historical behaviour and keeps a host that hasn't wired
+ *   `initialize` results through working exactly as before.
+ * - provided → a capability is supported only if it is explicitly `true`. ACP
+ *   says an omitted capability means unsupported, so `{}` correctly gates
+ *   everything off.
+ *
+ * A `file` the agent can't take embedded is not simply discarded when it is
+ * textual: its content is appended to the text block instead. Text is a
+ * baseline capability every agent supports, and the token cost is the same
+ * either way — the file's words are the file's words — so the fallback keeps
+ * Markdown, CSV, JSON and source files usable on agents that advertise
+ * nothing. Binary files have no such fallback and say so.
  */
 export function buildPromptContent(
   text: string,
-  attachments: AcpAttachment[] | undefined,
-): acp.ContentBlock[] {
-  return [
-    { type: "text", text },
-    ...(attachments ?? []).map(
-      (attachment): acp.ContentBlock => ({
-        type: attachment.kind,
-        data: attachment.data,
-        mimeType: attachment.mimeType,
-      }),
-    ),
-  ];
+  attachments: readonly AcpAttachment[] | undefined,
+  capabilities?: acp.PromptCapabilities | null,
+): BuiltPrompt {
+  const negotiated = capabilities != null;
+  const supports = (capability: keyof acp.PromptCapabilities) =>
+    !negotiated || capabilities?.[capability] === true;
+
+  const blocks: acp.ContentBlock[] = [];
+  const inlined: string[] = [];
+  const rejectedMedia: string[] = [];
+  const rejectedBinary: string[] = [];
+  const inlinedNames: string[] = [];
+
+  for (const attachment of attachments ?? []) {
+    if (attachment.kind === "image" || attachment.kind === "audio") {
+      if (supports(attachment.kind)) {
+        blocks.push(attachmentToContentBlock(attachment));
+      } else {
+        rejectedMedia.push(attachment.kind);
+      }
+      continue;
+    }
+
+    const name = attachment.filename?.trim() || "attachment";
+    const asText = attachmentText(attachment.mimeType, attachment.data);
+
+    if (supports("embeddedContext")) {
+      blocks.push(attachmentToContentBlock(attachment));
+      continue;
+    }
+
+    if (asText === null) {
+      rejectedBinary.push(name);
+    } else {
+      inlined.push(
+        `--- Attached file: ${name} ---\n${asText}\n--- End of attached file: ${name} ---`,
+      );
+      inlinedNames.push(name);
+    }
+  }
+
+  const notes: string[] = [];
+  if (rejectedMedia.length > 0) {
+    const kinds = [...new Set(rejectedMedia)].sort().join(" or ");
+    notes.push(
+      `This agent does not accept ${kinds} attachments, so ${rejectedMedia.length === 1 ? "it was" : "they were"} not sent.`,
+    );
+  }
+  if (inlinedNames.length > 0) {
+    notes.push(
+      `This agent does not accept file attachments, so ${formatList(inlinedNames)} ${inlinedNames.length === 1 ? "was" : "were"} included as plain text instead.`,
+    );
+  }
+  if (rejectedBinary.length > 0) {
+    notes.push(
+      `This agent does not accept file attachments, and ${formatList(rejectedBinary)} ${rejectedBinary.length === 1 ? "is" : "are"} not text, so ${rejectedBinary.length === 1 ? "it was" : "they were"} not sent.`,
+    );
+  }
+
+  // The text block stays first and is emitted even when empty: an
+  // attachment-only prompt is valid, and both hosts' contracts already
+  // guarantee at least one of text/attachments is present.
+  const promptText = [text, ...inlined].filter((part) => part.length > 0).join("\n\n");
+  return { prompt: [{ type: "text", text: promptText }, ...blocks], notes };
+}
+
+function formatList(names: string[]): string {
+  if (names.length === 1) return names[0] as string;
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
 }

--- a/packages/@acp-ui/core/src/prompt/index.ts
+++ b/packages/@acp-ui/core/src/prompt/index.ts
@@ -1,1 +1,10 @@
+export {
+  attachmentText,
+  attachmentToContentBlock,
+  attachmentUri,
+  classifyMimeType,
+  decodeBase64,
+  decodeUtf8Text,
+} from "./attachment-media";
+export type { BuiltPrompt } from "./build-prompt-content";
 export { buildPromptContent } from "./build-prompt-content";

--- a/packages/@acp-ui/core/src/reduce/reduce-acp-event.test.ts
+++ b/packages/@acp-ui/core/src/reduce/reduce-acp-event.test.ts
@@ -163,6 +163,69 @@ describe("attachments", () => {
       { kind: "audio", data: "clip", mimeType: "audio/wav" },
     ]);
   });
+
+  // An embedded `resource` is what the user's own file attachments echo back
+  // as, and what an agent forwarding MCP tool output can send. Both arms of
+  // `EmbeddedResourceResource` normalise to the same base64 `data` shape so
+  // the renderers never branch on which one arrived.
+  const resourceChunk = (resource: unknown): AcpUiEvent => ({
+    type: "session_update",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "resource", resource },
+    } as never,
+  });
+
+  it("normalises a text resource to base64, recovering the filename from its uri", () => {
+    const blocks = fold([
+      resourceChunk({
+        uri: "attachment:///my%20notes.md",
+        mimeType: "text/markdown",
+        text: "# hi",
+      }),
+    ]);
+    expect((blocks[0] as AcpMessageBlock).attachments).toEqual([
+      {
+        kind: "file",
+        data: Buffer.from("# hi", "utf8").toString("base64"),
+        mimeType: "text/markdown",
+        filename: "my notes.md",
+      },
+    ]);
+  });
+
+  it("passes a blob resource through untouched", () => {
+    const blocks = fold([
+      resourceChunk({
+        uri: "file:///tmp/report.pdf",
+        mimeType: "application/pdf",
+        blob: "JVBERi0=",
+      }),
+    ]);
+    expect((blocks[0] as AcpMessageBlock).attachments).toEqual([
+      { kind: "file", data: "JVBERi0=", mimeType: "application/pdf", filename: "report.pdf" },
+    ]);
+  });
+
+  it("defaults a resource with no declared mime type rather than dropping it", () => {
+    const blocks = fold([resourceChunk({ uri: "attachment:///x", text: "plain" })]);
+    expect((blocks[0] as AcpMessageBlock).attachments?.[0]?.mimeType).toBe(
+      "application/octet-stream",
+    );
+  });
+
+  it("still ignores resource_link, which names a file rather than carrying one", () => {
+    const blocks = fold([
+      {
+        type: "session_update",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "resource_link", uri: "file:///a.ts", name: "a.ts" },
+        } as never,
+      },
+    ]);
+    expect(blocks).toEqual([]);
+  });
 });
 
 describe("tool calls", () => {

--- a/packages/@acp-ui/core/src/reduce/reduce-acp-event.ts
+++ b/packages/@acp-ui/core/src/reduce/reduce-acp-event.ts
@@ -144,16 +144,49 @@ function textOf(content: ContentBlock): string | null {
 }
 
 /**
- * Images and audio become `AcpAttachment`s. `resource_link`/`resource` are
- * explicitly out of scope (see `AcpAttachment`'s doc comment) and, like the
- * eight unhandled `sessionUpdate` kinds, fall through as neither text nor an
- * attachment — silently ignored rather than surfaced as unreadable JSON.
+ * Images, audio and embedded resources become `AcpAttachment`s.
+ *
+ * A `resource` arrives as either `TextResourceContents` or
+ * `BlobResourceContents`; `AcpAttachment.data` is uniformly base64, so a text
+ * resource is re-encoded here rather than stored in a second representation
+ * the renderers would each have to branch on. `resource_link` stays out of
+ * scope (see `AcpAttachment`'s doc comment) and, like the eight unhandled
+ * `sessionUpdate` kinds, falls through as neither text nor an attachment —
+ * silently ignored rather than surfaced as unreadable JSON.
  */
 function attachmentOf(content: ContentBlock): AcpAttachment | null {
   if (content.type === "image" || content.type === "audio") {
     return { kind: content.type, data: content.data, mimeType: content.mimeType };
   }
+  if (content.type === "resource") {
+    const resource = content.resource;
+    const filename = filenameFromUri(resource.uri);
+    const mimeType = resource.mimeType ?? "application/octet-stream";
+    if ("text" in resource) {
+      return { kind: "file", data: encodeUtf8Base64(resource.text), mimeType, filename };
+    }
+    return { kind: "file", data: resource.blob, mimeType, filename };
+  }
   return null;
+}
+
+/** The trailing path segment of a resource `uri`, percent-decoded, for display. */
+function filenameFromUri(uri: string): string | undefined {
+  const withoutQuery = uri.split(/[?#]/)[0] ?? "";
+  const last = withoutQuery.split("/").pop();
+  if (!last) return undefined;
+  try {
+    return decodeURIComponent(last) || undefined;
+  } catch {
+    return last;
+  }
+}
+
+function encodeUtf8Base64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
 }
 
 function appendChunk(

--- a/packages/@acp-ui/core/src/reduce/types.ts
+++ b/packages/@acp-ui/core/src/reduce/types.ts
@@ -14,23 +14,39 @@ import type { SessionUpdate, ToolCallStatus, ToolKind } from "@agentclientprotoc
 export type AcpBlock = AcpMessageBlock | AcpToolCallBlock | AcpPermissionBlock | AcpNoteBlock;
 
 /**
- * An image or audio clip attached to a message — either the agent sent one
- * (an ACP `image`/`audio` content block arrived mid-message) or the user
- * attached one when sending (see `AcpOutgoingAttachment`, which this is a
- * superset shape of).
+ * Something attached to a message — either the agent sent one (an ACP
+ * `image`/`audio`/`resource` content block arrived mid-message) or the user
+ * attached one when sending.
  *
- * Scoped to the two content kinds a file picker or paste realistically
- * produces. ACP's `resource_link`/`resource` content blocks are a different
- * UX (referencing something the agent already knows about, like a repo path —
- * closer to an `@mention` picker than an attach button) and are explicitly
- * out of scope here, same as the other unhandled `sessionUpdate` kinds: not
- * silently dropped forever, just not this round.
+ * `file` covers everything a file picker produces that isn't an image or an
+ * audio clip: a PDF, a spreadsheet, a Markdown note, a source file. It maps to
+ * ACP's embedded `resource` content block, which the protocol calls the
+ * "preferred" way to include context precisely because the agent has no other
+ * route to a file the user picked in a browser. (ACP's *other* resource block,
+ * `resource_link`, is a different UX — it names a path the agent can already
+ * read, closer to an `@mention` picker than an attach button — and remains out
+ * of scope.)
+ *
+ * `data` is ALWAYS base64, for every kind, so the browser never has to guess
+ * an encoding and binary payloads can't be corrupted in transit. Whether a
+ * `file` reaches the agent as ACP text or as an ACP blob is decided at send
+ * time from the payload itself — see `prompt/attachment-media.ts`.
  */
 export interface AcpAttachment {
-  kind: "image" | "audio";
-  /** Base64-encoded payload, verbatim from ACP's `ImageContent`/`AudioContent`. */
+  kind: "image" | "audio" | "file";
+  /**
+   * Base64-encoded payload. Verbatim from ACP's `ImageContent`/`AudioContent`
+   * for those kinds; for `file`, base64 of the raw bytes regardless of whether
+   * the file is textual.
+   */
   data: string;
   mimeType: string;
+  /**
+   * The original filename. Only carried for `kind: "file"`, where it is what
+   * the user recognises the attachment by — two PDFs are otherwise
+   * indistinguishable in the composer — and what becomes the resource's `uri`.
+   */
+  filename?: string;
 }
 
 export interface AcpMessageBlock {

--- a/packages/@acp-ui/core/src/session/use-acp-session.ts
+++ b/packages/@acp-ui/core/src/session/use-acp-session.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { attachmentToContentBlock } from "../prompt/attachment-media";
 import type { AcpAttachment, AcpBlock, AcpPermissionBlock, AcpUiEvent, AcpUsage } from "../reduce";
 import {
   foldSessionTitle,
@@ -187,12 +188,8 @@ export function useAcpSession(port: AcpSessionPort, key: string | null): AcpSess
               type: "session_update",
               update: {
                 sessionUpdate: "user_message_chunk",
-                content: {
-                  type: attachment.kind,
-                  data: attachment.data,
-                  mimeType: attachment.mimeType,
-                },
-              } as never,
+                content: attachmentToContentBlock(attachment),
+              },
             }),
           ),
         ];

--- a/packages/@acp-ui/web/package.json
+++ b/packages/@acp-ui/web/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@acp-ui/core": "workspace:*",
-    "lucide-react": "^0.556.0"
+    "lucide-react": "^1.34.0"
   },
   "peerDependencies": {
     "kui": "workspace:*",

--- a/packages/@acp-ui/web/src/composer/acp-composer.test.tsx
+++ b/packages/@acp-ui/web/src/composer/acp-composer.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { AcpComposer, toAttachments } from "./acp-composer";
 
 const submitButton = () => screen.getByRole("button", { name: /Submit|Stop/ });
-const attachButton = () => screen.getByRole("button", { name: "Attach an image or audio clip" });
+const attachButton = () => screen.getByRole("button", { name: "Attach a file" });
 
 describe("sending", () => {
   it("sends the trimmed text on Enter and clears the field", async () => {
@@ -241,12 +241,38 @@ describe("toAttachments", () => {
     expect(result[0].kind).toBe("audio");
   });
 
-  // Guards the one thing ACP's AcpAttachment can represent: image/audio only.
-  it("drops a file whose media type isn't image or audio", () => {
+  // Anything that isn't image/audio is a `file` — an ACP embedded resource —
+  // rather than being dropped, which is what "attach a PDF" needs.
+  it('classifies everything else as kind "file", keeping the filename', () => {
+    const result = toAttachments([
+      {
+        type: "file",
+        mediaType: "application/pdf",
+        filename: "report.pdf",
+        url: "data:application/pdf;base64,QUJD",
+      },
+    ]);
+    expect(result).toEqual([
+      { kind: "file", data: "QUJD", mimeType: "application/pdf", filename: "report.pdf" },
+    ]);
+  });
+
+  it("keeps a file the browser could not type at all", () => {
+    // An extensionless `Dockerfile` reports `mediaType: ""`. Falling back to
+    // a MIME type keeps it representable; the bytes decide text-vs-blob later.
+    const result = toAttachments([
+      { type: "file", mediaType: "", filename: "Dockerfile", url: "data:;base64,QUJD" },
+    ]);
+    expect(result).toEqual([
+      { kind: "file", data: "QUJD", mimeType: "application/octet-stream", filename: "Dockerfile" },
+    ]);
+  });
+
+  it("omits filename rather than sending an empty one", () => {
     const result = toAttachments([
       { type: "file", mediaType: "application/pdf", url: "data:application/pdf;base64,QUJD" },
     ]);
-    expect(result).toEqual([]);
+    expect(result[0]).not.toHaveProperty("filename");
   });
 
   // If kui's blob→data conversion ever failed and fell back to the original
@@ -261,5 +287,38 @@ describe("toAttachments", () => {
 
   it("returns an empty array for no files", () => {
     expect(toAttachments([])).toEqual([]);
+  });
+});
+
+describe("staging a document", () => {
+  it("shows a document's filename, which a thumbnail-only chip could not", async () => {
+    render(<AcpComposer disabled={false} onSend={vi.fn()} />);
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(fileInput, fakeFile("q3-report.pdf", "application/pdf"));
+
+    // The whole reason documents render through the `inline` variant: two
+    // attached PDFs must be tellable apart before sending.
+    expect(await screen.findByText("q3-report.pdf")).toBeInTheDocument();
+  });
+
+  it("delivers a document to onSend as a file attachment", async () => {
+    const onSend = vi.fn();
+    render(<AcpComposer disabled={false} onSend={onSend} />);
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(fileInput, fakeFile("notes.md", "text/markdown"));
+    await userEvent.click(submitButton());
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    const [, attachments] = onSend.mock.calls[0];
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({ kind: "file", filename: "notes.md" });
+  });
+
+  it("refuses a file over the size cap and says so, instead of failing at send", async () => {
+    render(<AcpComposer disabled={false} maxFileSize={10} onSend={vi.fn()} />);
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(fileInput, fakeFile("big.pdf", "application/pdf", "way-past-ten-bytes"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/too large/i);
   });
 });

--- a/packages/@acp-ui/web/src/composer/acp-composer.tsx
+++ b/packages/@acp-ui/web/src/composer/acp-composer.tsx
@@ -3,6 +3,7 @@
 import type { AcpAttachment } from "@acp-ui/core/reduce";
 import {
   Attachment,
+  AttachmentInfo,
   AttachmentPreview,
   AttachmentRemove,
   Attachments,
@@ -18,10 +19,16 @@ import {
   usePromptInputAttachments,
 } from "kui/ai-elements/prompt-input";
 import { PaperclipIcon } from "lucide-react";
-import type { FormEvent } from "react";
+import { type FormEvent, useState } from "react";
+
+/** 10 MB. Base64 inflates a payload by a third, and the whole prompt travels
+ * as one JSON-RPC message — a cap here is what keeps a stray 200 MB video
+ * from becoming a 270 MB request body nothing downstream is sized for. */
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
+const DEFAULT_MAX_FILES = 10;
 
 export interface AcpComposerProps {
-  /** Called with the trimmed text, and any image/audio attached, once the user submits. */
+  /** Called with the trimmed text, and any attachments, once the user submits. */
   onSend: (text: string, attachments?: AcpAttachment[]) => void;
   /** Host-computed: acprouter derives this from session lifecycle, busabase
    * from its richer session status (busy / waiting_permission / ended /
@@ -40,33 +47,50 @@ export interface AcpComposerProps {
   onStop?: () => void;
   placeholder?: string;
   className?: string;
+  /** Per-file ceiling in bytes. Defaults to 10 MB. */
+  maxFileSize?: number;
+  /** How many files may be staged at once. Defaults to 10. */
+  maxFiles?: number;
 }
 
-/** Only these are representable as `AcpAttachment` — see its doc comment. */
-const isAttachableMediaType = (mediaType: string) =>
+/** Images and audio have dedicated ACP content blocks; everything else is a file. */
+const isMediaType = (mediaType: string) =>
   mediaType.startsWith("image/") || mediaType.startsWith("audio/");
 
 /**
  * `PromptInputMessage.files[].url` is always a `data:` URL by the time
  * `onSubmit` fires — `PromptInput` converts blob URLs before calling it. This
  * strips the `data:<mime>;base64,` prefix back to the raw payload ACP wants.
- * A file whose type slipped past `accept` (e.g. a drag-drop of something
- * other than image/audio) is dropped here rather than sent malformed —
- * `accept` on `<PromptInput>` keeps the file *dialog* to image/audio, but
- * paste and drag-drop are not filterable that strictly, so this is the real
- * gate.
+ *
+ * Every file maps to some `AcpAttachment`: images and audio to their own ACP
+ * content blocks, and anything else — a PDF, a spreadsheet, a Markdown note,
+ * an extensionless `Dockerfile` — to `kind: "file"`, which becomes an ACP
+ * embedded resource at send time. Nothing is silently discarded here any
+ * more; what an individual agent can actually accept is negotiated
+ * server-side against its advertised `promptCapabilities`, which is the only
+ * place that answer is known.
  */
 export function toAttachments(files: PromptInputMessage["files"]): AcpAttachment[] {
   const attachments: AcpAttachment[] = [];
   for (const file of files) {
-    if (!isAttachableMediaType(file.mediaType)) continue;
     const commaIndex = file.url.indexOf(",");
     if (!file.url.startsWith("data:") || commaIndex === -1) continue;
-    attachments.push({
-      kind: file.mediaType.startsWith("audio/") ? "audio" : "image",
-      data: file.url.slice(commaIndex + 1),
-      mimeType: file.mediaType,
-    });
+    const data = file.url.slice(commaIndex + 1);
+    const mediaType = file.mediaType || "application/octet-stream";
+    if (isMediaType(mediaType)) {
+      attachments.push({
+        kind: mediaType.startsWith("audio/") ? "audio" : "image",
+        data,
+        mimeType: mediaType,
+      });
+    } else {
+      attachments.push({
+        kind: "file",
+        data,
+        mimeType: mediaType,
+        ...(file.filename ? { filename: file.filename } : {}),
+      });
+    }
   }
   return attachments;
 }
@@ -77,7 +101,7 @@ function AttachButton({ disabled }: { disabled: boolean }) {
   return (
     <PromptInputTools>
       <button
-        aria-label="Attach an image or audio clip"
+        aria-label="Attach a file"
         className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
         disabled={disabled}
         onClick={() => attachments.openFileDialog()}
@@ -89,19 +113,47 @@ function AttachButton({ disabled }: { disabled: boolean }) {
   );
 }
 
-/** What's staged before send — cleared by `PromptInput` itself once `onSubmit` accepts. */
+/**
+ * What's staged before send — cleared by `PromptInput` itself once `onSubmit`
+ * accepts.
+ *
+ * Split by kind rather than rendered as one list, because kui's `grid`
+ * variant deliberately drops `AttachmentInfo`: a thumbnail identifies an
+ * image on its own, but a document rendered that way is a nameless file icon,
+ * and two attached PDFs would be indistinguishable. Documents therefore use
+ * the `inline` variant, which keeps the filename visible.
+ */
 function StagedAttachments() {
   const attachments = usePromptInputAttachments();
   if (attachments.files.length === 0) return null;
+
+  const images = attachments.files.filter((file) => (file.mediaType ?? "").startsWith("image/"));
+  const rest = attachments.files.filter((file) => !(file.mediaType ?? "").startsWith("image/"));
+
   return (
-    <Attachments className="px-3 pt-2" variant="grid">
-      {attachments.files.map((file) => (
-        <Attachment data={file} key={file.id} onRemove={() => attachments.remove(file.id)}>
-          <AttachmentPreview />
-          <AttachmentRemove />
-        </Attachment>
-      ))}
-    </Attachments>
+    <div className="space-y-2 px-3 pt-2">
+      {images.length > 0 ? (
+        <Attachments variant="grid">
+          {images.map((file) => (
+            <Attachment data={file} key={file.id} onRemove={() => attachments.remove(file.id)}>
+              <AttachmentPreview />
+              <AttachmentRemove />
+            </Attachment>
+          ))}
+        </Attachments>
+      ) : null}
+      {rest.length > 0 ? (
+        <Attachments variant="inline">
+          {rest.map((file) => (
+            <Attachment data={file} key={file.id} onRemove={() => attachments.remove(file.id)}>
+              <AttachmentPreview />
+              <AttachmentInfo className="max-w-40" />
+              <AttachmentRemove />
+            </Attachment>
+          ))}
+        </Attachments>
+      ) : null}
+    </div>
   );
 }
 
@@ -112,8 +164,16 @@ function StagedAttachments() {
  * hand-rolling twice: IME-safe Enter-to-send (a real gap in both apps' prior
  * hand-rolled textareas — pressing Enter to confirm a Chinese/Japanese IME
  * candidate would have submitted early), Shift+Enter for a newline, a submit
- * button disabled while the field is empty, and attaching images/audio —
- * paste or the picker — with a preview strip before sending.
+ * button disabled while the field is empty, and attaching files — picker,
+ * paste or drag-drop — with a preview strip before sending.
+ *
+ * No `accept` is passed on purpose. kui's own filter compares `accept`
+ * patterns against a file's MIME type only, so an extension pattern like
+ * `.md` would pass the OS file dialog and then be rejected by kui itself,
+ * and a source file the browser reports as `""` would be rejected by any
+ * MIME-based allowlist at all. Since what a given agent can accept is
+ * negotiated server-side from its `promptCapabilities` anyway, the composer
+ * takes the file and lets that single decision point apply.
  */
 export function AcpComposer({
   onSend,
@@ -122,12 +182,17 @@ export function AcpComposer({
   onStop,
   placeholder,
   className,
+  maxFileSize = DEFAULT_MAX_FILE_SIZE,
+  maxFiles = DEFAULT_MAX_FILES,
 }: AcpComposerProps) {
+  const [attachError, setAttachError] = useState<string | null>(null);
+
   const handleSubmit = (message: PromptInputMessage, event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const text = message.text.trim();
     const attachments = toAttachments(message.files);
     if ((!text && attachments.length === 0) || disabled) return;
+    setAttachError(null);
     onSend(text, attachments.length > 0 ? attachments : undefined);
   };
 
@@ -138,8 +203,27 @@ export function AcpComposer({
   const submitDisabled = disabled && !canStop;
 
   return (
-    <PromptInput accept="image/*,audio/*" className={className} onSubmit={handleSubmit}>
+    <PromptInput
+      className={className}
+      maxFileSize={maxFileSize}
+      maxFiles={maxFiles}
+      onError={(err) =>
+        setAttachError(
+          err.code === "max_file_size"
+            ? `That file is too large. The limit is ${Math.round(maxFileSize / (1024 * 1024))} MB.`
+            : err.code === "max_files"
+              ? `You can attach at most ${maxFiles} files at a time.`
+              : err.message,
+        )
+      }
+      onSubmit={handleSubmit}
+    >
       <StagedAttachments />
+      {attachError ? (
+        <p className="px-3 pt-2 text-destructive text-xs" role="alert">
+          {attachError}
+        </p>
+      ) : null}
       <PromptInputBody>
         <PromptInputTextarea disabled={disabled} placeholder={placeholder} />
       </PromptInputBody>

--- a/packages/@acp-ui/web/src/transcript/acp-transcript.test.tsx
+++ b/packages/@acp-ui/web/src/transcript/acp-transcript.test.tsx
@@ -95,6 +95,40 @@ describe("attachments", () => {
     renderBlocks([message({ text: "plain text" })]);
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
+
+  it("names a file attachment instead of showing an anonymous icon", () => {
+    renderBlocks([
+      message({
+        text: "here you go",
+        attachments: [
+          {
+            kind: "file",
+            data: "JVBERi0=",
+            mimeType: "application/pdf",
+            filename: "q3-report.pdf",
+          },
+        ],
+      }),
+    ]);
+    expect(screen.getByText("q3-report.pdf")).toBeInTheDocument();
+    // A document is not an <img>, and must not materialise a data: URL it
+    // would never display — that would double a multi-megabyte payload.
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("renders an image and a file side by side, each in its own strip", () => {
+    renderBlocks([
+      message({
+        text: "both",
+        attachments: [
+          { kind: "image", data: "abc", mimeType: "image/png" },
+          { kind: "file", data: "def", mimeType: "text/csv", filename: "rows.csv" },
+        ],
+      }),
+    ]);
+    expect(screen.getByRole("img")).toBeInTheDocument();
+    expect(screen.getByText("rows.csv")).toBeInTheDocument();
+  });
 });
 
 describe("tool calls", () => {

--- a/packages/@acp-ui/web/src/transcript/message-view.tsx
+++ b/packages/@acp-ui/web/src/transcript/message-view.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import type { AcpAttachment } from "@acp-ui/core/reduce";
-import { Attachment, AttachmentPreview, Attachments } from "kui/ai-elements/attachments";
+import {
+  Attachment,
+  AttachmentInfo,
+  AttachmentPreview,
+  Attachments,
+} from "kui/ai-elements/attachments";
 import { Message, MessageContent } from "kui/ai-elements/message";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "kui/ai-elements/reasoning";
 import type { AcpMessageViewProps } from "./slots";
@@ -10,9 +15,16 @@ import type { AcpMessageViewProps } from "./slots";
  * Renders through `kui`'s `Attachments`/`Attachment`, which are typed against
  * the AI SDK's `FileUIPart` — a structural shape, not an `ai` import of our
  * own (`src/__tests__/boundary.test.ts` enforces that distinction, same as
- * `tool-status.ts`'s seam onto `ToolUIPart["state"]`). ACP's `data`/`mimeType`
- * become a `data:` URL, since ACP sends the payload inline, base64, with no
- * separate URL of its own.
+ * `tool-status.ts`'s seam onto `ToolUIPart["state"]`).
+ *
+ * Images become a `data:` URL, since ACP sends the payload inline, base64,
+ * with no separate URL of its own, and grid thumbnails identify them on their
+ * own. Everything else — a PDF, a spreadsheet, an attached source file —
+ * renders through the `inline` variant instead, because kui's `grid` variant
+ * deliberately drops `AttachmentInfo` and a document without its name is an
+ * anonymous file icon. Those also skip the `data:` URL entirely: nothing
+ * displays it, and materialising one would double a multi-megabyte payload in
+ * memory for no visible gain.
  */
 function AcpAttachmentsView({
   messageId,
@@ -21,23 +33,43 @@ function AcpAttachmentsView({
   messageId: string;
   attachments: AcpAttachment[];
 }) {
+  const toData = (attachment: AcpAttachment, index: number) => {
+    const isImage = attachment.mimeType.startsWith("image/");
+    return {
+      id: `${messageId}-attachment-${index}`,
+      type: "file" as const,
+      mediaType: attachment.mimeType,
+      url: isImage ? `data:${attachment.mimeType};base64,${attachment.data}` : "",
+      ...(attachment.filename ? { filename: attachment.filename } : {}),
+    };
+  };
+
+  const indexed = attachments.map((attachment, index) => ({ attachment, index }));
+  const images = indexed.filter(({ attachment }) => attachment.mimeType.startsWith("image/"));
+  const rest = indexed.filter(({ attachment }) => !attachment.mimeType.startsWith("image/"));
+
   return (
-    <Attachments className="mt-2" variant="grid">
-      {attachments.map((attachment, index) => (
-        <Attachment
-          data={{
-            id: `${messageId}-attachment-${index}`,
-            type: "file",
-            mediaType: attachment.mimeType,
-            url: `data:${attachment.mimeType};base64,${attachment.data}`,
-          }}
-          // biome-ignore lint/suspicious/noArrayIndexKey: the reducer only ever appends to a message's attachments array, never reorders or removes — index is a stable identity here, and attachments carry no id of their own to key on instead.
-          key={`${messageId}-attachment-${index}`}
-        >
-          <AttachmentPreview />
-        </Attachment>
-      ))}
-    </Attachments>
+    <div className="mt-2 space-y-2">
+      {images.length > 0 ? (
+        <Attachments variant="grid">
+          {images.map(({ attachment, index }) => (
+            <Attachment data={toData(attachment, index)} key={`${messageId}-attachment-${index}`}>
+              <AttachmentPreview />
+            </Attachment>
+          ))}
+        </Attachments>
+      ) : null}
+      {rest.length > 0 ? (
+        <Attachments variant="inline">
+          {rest.map(({ attachment, index }) => (
+            <Attachment data={toData(attachment, index)} key={`${messageId}-attachment-${index}`}>
+              <AttachmentPreview />
+              <AttachmentInfo className="max-w-40" />
+            </Attachment>
+          ))}
+        </Attachments>
+      ) : null}
+    </div>
   );
 }
 

--- a/packages/busabase-cms-nextjs-example/package.json
+++ b/packages/busabase-cms-nextjs-example/package.json
@@ -16,7 +16,7 @@
     "busabase-sdk": "workspace:*",
     "fumadocs-core": "16.14.5",
     "fumadocs-ui": "16.14.5",
-    "lucide-react": "^0.556.0",
+    "lucide-react": "^1.34.0",
     "next": "16.3.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/busabase-cms-nextjs-example/tsconfig.json
+++ b/packages/busabase-cms-nextjs-example/tsconfig.json
@@ -23,6 +23,7 @@
       "busabase-cms": ["../busabase-cms/src/index.ts"],
       "busabase-cms/*": ["../busabase-cms/src/*.ts"],
       "busabase-sdk": ["../../apps/busabase-sdk/src/index.ts"],
+      "busabase-sdk/*": ["../../apps/busabase-sdk/src/*.ts"],
       "busabase-contract/contract/cloud": ["../busabase-contract/src/contract/cloud.ts"],
       "busabase-contract/domains": ["../busabase-contract/src/domains/registry.ts"],
       "busabase-contract/types": ["../busabase-contract/src/types/index.ts"],

--- a/packages/busabase-cms/tsconfig.json
+++ b/packages/busabase-cms/tsconfig.json
@@ -13,6 +13,7 @@
     "types": ["node"],
     "paths": {
       "busabase-sdk": ["../../apps/busabase-sdk/src/index.ts"],
+      "busabase-sdk/*": ["../../apps/busabase-sdk/src/*.ts"],
       "busabase-contract": ["../busabase-contract/src/index.ts"],
       "busabase-contract/domains": ["../busabase-contract/src/domains/registry.ts"],
       "busabase-contract/*": ["../busabase-contract/src/*"],

--- a/packages/busabase-contract/package.json
+++ b/packages/busabase-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-contract",
-  "description": "Client-safe Busabase surface: oRPC contracts (OSS + cloud), node-type kernel, VO types, and the oRPC client factories. Pure leaf — no db/logic/server deps. Consumed by busabase-cli, busabase-mobile, busabase-core, busabase, and busabase-cloud.",
-  "version": "0.20.0",
+  "description": "Client-safe Busabase surface: oRPC contracts (OSS + cloud), node-type kernel, VO types, and the oRPC client factories. Pure leaf \u2014 no db/logic/server deps. Consumed by busabase-cli, busabase-mobile, busabase-core, busabase, and busabase-cloud.",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -166,6 +166,10 @@
     "./domains/skill/contract": {
       "types": "./src/domains/skill/contract.ts",
       "default": "./src/domains/skill/contract.ts"
+    },
+    "./domains/skill/frontmatter": {
+      "types": "./src/domains/skill/frontmatter.ts",
+      "default": "./src/domains/skill/frontmatter.ts"
     },
     "./domains/drive/contract": {
       "types": "./src/domains/drive/contract.ts",

--- a/packages/busabase-contract/src/access-control/api-key-level.ts
+++ b/packages/busabase-contract/src/access-control/api-key-level.ts
@@ -127,6 +127,11 @@ export const PROCEDURE_PERMISSION_POLICY: Record<string, ProcedurePermissionPoli
   "nodes.get": node("read"),
   "nodes.searchByName": node("read"),
   "nodes.isDescendant": node("read"),
+  // The ancestor chain of one node. A `read` for the same reason
+  // `nodes.isDescendant` is: it returns ids from the tree the caller can
+  // already list, resolved through the same per-node ACL, and reveals nothing
+  // a `nodes.list` would not.
+  "nodes.ancestors": node("read"),
   // ---- changeRequest: the full proposal-lifecycle family (never touches live
   // data), plus amending a still-pending proposal, plus uploading/writing an
   // asset for use inside a not-yet-merged proposal (deliberate inclusion). ----

--- a/packages/busabase-contract/src/contract/busabase.ts
+++ b/packages/busabase-contract/src/contract/busabase.ts
@@ -39,7 +39,11 @@ import {
 } from "./embed-link-schemas";
 import { UnifiedGrepInputSchema, UnifiedGrepResultVOSchema } from "./grep-schemas";
 import { updateNodeContentInputSchema } from "./node-content-schemas";
-import { getNodeInputSchema, NodeDetailVOSchema } from "./node-detail-schemas";
+import {
+  getNodeInputSchema,
+  NodeDetailVOSchema,
+  nodeAncestorsVOSchema,
+} from "./node-detail-schemas";
 import {
   NodeIconConfirmInputSchema,
   NodeIconConfirmVOSchema,
@@ -221,7 +225,7 @@ export const busabaseContractRoutes = {
         tags: ["Nodes", "Search"],
         summary: "Search nodes by name/slug (cheap, name-only quick-jump)",
         successDescription:
-          "Plain ilike match on name/slug across every registered node type, scoped by the same node-visibility ACL as `nodes.list`. No content scan and no full-text ranking — ordered exact-slug-match first, then by name. Backs the dashboard search dialog's 'Recent' tab cache-miss path; the heavier `search` endpoint remains the dedicated full-text content search.",
+          "Plain ilike match on name/slug across every registered node type, scoped by the same node-visibility ACL as `nodes.list`. No content scan and no full-text ranking — ordered exact-slug-match first, then by name. Backs the dashboard search dialog's 'Recent' tab cache-miss path. To search what is written INSIDE nodes, use `search` with the `nodes` source (indexed, paginated) or `grep` (exhaustive, no index).",
       })
       .input(searchNodesByNameInputSchema)
       .output(z.array(nodeSearchResultSchema)),
@@ -236,6 +240,17 @@ export const busabaseContractRoutes = {
       })
       .input(isDescendantInputSchema)
       .output(isDescendantOutputSchema),
+    ancestors: oc
+      .route({
+        method: "GET",
+        path: "/nodes/{nodeId}/ancestors",
+        tags: ["Nodes"],
+        summary: "List a node's ancestor ids",
+        successDescription:
+          "The node's ancestor ids, root-first, excluding the node itself (`[]` directly under the workspace root). `nodeId` accepts an id or a slug, same as `nodes.get`; pass `type` when a slug exists under more than one type. Lets a depth-bounded, lazily-expanded tree open straight to a deep node on a cold load (a refresh, a bookmark, a shared link) without one round trip per level.",
+      })
+      .input(getNodeInputSchema)
+      .output(nodeAncestorsVOSchema),
     createChangeRequest: oc
       .route({
         method: "POST",

--- a/packages/busabase-contract/src/contract/node-detail-schemas.ts
+++ b/packages/busabase-contract/src/contract/node-detail-schemas.ts
@@ -118,6 +118,17 @@ export type NodeDetailVO = z.infer<typeof NodeDetailVOSchema>;
  * hint. An ambiguous slug with no `type` is refused rather than silently
  * resolved to whichever row sorts first.
  */
+/**
+ * `nodes.ancestors` output — the node's ancestor ids, ROOT-FIRST, excluding
+ * the node itself. Ids only, deliberately: the sidebar already has (or can
+ * lazily fetch) each ancestor's own row, and it only needs to know WHICH
+ * folders to expand. Returning full nodes here would duplicate `nodes.list`
+ * and make a cheap navigational lookup expensive.
+ */
+export const nodeAncestorsVOSchema = z.object({
+  ancestorIds: z.array(z.string()),
+});
+
 export const getNodeInputSchema = z.object({
   nodeId: z.string().describe("Node id, or a slug that is unique within its type."),
   type: z

--- a/packages/busabase-contract/src/contract/schemas.ts
+++ b/packages/busabase-contract/src/contract/schemas.ts
@@ -388,7 +388,13 @@ const agentTaskSchema = z.object({
 
 const searchResultSchema = z.object({
   id: z.string(),
-  kind: z.enum(["record", "change_request", "base", "file"]),
+  /**
+   * `node` covers the CONTENT of a content-bearing node (doc / html /
+   * whiteboard / workflow). Purely additive — callers that do not know it can
+   * ignore the kind, and callers that never asked for it (an explicit
+   * `sources` list without `nodes`) never receive it.
+   */
+  kind: z.enum(["record", "change_request", "base", "file", "node"]),
   title: z.string(),
   body: z.string(),
   eyebrow: z.string(),
@@ -402,6 +408,16 @@ const searchResponseSchema = z.object({
   offset: z.number(),
   hasMore: z.boolean(),
   results: z.array(searchResultSchema),
+  /**
+   * True when at least one in-scope node's content was indexed only up to the
+   * projection cap, so this search could not see all of it.
+   *
+   * Exists so an empty result can be reported honestly: without it, "no
+   * results" is ambiguous between "the workspace does not contain this" and
+   * "we did not look at all of it". Clients should surface it — and point at
+   * `grep`, which has no such cap — rather than implying absence.
+   */
+  contentTruncated: z.boolean().default(false),
 });
 
 const liveEventSchema = z.object({
@@ -748,7 +764,9 @@ const inboxSnapshotResponseSchema = listChangeRequestsPageResponseSchema.extend(
   counts: changeRequestCountsSchema,
 });
 
-const SEARCH_SOURCES = ["records", "files", "names"] as const;
+// `nodes` searches node CONTENT and is named to match grep's `nodes` source,
+// so both surfaces describe the same content with the same word.
+const SEARCH_SOURCES = ["records", "files", "names", "nodes"] as const;
 
 const searchInputSchema = z.object({
   query: z.string().default(""),

--- a/packages/busabase-contract/src/domains/agents/contract.ts
+++ b/packages/busabase-contract/src/domains/agents/contract.ts
@@ -8,6 +8,7 @@ import {
   AgentSessionVOSchema,
   CreateAgentSessionInputSchema,
   DisconnectAgentInputSchema,
+  ListAgentConnectionsInputSchema,
   PromptAgentSessionInputSchema,
   RespondToAgentPermissionInputSchema,
 } from "./types";
@@ -32,8 +33,8 @@ export const agentsContract = {
   ),
 
   connections: {
-    /** Connected backends, scoped to the current space and authenticated user. */
-    list: oc.output(AgentConnectionVOSchema.array()),
+    /** Connected backends in the current user's personal or active-space scope. */
+    list: oc.input(ListAgentConnectionsInputSchema).output(AgentConnectionVOSchema.array()),
   },
 
   sessions: {

--- a/packages/busabase-contract/src/domains/agents/types.ts
+++ b/packages/busabase-contract/src/domains/agents/types.ts
@@ -93,13 +93,15 @@ export const AgentSessionVOSchema = z.object({
 });
 export type AgentSessionVO = z.infer<typeof AgentSessionVOSchema>;
 
-/** One connected agent backend in the current space and authenticated user's scope. */
+/** One connected agent backend visible in the requested workspace scope. */
 export const AgentConnectionVOSchema = z.object({
   slug: z.string(),
   agentName: z.string(),
   transport: AgentTransportSchema,
   sessionCount: z.number().int().nonnegative(),
   latest: AgentSessionVOSchema.nullable(),
+  /** Controls owner-only actions such as deleting the saved OAuth grant. */
+  ownedByCurrentUser: z.boolean(),
 });
 export type AgentConnectionVO = z.infer<typeof AgentConnectionVOSchema>;
 
@@ -135,6 +137,14 @@ export type AgentSessionEventVO = z.infer<typeof AgentSessionEventVOSchema>;
 
 // ── Inputs (DTO) ─────────────────────────────────────────────────────────────
 
+export const AgentConnectionScopeSchema = z.enum(["mine", "space"]);
+export type AgentConnectionScope = z.infer<typeof AgentConnectionScopeSchema>;
+
+export const ListAgentConnectionsInputSchema = z.object({
+  scope: AgentConnectionScopeSchema.default("mine"),
+});
+export type ListAgentConnectionsInput = z.infer<typeof ListAgentConnectionsInputSchema>;
+
 export const CreateAgentSessionInputSchema = z.object({
   /** Must name a catalog entry. Deliberately NOT a command line — see below. */
   slug: z.string().min(1),
@@ -147,11 +157,26 @@ export const DisconnectAgentInputSchema = z.object({
 });
 export type DisconnectAgentInput = z.infer<typeof DisconnectAgentInputSchema>;
 
-/** Base64 image/audio the browser attached — ACP's `ImageContent`/`AudioContent` shape verbatim. */
+/**
+ * A base64 payload the browser attached.
+ *
+ * `image`/`audio` map to ACP's `ImageContent`/`AudioContent` verbatim; `file`
+ * is everything else (a PDF, a spreadsheet, a Markdown note) and becomes an
+ * ACP embedded `resource` block at send time. `data` is base64 for every kind
+ * — including textual files — so the browser never has to guess an encoding;
+ * whether a file travels to the agent as ACP text or as an ACP blob is decided
+ * server-side from the payload itself.
+ */
 export const PromptAttachmentInputSchema = z.object({
-  kind: z.enum(["image", "audio"]),
-  data: z.string().min(1),
+  kind: z.enum(["image", "audio", "file"]),
+  // ~15 MB of raw bytes once base64 is decoded. A backstop, not the real
+  // limit: the composer caps files at 10 MB where it can tell the user why.
+  // This only stops a hand-rolled request from turning one prompt into an
+  // unbounded request body.
+  data: z.string().min(1).max(20_000_000),
   mimeType: z.string().min(1),
+  /** The original filename, carried for `file` so the agent and the transcript can name it. */
+  filename: z.string().max(255).optional(),
 });
 export type PromptAttachmentInput = z.infer<typeof PromptAttachmentInputSchema>;
 

--- a/packages/busabase-contract/src/domains/airapp/definition.ts
+++ b/packages/busabase-contract/src/domains/airapp/definition.ts
@@ -13,4 +13,8 @@ export const airappNodeType = makeFileTreeNodeType({
   routeBase: "airapps",
   tag: "AirApps",
   entryFile: "package.json",
+  // Public execution needs the isolated runtime from PR #6648. Until that is
+  // merged, offering Share here would create a link that anonymous visitors
+  // cannot open without exposing AirApp source through `nodes.get`.
+  publicAccess: "no",
 });

--- a/packages/busabase-contract/src/domains/base/definition.ts
+++ b/packages/busabase-contract/src/domains/base/definition.ts
@@ -5,7 +5,7 @@ export const baseNodeType = {
   type: "base",
   label: "Base",
   icon: "table",
-  capabilities: { hasDetail: true, creatable: true },
+  capabilities: { hasDetail: true, creatable: true, publicAccess: "detail" },
   operations: [
     {
       kind: "record_create",

--- a/packages/busabase-contract/src/domains/doc/definition.ts
+++ b/packages/busabase-contract/src/domains/doc/definition.ts
@@ -9,7 +9,7 @@ export const docNodeType = {
   type: "doc",
   label: "Doc",
   icon: "file-text",
-  capabilities: { hasDetail: true, creatable: true },
+  capabilities: { hasDetail: true, creatable: true, publicAccess: "detail" },
   operations: [
     {
       kind: "doc_update",

--- a/packages/busabase-contract/src/domains/drive/definition.ts
+++ b/packages/busabase-contract/src/domains/drive/definition.ts
@@ -8,4 +8,5 @@ export const driveNodeType = makeFileTreeNodeType({
   routeBase: "drives",
   tag: "Drives",
   entryFile: "README.md",
+  publicAccess: "no",
 });

--- a/packages/busabase-contract/src/domains/dump/contract.ts
+++ b/packages/busabase-contract/src/domains/dump/contract.ts
@@ -5,6 +5,7 @@ import {
   ExportTablesInputSchema,
   ExportTablesVOSchema,
   ImportAbortVOSchema,
+  ImportBeginInputSchema,
   ImportBeginVOSchema,
   ImportCommitVOSchema,
   ImportSessionInputSchema,
@@ -54,6 +55,7 @@ export const dumpContract = {
       successDescription:
         "Created an import session for the current space. Refused unless the space's node tree is empty (full-fidelity import preserves original ids and cannot merge into existing data).",
     })
+    .input(ImportBeginInputSchema)
     .output(ImportBeginVOSchema),
   importTables: oc
     .route({

--- a/packages/busabase-contract/src/domains/dump/types.ts
+++ b/packages/busabase-contract/src/domains/dump/types.ts
@@ -98,6 +98,22 @@ export const ExportAssetTextVOSchema = z.object({
 });
 export type ExportAssetTextVO = z.infer<typeof ExportAssetTextVOSchema>;
 
+export const ImportBeginInputSchema = z.object({
+  /**
+   * The space id the archive was ORIGINALLY exported from (`manifest.spaceId`
+   * in the `.bbdump`, already integrity-verified before this is called).
+   * `importTableRows`'s "nodes" handling needs this to recognize the
+   * archive's own root-node row deterministically (`rootNodeIdForSpace`) —
+   * scanning each batch's rows for "the one with a null `parentId`" only
+   * works when that row happens to land in the SAME batch as its children,
+   * which cursor pagination (id-ordered, not tree-ordered) does not
+   * guarantee once a space has more nodes than one page. See the matching
+   * comment in `import-logic.ts`.
+   */
+  sourceSpaceId: z.string(),
+});
+export type ImportBeginInput = z.infer<typeof ImportBeginInputSchema>;
+
 export const ImportBeginVOSchema = z.object({
   sessionId: z.string(),
 });

--- a/packages/busabase-contract/src/domains/file-node/definition.ts
+++ b/packages/busabase-contract/src/domains/file-node/definition.ts
@@ -6,6 +6,6 @@ export const fileNodeType = {
   type: "file",
   label: "File",
   icon: "file",
-  capabilities: { hasDetail: true, creatable: true },
+  capabilities: { hasDetail: true, creatable: true, publicAccess: "detail" },
   operations: [],
 } as const satisfies NodeTypeDefinition;

--- a/packages/busabase-contract/src/domains/filetree/definition.ts
+++ b/packages/busabase-contract/src/domains/filetree/definition.ts
@@ -1,4 +1,4 @@
-import type { NodeTypeDefinition, OperationDefinition } from "../types";
+import type { NodePublicAccess, NodeTypeDefinition, OperationDefinition } from "../types";
 
 export interface FileTreeKindDefinitionConfig {
   type: string;
@@ -7,6 +7,7 @@ export interface FileTreeKindDefinitionConfig {
   routeBase: string;
   tag: string;
   entryFile: string;
+  publicAccess: NodePublicAccess;
 }
 
 export const fileTreeOperations = <TType extends string>(type: TType) =>
@@ -40,6 +41,6 @@ export const makeFileTreeNodeType = <TConfig extends FileTreeKindDefinitionConfi
     type: config.type,
     label: config.label,
     icon: config.icon,
-    capabilities: { hasDetail: true, creatable: true },
+    capabilities: { hasDetail: true, creatable: true, publicAccess: config.publicAccess },
     operations: fileTreeOperations(config.type),
   }) as const satisfies NodeTypeDefinition;

--- a/packages/busabase-contract/src/domains/folder/definition.ts
+++ b/packages/busabase-contract/src/domains/folder/definition.ts
@@ -6,6 +6,11 @@ export const folderNodeType = {
   type: "folder",
   label: "Folder",
   icon: "folder",
-  capabilities: { container: true, creatable: true, hasDetail: true },
+  capabilities: {
+    container: true,
+    creatable: true,
+    hasDetail: true,
+    publicAccess: "detail",
+  },
   operations: [],
 } as const satisfies NodeTypeDefinition;

--- a/packages/busabase-contract/src/domains/form/definition.ts
+++ b/packages/busabase-contract/src/domains/form/definition.ts
@@ -13,6 +13,6 @@ export const formNodeType = {
   type: "form",
   label: "Form",
   icon: "form",
-  capabilities: { hasDetail: true, creatable: true },
+  capabilities: { hasDetail: true, creatable: true, publicAccess: "submit" },
   operations: [],
 } as const satisfies NodeTypeDefinition;

--- a/packages/busabase-contract/src/domains/html/definition.ts
+++ b/packages/busabase-contract/src/domains/html/definition.ts
@@ -11,7 +11,7 @@ export const htmlNodeType = {
   type: "html",
   label: "HTML",
   icon: "code-xml",
-  capabilities: { hasDetail: true, creatable: true },
+  capabilities: { hasDetail: true, creatable: true, publicAccess: "no" },
   operations: [
     {
       kind: "html_document_update",

--- a/packages/busabase-contract/src/domains/package/template.ts
+++ b/packages/busabase-contract/src/domains/package/template.ts
@@ -24,6 +24,8 @@
  */
 import { z } from "zod";
 
+import { SkillFrontmatterSchema as BaseSkillFrontmatterSchema } from "../skill/frontmatter";
+
 // ── Layout constants (all OUTSIDE `content/`) ────────────────────────────────
 
 /**
@@ -167,10 +169,16 @@ export const SkillBusabaseMetadataSchema = z.object({
 });
 export type SkillBusabaseMetadata = z.infer<typeof SkillBusabaseMetadataSchema>;
 
-/** Root `SKILL.md` frontmatter, as far as the template format cares about it. */
-export const SkillFrontmatterSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().default(""),
+/**
+ * Root `SKILL.md` frontmatter, as the template format sees it.
+ *
+ * The generic Skill shape lives in `domains/skill/frontmatter` — a Skill is not a
+ * template component, and most Skills are not templates at all. This narrows the
+ * open `metadata` bag to the one block that decides template-ness, so the
+ * dependency runs the only direction that is true: the template format knows
+ * about Skills, not the other way round.
+ */
+export const SkillFrontmatterSchema = BaseSkillFrontmatterSchema.extend({
   metadata: z
     .object({
       busabase: SkillBusabaseMetadataSchema.optional(),

--- a/packages/busabase-contract/src/domains/registry.test.ts
+++ b/packages/busabase-contract/src/domains/registry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isPubliclyReadableNodeType, listNodeTypes, publicAccessOf } from "./registry";
+
+describe("node public sharing capabilities", () => {
+  it("requires every built-in node type to declare its public behavior", () => {
+    expect(
+      listNodeTypes()
+        .filter((definition) => definition.capabilities.publicAccess === undefined)
+        .map((definition) => definition.type),
+    ).toEqual([]);
+  });
+
+  it("explicitly covers every built-in node type", () => {
+    expect(
+      Object.fromEntries(
+        listNodeTypes().map((definition) => [definition.type, publicAccessOf(definition.type)]),
+      ),
+    ).toEqual({
+      folder: "detail",
+      base: "detail",
+      skill: "no",
+      drive: "no",
+      airapp: "no",
+      file: "detail",
+      doc: "detail",
+      form: "submit",
+      whiteboard: "detail",
+      workflow: "detail",
+      html: "no",
+    });
+  });
+
+  it("fails closed for an unknown plugin type", () => {
+    expect(publicAccessOf("brand-new-plugin-type")).toBe("no");
+    expect(isPubliclyReadableNodeType("brand-new-plugin-type")).toBe(false);
+  });
+
+  it("keeps AirApp closed until its isolated public runtime is available", () => {
+    expect(publicAccessOf("airapp")).toBe("no");
+    expect(isPubliclyReadableNodeType("airapp")).toBe(false);
+  });
+});

--- a/packages/busabase-contract/src/domains/registry.ts
+++ b/packages/busabase-contract/src/domains/registry.ts
@@ -27,6 +27,7 @@ import { htmlNodeType } from "./html/definition";
 import { skillNodeType } from "./skill/definition";
 import type {
   NodeCapabilities,
+  NodePublicAccess,
   NodeTypeDefinition,
   OperationDefinition,
   OperationMeta,
@@ -36,6 +37,7 @@ import { workflowNodeType } from "./workflow/definition";
 
 export type {
   NodeCapabilities,
+  NodePublicAccess,
   NodeTypeDefinition,
   OperationDefinition,
   OperationMeta,
@@ -147,3 +149,13 @@ export const getNodeType = (type: string): NodeTypeDefinition | undefined => reg
 
 export const hasCapability = (type: string, capability: keyof NodeCapabilities): boolean =>
   Boolean(getNodeType(type)?.capabilities[capability]);
+
+/** Public-link behavior for a node type. Unknown and undeclared types fail closed. */
+export const publicAccessOf = (type: string): NodePublicAccess =>
+  getNodeType(type)?.capabilities.publicAccess ?? "no";
+
+/** Whether anonymous `nodes.get` may hydrate this type's detail document. */
+export const isPubliclyReadableNodeType = (type: string): boolean => {
+  const access = publicAccessOf(type);
+  return access === "detail" || access === "submit";
+};

--- a/packages/busabase-contract/src/domains/skill/definition.ts
+++ b/packages/busabase-contract/src/domains/skill/definition.ts
@@ -8,4 +8,5 @@ export const skillNodeType = makeFileTreeNodeType({
   routeBase: "skills",
   tag: "Skills",
   entryFile: "SKILL.md",
+  publicAccess: "no",
 });

--- a/packages/busabase-contract/src/domains/skill/frontmatter.ts
+++ b/packages/busabase-contract/src/domains/skill/frontmatter.ts
@@ -1,0 +1,44 @@
+/**
+ * `SKILL.md` frontmatter — the generic shape, independent of Busabase.
+ *
+ * This used to live inside `domains/package/template.ts`, which encoded an
+ * assumption that no longer holds: that a Skill is a *part of* a template. Most
+ * Skills are not. A Skill is a directory with a `SKILL.md` an agent reads; it
+ * needs no `busabase.json`, ships no `content/`, and never installs into a
+ * workspace. Busabase's own `busabase-app-creator` is one.
+ *
+ * Modelling it only as a template component meant there was nowhere to hang
+ * checks for a plain Skill, so there were none. Hence its own file, in the
+ * domain it belongs to.
+ *
+ * `metadata` is deliberately open: a Skill carries whatever its ecosystem
+ * defines (categories, tags, risk labels, per-agent hints). The Busabase-specific
+ * block that decides template-ness is layered on in `domains/package/template.ts`
+ * — the template format knows about Skills, not the other way round.
+ */
+import { z } from "zod";
+
+/** The entry file that makes a directory a Skill. */
+export const SKILL_ENTRY_FILE = "SKILL.md";
+
+/**
+ * Directories carried alongside `SKILL.md` and installed with it.
+ *
+ * Not arbitrary: an agent follows what the manual says, and the manual routinely
+ * points at `references/…` for detail it deliberately did not inline. A reference
+ * that does not travel with the file turns into an instruction the agent cannot
+ * satisfy.
+ */
+export const SKILL_SIDECAR_DIRS: readonly string[] = ["references", "agents", "scripts"];
+
+export const SkillFrontmatterSchema = z.object({
+  /** Identity. For a Skill inside a package this must equal the package name. */
+  name: z.string().min(1),
+  /**
+   * How an agent decides whether to reach for this Skill at all — so an empty one
+   * is not a cosmetic omission, it is a Skill that never gets picked.
+   */
+  description: z.string().default(""),
+  metadata: z.object({}).passthrough().optional(),
+});
+export type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;

--- a/packages/busabase-contract/src/domains/types.ts
+++ b/packages/busabase-contract/src/domains/types.ts
@@ -4,6 +4,8 @@
  * `NodeTypeDefinition`; the registry composes + registers them.
  */
 
+export type NodePublicAccess = "detail" | "submit" | "runtime" | "no";
+
 export interface NodeCapabilities {
   /** Can hold children / renders as an expandable container (folder, future space/section). */
   container?: boolean;
@@ -11,6 +13,8 @@ export interface NodeCapabilities {
   hasDetail?: boolean;
   /** Can be created via a node change request. */
   creatable?: boolean;
+  /** How an anonymous visitor may open this node type. Omission fails closed as `no`. */
+  publicAccess?: NodePublicAccess;
   /**
    * Hidden from the workbench UI (sidebar node tree + create menu) while the
    * backend stays fully active — the type is still registered, its contract /

--- a/packages/busabase-contract/src/domains/whiteboard/definition.ts
+++ b/packages/busabase-contract/src/domains/whiteboard/definition.ts
@@ -10,7 +10,7 @@ export const whiteboardNodeType = {
   type: "whiteboard",
   label: "Whiteboard",
   icon: "pen-tool",
-  capabilities: { hasDetail: true, creatable: true },
+  capabilities: { hasDetail: true, creatable: true, publicAccess: "detail" },
   operations: [
     {
       kind: "whiteboard_document_update",

--- a/packages/busabase-contract/src/domains/workflow/definition.ts
+++ b/packages/busabase-contract/src/domains/workflow/definition.ts
@@ -11,7 +11,7 @@ export const workflowNodeType = {
   type: "workflow",
   label: "Workflow",
   icon: "workflow",
-  capabilities: { hasDetail: true, creatable: true },
+  capabilities: { hasDetail: true, creatable: true, publicAccess: "detail" },
   operations: [
     {
       kind: "workflow_document_update",

--- a/packages/busabase-contract/src/tasks/change-request.test.ts
+++ b/packages/busabase-contract/src/tasks/change-request.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { changeRequestQueryTask } from "./change-request";
+import type { BusabaseTaskClient } from "./types";
+
+describe("changeRequestQueryTask", () => {
+  it("passes affectsNodeId through, so an MCP caller can scope the check to one node", async () => {
+    const list = vi.fn(async (input: unknown) => input);
+    const client = { changeRequests: { list } } as unknown as BusabaseTaskClient;
+
+    await changeRequestQueryTask.execute(client, {
+      status: "in_review",
+      affectsNodeId: "nod_123",
+      limit: 1,
+    });
+
+    expect(list).toHaveBeenCalledWith({
+      status: "in_review",
+      affectsNodeId: "nod_123",
+      limit: 1,
+    });
+  });
+
+  it("omits affectsNodeId when it was not asked for", async () => {
+    const list = vi.fn(async (input: unknown) => input);
+    const client = { changeRequests: { list } } as unknown as BusabaseTaskClient;
+
+    await changeRequestQueryTask.execute(client, { status: "in_review" });
+
+    expect(list).toHaveBeenCalledWith({ status: "in_review" });
+  });
+
+  // The counts endpoint aggregates over the whole space, so a node filter would
+  // narrow nothing while implying it had — the param is declared as unavailable
+  // there and must not silently reach a different procedure.
+  it("ignores affectsNodeId on the counts variant rather than mis-scoping it", async () => {
+    const counts = vi.fn(async () => ({}));
+    const list = vi.fn();
+    const client = { changeRequests: { counts, list } } as unknown as BusabaseTaskClient;
+
+    await changeRequestQueryTask.execute(client, {
+      countsOnly: true,
+      affectsNodeId: "nod_123",
+    });
+
+    expect(counts).toHaveBeenCalledWith();
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("declares affectsNodeId as a tool parameter", () => {
+    expect(changeRequestQueryTask.params.map((param) => param.name)).toContain("affectsNodeId");
+  });
+});

--- a/packages/busabase-contract/src/tasks/change-request.ts
+++ b/packages/busabase-contract/src/tasks/change-request.ts
@@ -31,6 +31,7 @@ const singleItemError = (result: { error?: string; code?: string; data?: unknown
 export interface ChangeRequestQueryInput {
   status?: string;
   mine?: boolean;
+  affectsNodeId?: string;
   limit?: number;
   cursor?: string;
   countsOnly?: boolean;
@@ -49,7 +50,8 @@ export const changeRequestQueryTask: TaskDefinition<ChangeRequestQueryInput> = {
   summary: "List change requests, or count them per inbox tab",
   guidance:
     "Keyset-paginated: page with the returned `cursor` rather than raising `limit`. " +
-    "Pass countsOnly for just the per-tab totals (review / changes / created / approved / merged / rejected) without fetching rows.",
+    "Pass countsOnly for just the per-tab totals (review / changes / created / approved / merged / rejected) without fetching rows. " +
+    "To check whether a specific resource already has an unfinished change request, pass affectsNodeId with limit 1 instead of paging the whole space: an empty result is conclusive.",
   annotations: { readOnly: true, destructive: false },
   params: [
     {
@@ -58,6 +60,12 @@ export const changeRequestQueryTask: TaskDefinition<ChangeRequestQueryInput> = {
       description: "Filter by status, e.g. `in_review`, `approved`, `merged`.",
     },
     { name: "mine", kind: "boolean", description: "Only change requests you submitted." },
+    {
+      name: "affectsNodeId",
+      kind: "string",
+      description:
+        "Only change requests affecting this node — matching the node directly, its Base, or any of the change request's operations. Not available on the counts variant, whose totals are always space-wide.",
+    },
     { name: "limit", kind: "number", min: 1, max: 100, description: "Page size; 100 max." },
     { name: "cursor", kind: "string", description: "Opaque cursor from the previous page." },
     {
@@ -68,6 +76,7 @@ export const changeRequestQueryTask: TaskDefinition<ChangeRequestQueryInput> = {
   ],
   examples: [
     "busabase-cli change-requests query --status in_review",
+    "busabase-cli change-requests query --affects-node-id nod_123 --status in_review --limit 1",
     "busabase-cli change-requests counts",
   ],
   execute: async (client: BusabaseTaskClient, input: ChangeRequestQueryInput) => {
@@ -75,6 +84,7 @@ export const changeRequestQueryTask: TaskDefinition<ChangeRequestQueryInput> = {
     return client.changeRequests.list({
       ...(input.status ? { status: input.status } : {}),
       ...(input.mine !== undefined ? { mine: input.mine } : {}),
+      ...(input.affectsNodeId ? { affectsNodeId: input.affectsNodeId } : {}),
       ...(input.limit !== undefined ? { limit: input.limit } : {}),
       ...(input.cursor ? { cursor: input.cursor } : {}),
     } as Parameters<BusabaseTaskClient["changeRequests"]["list"]>[0]);

--- a/packages/busabase-contract/src/tasks/index.ts
+++ b/packages/busabase-contract/src/tasks/index.ts
@@ -181,6 +181,11 @@ export const AGENT_EXCLUDED_MCP_TOOLS: readonly string[] = [
   "dump_import_abort",
   // Internal tree predicate used by the UI to validate a drag target.
   "nodes_is_descendant",
+  // The same category: the sidebar asks for a node's ancestor chain purely to
+  // know which folders to expand when it renders. An agent holding a node id
+  // already gets its `parentId` from `nodes_get` and the whole shape from
+  // `nodes_list`; this adds no reach, only UI plumbing.
+  "nodes_ancestors",
   // Installing a package writes a whole subtree of nodes into the workspace from
   // a third-party GitHub repo. That is a human's decision about what to trust,
   // not a step an agent should take on its own. `busabase-cli install` keeps it.

--- a/packages/busabase-contract/src/types/index.ts
+++ b/packages/busabase-contract/src/types/index.ts
@@ -65,7 +65,7 @@ export type BusabaseSourceChannel =
   | "automation"
   | "import";
 export type ReviewVerdict = "approved" | "rejected";
-export type SearchResultKind = "record" | "change_request" | "base" | "file";
+export type SearchResultKind = "record" | "change_request" | "base" | "file" | "node";
 export type CommentSubjectType = "record" | "change_request" | "operation" | "commit";
 export type AuditAction =
   | "record.viewed"
@@ -404,6 +404,12 @@ export interface SearchResponseVO {
   offset: number;
   hasMore: boolean;
   results: SearchResultVO[];
+  /**
+   * True when some in-scope node content was indexed only up to the projection
+   * cap, so this search could not see all of it. Lets a client report an empty
+   * result honestly instead of implying the workspace lacks the phrase.
+   */
+  contentTruncated: boolean;
 }
 
 export interface AuditEventVO {

--- a/packages/busabase-core/package.json
+++ b/packages/busabase-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-core",
   "description": "Shared Busabase open-core protocol, local store, API helpers, and dashboard components.",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -253,6 +253,10 @@
       "types": "./src/domains/dashboard/helpers/node-icons.ts",
       "default": "./src/domains/dashboard/helpers/node-icons.ts"
     },
+    "./dashboard/brand-icons": {
+      "types": "./src/domains/dashboard/helpers/brand-icons.tsx",
+      "default": "./src/domains/dashboard/helpers/brand-icons.tsx"
+    },
     "./dashboard/home": {
       "types": "./src/domains/dashboard/helpers/home.ts",
       "default": "./src/domains/dashboard/helpers/home.ts"
@@ -375,6 +379,7 @@
     "@orpc/server": "^1.14.6",
     "@orpc/tanstack-query": "1.14.6",
     "@orpc/zod": "^1.14.6",
+    "@radix-ui/react-dialog": "^1.1.23",
     "@scelar/nodepod": "^1.9.20",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-virtual": "^3.13.12",
@@ -386,7 +391,7 @@
     "framer-motion": "^12.33.0",
     "ignore": "^7.0.5",
     "kui": "workspace:*",
-    "lucide-react": "^0.556.0",
+    "lucide-react": "^1.34.0",
     "micromark": "^4.0.2",
     "open-domains": "workspace:*",
     "openlib": "workspace:*",
@@ -423,6 +428,7 @@
     "bench:records:pg": "BENCH_ENGINE=postgres NODE_OPTIONS='--conditions=react-server --expose-gc --max-old-space-size=4096' tsx scripts/bench-records.ts",
     "bench:inbox": "NODE_OPTIONS='--conditions=react-server --expose-gc --max-old-space-size=4096' tsx scripts/bench-inbox.ts",
     "verify:inbox-index": "NODE_OPTIONS='--conditions=react-server' tsx scripts/verify-inbox-index.ts",
-    "bench:node-grep": "NODE_OPTIONS=--conditions=react-server tsx scripts/bench-node-grep.ts"
+    "bench:node-grep": "NODE_OPTIONS=--conditions=react-server tsx scripts/bench-node-grep.ts",
+    "backfill:node-content-search": "NODE_OPTIONS=--conditions=react-server tsx scripts/backfill-node-content-search.ts"
   }
 }

--- a/packages/busabase-core/scripts/backfill-node-content-search.ts
+++ b/packages/busabase-core/scripts/backfill-node-content-search.ts
@@ -1,0 +1,76 @@
+/**
+ * Backfill the node content search projection.
+ *
+ * A SQL migration cannot populate `busabase_node_content_search`: the content
+ * lives in object storage, not in Postgres. Searching self-heals a bounded
+ * batch per request, so an upgraded workspace becomes complete on its own —
+ * this script is for operators who would rather have it warm before first use,
+ * and for dev/CI seeds.
+ *
+ * Idempotent: re-running only rewrites rows, it never duplicates them
+ * (`nodeId` is the primary key).
+ *
+ * Usage:
+ *   pnpm --filter busabase-core backfill:node-content-search
+ *   BACKFILL_ONLY_MISSING=1 pnpm --filter busabase-core backfill:node-content-search
+ */
+import { and, eq, isNull } from "drizzle-orm";
+import { getDb } from "../src/db";
+import { busabaseNodeContentSearch, busabaseNodes } from "../src/db/schema";
+import {
+  isSearchableNodeType,
+  reindexNodeContent,
+  SEARCHABLE_NODE_TYPES,
+} from "../src/logic/node-content";
+
+const ONLY_MISSING = process.env.BACKFILL_ONLY_MISSING === "1";
+
+const main = async () => {
+  const db = await getDb();
+  const nodes = await db
+    .select({ id: busabaseNodes.id, spaceId: busabaseNodes.spaceId, type: busabaseNodes.type })
+    .from(busabaseNodes)
+    .where(and(isNull(busabaseNodes.archivedAt)));
+
+  const targets = nodes.filter((node) => isSearchableNodeType(node.type));
+  console.log(
+    `Found ${targets.length} content-bearing node(s) of types ${SEARCHABLE_NODE_TYPES.join("/")}.`,
+  );
+
+  let indexed = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const node of targets) {
+    if (!isSearchableNodeType(node.type)) continue;
+    if (ONLY_MISSING) {
+      const [existing] = await db
+        .select({ nodeId: busabaseNodeContentSearch.nodeId })
+        .from(busabaseNodeContentSearch)
+        .where(eq(busabaseNodeContentSearch.nodeId, node.id))
+        .limit(1);
+      if (existing) {
+        skipped++;
+        continue;
+      }
+    }
+    const ok = await reindexNodeContent(db, {
+      nodeId: node.id,
+      spaceId: node.spaceId,
+      nodeType: node.type,
+    });
+    if (ok) indexed++;
+    else failed++;
+  }
+
+  console.log(`Indexed ${indexed}, skipped ${skipped}, failed ${failed}.`);
+  if (failed > 0) {
+    // Not fatal: a node whose content object is missing is a pre-existing data
+    // problem, not a backfill failure, and the rest of the index is still valid.
+    console.log("Failed nodes have no readable content object; they stay unindexed.");
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/busabase-core/src/db/index.ts
+++ b/packages/busabase-core/src/db/index.ts
@@ -12,7 +12,7 @@ import * as schema from "./schema";
 
 type PgDb = ReturnType<typeof drizzlePg<typeof schema>>;
 type PgliteDb = ReturnType<typeof drizzlePglite<typeof schema>>;
-type DbInstance = PgDb | PgliteDb;
+export type DbInstance = PgDb | PgliteDb;
 
 type DbState = {
   db: DbInstance | null;

--- a/packages/busabase-core/src/db/schema.ts
+++ b/packages/busabase-core/src/db/schema.ts
@@ -200,6 +200,63 @@ export const busabaseNodes = pgTable(
 );
 
 /**
+ * Search projection for node CONTENT — one row per content-bearing node
+ * (`doc` / `html` / `whiteboard` / `workflow`).
+ *
+ * Why a table and not a column on `busabase_nodes`: that table is read on the
+ * hot path with a bare `.select()` (the sidebar tree via `listNodes`, and
+ * `listNodeSummaries` — the list that exists specifically to be the cheap one).
+ * A large TEXT column there would be detoasted and shipped on every sidebar
+ * render. See `content/spec/node-content-search.md` D1.
+ *
+ * `contentText` holds the SAME extracted text grep scans (via
+ * `logic/node-content.ts`'s `NODE_CONTENT_ADAPTERS`), truncated to
+ * `VALUE_TEXT_INDEX_LIMIT`. Storing anything else would let search and grep
+ * disagree about what a workspace contains.
+ */
+export const busabaseNodeContentSearch = pgTable(
+  "busabase_node_content_search",
+  {
+    nodeId: text("node_id")
+      .primaryKey()
+      .references((): AnyPgColumn => busabaseNodes.id, { onDelete: "cascade" }),
+    spaceId: spaceIdColumn(),
+    nodeType: text("node_type").$type<BusabaseNodeType>().notNull(),
+    contentText: text("content_text"),
+    /** sha256 of the FULL pre-truncation text — skips no-op reindexes. */
+    contentHash: text("content_hash"),
+    /** True when the source content was longer than the projected prefix. */
+    truncated: boolean("truncated").notNull().default(false),
+    indexedAt: timestamp("indexed_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (base) => [
+    // Mirrors busabase_field_values exactly (domains/base/schema.ts).
+    //
+    // NEVER add a btree index on `contentText`: a multi-byte-heavy value at the
+    // projection limit overflows Postgres's ~2,704-byte btree row-size limit and
+    // ABORTS THE WRITE (the 2026-07-15 news-merge incident recorded on
+    // busabase_field_values). GIN has no such constraint.
+    //
+    // Both GIN indexes are required, and the trigram one especially: Postgres has
+    // no CJK segmenter, so `to_tsvector('simple', …)` turns a whole Chinese run
+    // into ONE lexeme and silently drops words past 2,047 chars. Measured, a CJK
+    // term scores 0 hits through the tsvector branch and every hit through the
+    // ilike/trigram branch — Chinese search rides entirely on this second index.
+    // See spec D2a.
+    index("busabase_node_content_search_fts_idx").using(
+      "gin",
+      sql`to_tsvector('simple', coalesce(${base.contentText}, ''))`,
+    ),
+    index("busabase_node_content_search_trgm_idx").using(
+      "gin",
+      sql`${base.contentText} gin_trgm_ops`,
+    ),
+    index("busabase_node_content_search_space_idx").on(base.spaceId),
+  ],
+);
+export type NodeContentSearchPO = typeof busabaseNodeContentSearch.$inferSelect;
+
+/**
  * Public link sharing — the orthogonal companion to `busabase_node_principals`.
  *
  * One row per node (`nodeId` unique): sharing is an ATTRIBUTE of the resource,

--- a/packages/busabase-core/src/demo/dataset.ts
+++ b/packages/busabase-core/src/demo/dataset.ts
@@ -53,6 +53,7 @@ import {
   FORMULA_LAB_RECORDS,
   FORMULA_LAB_VIEWS,
 } from "./scenarios/formula-functions-lab";
+import { nestedFoldersScenario } from "./scenarios/nested-folders";
 import { enNodeTypesScenario } from "./scenarios/node-types.en";
 import {
   AGENT_GALLERY_BASES,
@@ -3263,76 +3264,118 @@ export const buildDemoDataset = (
     formsByFolder.set(form.folderNodeId, siblings);
   }
   // Group the (use-case-filtered) bases under their sidebar folder; only emit a
-  // folder that actually has bases.
-  const folderNodes: NodeVO[] = (scenario.folders ?? [])
-    .map((folder) => ({
-      id: folder.nodeId,
-      parentId: DEMO_ROOT_NODE_ID,
-      type: "folder" as const,
-      slug: folder.slug,
-      name: folder.name,
-      description: folder.description,
-      icon: seedNodeIcon({ ...folder, nodeType: "folder" }),
-      metadata: folder.metadata ?? {},
-      position: folder.position,
-      createdAt: rootCreatedAt,
-      updatedAt: rootCreatedAt,
-      explicitVisibility: null,
-      baseId: null,
-      children: [
-        ...bases
-          .filter((base) => base.folderNodeId === folder.nodeId)
-          .map((base, index) => ({
-            id: base.nodeId,
-            parentId: folder.nodeId,
-            type: "base" as const,
-            slug: base.slug,
-            name: base.name,
-            description: base.description,
-            icon: seedNodeIcon({ ...base, nodeType: "base" }),
-            metadata: {},
-            position: index,
-            createdAt: rootCreatedAt,
-            updatedAt: rootCreatedAt,
-            explicitVisibility: null,
-            baseId: base.id,
-            children: [],
-          })),
-        ...(richNodesByFolder.get(folder.nodeId) ?? []).map((richNode) => ({
-          id: richNode.nodeId,
+  // folder that actually has content (see `pruneEmptyFolders` below — for a
+  // folder with subfolders that means content anywhere in its subtree).
+  const flatFolderNodes: NodeVO[] = (scenario.folders ?? []).map((folder) => ({
+    id: folder.nodeId,
+    parentId: folder.parentNodeId ?? DEMO_ROOT_NODE_ID,
+    type: "folder" as const,
+    slug: folder.slug,
+    name: folder.name,
+    description: folder.description,
+    icon: seedNodeIcon({ ...folder, nodeType: "folder" }),
+    metadata: folder.metadata ?? {},
+    position: folder.position,
+    createdAt: rootCreatedAt,
+    updatedAt: rootCreatedAt,
+    explicitVisibility: null,
+    baseId: null,
+    children: [
+      ...bases
+        .filter((base) => base.folderNodeId === folder.nodeId)
+        .map((base, index) => ({
+          id: base.nodeId,
           parentId: folder.nodeId,
-          type: richNode.nodeType,
-          slug: richNode.slug,
-          name: richNode.name,
-          description: richNode.description,
-          icon: seedNodeIcon({ ...richNode, nodeType: richNode.nodeType }),
-          metadata: richNode.metadata,
-          position: richNode.position,
-          createdAt: rootCreatedAt,
-          updatedAt: rootCreatedAt,
-          explicitVisibility: null,
-          baseId: null,
-          children: [],
-        })),
-        ...(formsByFolder.get(folder.nodeId) ?? []).map((form) => ({
-          id: form.nodeId,
-          parentId: folder.nodeId,
-          type: "form" as const,
-          slug: form.slug,
-          name: form.name,
-          description: form.description,
-          icon: seedNodeIcon({ ...form, nodeType: "form" }),
+          type: "base" as const,
+          slug: base.slug,
+          name: base.name,
+          description: base.description,
+          icon: seedNodeIcon({ ...base, nodeType: "base" }),
           metadata: {},
-          position: form.position,
+          position: index,
           createdAt: rootCreatedAt,
           updatedAt: rootCreatedAt,
           explicitVisibility: null,
-          baseId: null,
+          baseId: base.id,
           children: [],
         })),
-      ],
-    }))
-    .filter((folder) => folder.children.length > 0);
+      ...(richNodesByFolder.get(folder.nodeId) ?? []).map((richNode) => ({
+        id: richNode.nodeId,
+        parentId: folder.nodeId,
+        type: richNode.nodeType,
+        slug: richNode.slug,
+        name: richNode.name,
+        description: richNode.description,
+        icon: seedNodeIcon({ ...richNode, nodeType: richNode.nodeType }),
+        metadata: richNode.metadata,
+        position: richNode.position,
+        createdAt: rootCreatedAt,
+        updatedAt: rootCreatedAt,
+        explicitVisibility: null,
+        baseId: null,
+        children: [],
+      })),
+      ...(formsByFolder.get(folder.nodeId) ?? []).map((form) => ({
+        id: form.nodeId,
+        parentId: folder.nodeId,
+        type: "form" as const,
+        slug: form.slug,
+        name: form.name,
+        description: form.description,
+        icon: seedNodeIcon({ ...form, nodeType: "form" }),
+        metadata: {},
+        position: form.position,
+        createdAt: rootCreatedAt,
+        updatedAt: rootCreatedAt,
+        explicitVisibility: null,
+        baseId: null,
+        children: [],
+      })),
+    ],
+  }));
+
+  // Nest subfolders (`SeedFolderDef.parentNodeId`) into their parent's
+  // `children`, leaving only root-level folders behind. Subfolders
+  // go FIRST, ahead of the parent's own bases/rich nodes/forms, so a folder
+  // reads like a file explorer (containers, then leaves) — and so that every
+  // existing, subfolder-less folder keeps byte-identical children.
+  const flatFolderNodeById = new Map(flatFolderNodes.map((folder) => [folder.id, folder]));
+  // Keyed by the parent NODE, not its id, so attaching below needs no second
+  // lookup and has no "parent vanished" branch that could never actually run.
+  const subfoldersByParent = new Map<NodeVO, NodeVO[]>();
+  const rootFolderNodes: NodeVO[] = [];
+  for (const folderNode of flatFolderNodes) {
+    // A `parentNodeId` pointing at something that isn't another seeded folder
+    // (e.g. a scenario referencing a folder it doesn't ship) degrades to
+    // root-level rather than vanishing from the sidebar.
+    const parent =
+      folderNode.parentId === null ? undefined : flatFolderNodeById.get(folderNode.parentId);
+    if (!parent) {
+      folderNode.parentId = DEMO_ROOT_NODE_ID;
+      rootFolderNodes.push(folderNode);
+      continue;
+    }
+    const siblings = subfoldersByParent.get(parent) ?? [];
+    siblings.push(folderNode);
+    subfoldersByParent.set(parent, siblings);
+  }
+  for (const [parent, subfolders] of subfoldersByParent) {
+    subfolders.sort((a, b) => a.position - b.position);
+    parent.children = [...subfolders, ...parent.children];
+  }
+  // Drop folders whose whole subtree is empty — the same "don't show an empty
+  // folder" rule as before, just applied bottom-up now that a folder can be
+  // non-empty purely because a descendant is.
+  const pruneEmptyFolders = (nodes: NodeVO[]): NodeVO[] =>
+    nodes.flatMap((node) => {
+      if (node.type !== "folder") return [node];
+      const children = pruneEmptyFolders(node.children);
+      if (children.length === 0) return [];
+      node.children = children;
+      return [node];
+    });
+  // The Docs/Files/Skill/Drive/AirApp folders below push onto this same array.
+  const folderNodes: NodeVO[] = pruneEmptyFolders(rootFolderNodes);
 
   // Docs/Files are workspace-structural content (like Skill/Drive), not use-case
   // tagged Bases — always include them regardless of `useCase`, matching the real
@@ -3818,7 +3861,11 @@ export const buildDemoDataset = (
 /** English default seed — used by ensureReady() to populate a fresh local workspace. */
 export const englishScenario: SeedScenario = withSeedNodeIcons(
   withCmsDemoStandard({
-    folders: [...DEMO_FOLDERS, ...(enNodeTypesScenario.folders ?? [])],
+    folders: [
+      ...DEMO_FOLDERS,
+      ...(enNodeTypesScenario.folders ?? []),
+      ...(nestedFoldersScenario.folders ?? []),
+    ],
     bases: DEMO_BASES,
     records: DEMO_RECORDS,
     views: DEMO_VIEWS,
@@ -3826,7 +3873,10 @@ export const englishScenario: SeedScenario = withSeedNodeIcons(
     docs: enNodeTypesScenario.docs,
     files: enNodeTypesScenario.files,
     fileTreeNodes: enNodeTypesScenario.fileTreeNodes,
-    richNodes: enNodeTypesScenario.richNodes,
+    richNodes: [
+      ...(enNodeTypesScenario.richNodes ?? []),
+      ...(nestedFoldersScenario.richNodes ?? []),
+    ],
     comments: enNodeTypesScenario.comments,
     forms: [
       {

--- a/packages/busabase-core/src/demo/scenarios/nested-folders.ts
+++ b/packages/busabase-core/src/demo/scenarios/nested-folders.ts
@@ -1,0 +1,228 @@
+import type { SeedFolderDef, SeedRichNodeDef, SeedScenario } from "../seed-types";
+
+/**
+ * A genuinely NESTED folder branch — the only one in the demo data set.
+ *
+ * Every other seeded folder is a single level under the workspace root, with
+ * its Bases/Docs/Files sitting directly inside it. That shape never reaches
+ * past the sidebar's eager prefetch (`nodes.list({ parentId: null, depth: 2 })`
+ * = root + 2 levels), so a fresh workspace never exercised — and could never
+ * demo — expanding a folder that has to fetch its children lazily. This branch
+ * is 4 folder levels deep on purpose:
+ *
+ *   Product Ops                  (level 1 — prefetched)
+ *   └── 2026 Launch              (level 2 — prefetched, children are NOT: the
+ *       │                                    first lazy `onExpand` fetch)
+ *       ├── Launch Assets        (level 3 — arrives with that fetch)
+ *       │   ├── Brand Kit        (level 4 — arrives with that fetch; its own
+ *       │   │   └── One-Pager …             children need a SECOND lazy fetch)
+ *       │   └── Press Page
+ *       └── Launch Checklist
+ *   └── Archive                  (level 2)
+ *       └── 2025 Retro           (level 3)
+ *           └── Retro Summary
+ *
+ * so `pnpm db:seed:all && pnpm dev` is enough to click through the whole
+ * lazy-expand path by hand, and any regression in it is visible in the demo
+ * workspace instead of only in a customer's own tree.
+ *
+ * Leaf content is deliberately plain `html` nodes: they need no Base/fields/
+ * records/views, so the branch stays about the folder nesting.
+ */
+
+export const NESTED_PRODUCT_OPS_FOLDER_NODE_ID = "nod_nested_product_ops";
+export const NESTED_LAUNCH_FOLDER_NODE_ID = "nod_nested_launch_2026";
+export const NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID = "nod_nested_launch_assets";
+export const NESTED_BRAND_KIT_FOLDER_NODE_ID = "nod_nested_brand_kit";
+export const NESTED_ARCHIVE_FOLDER_NODE_ID = "nod_nested_archive";
+export const NESTED_RETRO_FOLDER_NODE_ID = "nod_nested_retro_2025";
+
+/** Shared by the English and zh-CN twins — only the labels differ. */
+export const nestedFolderShape = {
+  productOps: { nodeId: NESTED_PRODUCT_OPS_FOLDER_NODE_ID, slug: "product-ops", position: 12 },
+  launch: {
+    nodeId: NESTED_LAUNCH_FOLDER_NODE_ID,
+    parentNodeId: NESTED_PRODUCT_OPS_FOLDER_NODE_ID,
+    slug: "launch-2026",
+    position: 0,
+  },
+  launchAssets: {
+    nodeId: NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID,
+    parentNodeId: NESTED_LAUNCH_FOLDER_NODE_ID,
+    slug: "launch-assets",
+    position: 0,
+  },
+  brandKit: {
+    nodeId: NESTED_BRAND_KIT_FOLDER_NODE_ID,
+    parentNodeId: NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID,
+    slug: "brand-kit",
+    position: 0,
+  },
+  archive: {
+    nodeId: NESTED_ARCHIVE_FOLDER_NODE_ID,
+    parentNodeId: NESTED_PRODUCT_OPS_FOLDER_NODE_ID,
+    slug: "product-ops-archive",
+    position: 1,
+  },
+  retro: {
+    nodeId: NESTED_RETRO_FOLDER_NODE_ID,
+    parentNodeId: NESTED_ARCHIVE_FOLDER_NODE_ID,
+    slug: "retro-2025",
+    position: 0,
+  },
+} as const;
+
+/** A tiny, readable HTML page — the leaf content at each nesting level. */
+export const nestedHtmlPage = (title: string, lede: string, bullets: string[]): string =>
+  [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '  <meta charset="utf-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+    `  <title>${title}</title>`,
+    "  <style>",
+    "    body { margin: 0; padding: 40px 32px; font: 16px/1.6 ui-sans-serif, system-ui, sans-serif; color: #0f172a; background: #f8fafc; }",
+    "    main { max-width: 640px; margin: 0 auto; background: #fff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 32px; }",
+    "    h1 { margin: 0 0 8px; font-size: 24px; }",
+    "    p { margin: 0 0 20px; color: #475569; }",
+    "    li { margin-bottom: 8px; }",
+    "  </style>",
+    "</head>",
+    "<body>",
+    "  <main>",
+    `    <h1>${title}</h1>`,
+    `    <p>${lede}</p>`,
+    "    <ul>",
+    ...bullets.map((bullet) => `      <li>${bullet}</li>`),
+    "    </ul>",
+    "  </main>",
+    "</body>",
+    "</html>",
+  ].join("\n");
+
+const folders: SeedFolderDef[] = [
+  {
+    ...nestedFolderShape.productOps,
+    name: "Product Ops",
+    description: "How a release is run — nested by campaign, then by workstream.",
+  },
+  {
+    ...nestedFolderShape.launch,
+    name: "2026 Launch",
+    description: "Everything for the 2026 launch, one subfolder per workstream.",
+  },
+  {
+    ...nestedFolderShape.launchAssets,
+    name: "Launch Assets",
+    description: "Pages and visuals shipped with the launch.",
+  },
+  {
+    ...nestedFolderShape.brandKit,
+    name: "Brand Kit",
+    description: "Logo, colours, and the one-pager partners get.",
+  },
+  {
+    ...nestedFolderShape.archive,
+    name: "Archive",
+    description: "Closed campaigns, kept for reference.",
+  },
+  {
+    ...nestedFolderShape.retro,
+    name: "2025 Retro",
+    description: "What the previous launch taught us.",
+  },
+];
+
+const richNodes: SeedRichNodeDef[] = [
+  {
+    nodeType: "html",
+    nodeId: "nod_nested_html_launch_checklist",
+    folderNodeId: NESTED_LAUNCH_FOLDER_NODE_ID,
+    slug: "launch-checklist",
+    name: "Launch Checklist",
+    description: "The go/no-go list for launch day.",
+    position: 1,
+    metadata: {
+      htmlDocument: {
+        version: 1,
+        source: nestedHtmlPage(
+          "2026 Launch checklist",
+          "Everything that has to be approved before launch day.",
+          [
+            "Pricing page reviewed and merged",
+            "Docs updated for the new onboarding flow",
+            "Support macros written and approved",
+            "Status page and rollback plan confirmed",
+          ],
+        ),
+      },
+    },
+  },
+  {
+    nodeType: "html",
+    nodeId: "nod_nested_html_press_page",
+    folderNodeId: NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID,
+    slug: "launch-press-page",
+    name: "Press Page",
+    description: "The public press page draft for launch week.",
+    position: 1,
+    metadata: {
+      htmlDocument: {
+        version: 1,
+        source: nestedHtmlPage("Press page draft", "What the press sees on launch day.", [
+          "Headline and one-line positioning",
+          "Three product screenshots with captions",
+          "Founder quote, approved by comms",
+          "Contact address for interview requests",
+        ]),
+      },
+    },
+  },
+  {
+    nodeType: "html",
+    nodeId: "nod_nested_html_one_pager",
+    folderNodeId: NESTED_BRAND_KIT_FOLDER_NODE_ID,
+    slug: "launch-one-pager",
+    name: "Partner One-Pager",
+    description: "The single page partners get when they ask what shipped.",
+    position: 0,
+    metadata: {
+      htmlDocument: {
+        version: 1,
+        source: nestedHtmlPage(
+          "Partner one-pager",
+          "One page a partner can forward internally without any context from us.",
+          [
+            "What changed, in one sentence",
+            "Who it is for, and who it is not for",
+            "Logo and colour usage rules",
+            "Where to send questions",
+          ],
+        ),
+      },
+    },
+  },
+  {
+    nodeType: "html",
+    nodeId: "nod_nested_html_retro_summary",
+    folderNodeId: NESTED_RETRO_FOLDER_NODE_ID,
+    slug: "retro-2025-summary",
+    name: "Retro Summary",
+    description: "What the 2025 launch taught us, in one page.",
+    position: 0,
+    metadata: {
+      htmlDocument: {
+        version: 1,
+        source: nestedHtmlPage("2025 launch retro", "Kept short on purpose — four takeaways.", [
+          "The checklist was written too late to be useful",
+          "Docs and pricing shipped out of sync",
+          "Support had no macros on day one",
+          "The rollback plan was never rehearsed",
+        ]),
+      },
+    },
+  },
+];
+
+export const nestedFoldersScenario: SeedScenario = { folders, richNodes };

--- a/packages/busabase-core/src/demo/scenarios/nested-folders.zh-cn.ts
+++ b/packages/busabase-core/src/demo/scenarios/nested-folders.zh-cn.ts
@@ -1,0 +1,133 @@
+import type { SeedFolderDef, SeedRichNodeDef, SeedScenario } from "../seed-types";
+import {
+  NESTED_BRAND_KIT_FOLDER_NODE_ID,
+  NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID,
+  NESTED_LAUNCH_FOLDER_NODE_ID,
+  NESTED_RETRO_FOLDER_NODE_ID,
+  nestedFolderShape,
+  nestedHtmlPage,
+} from "./nested-folders";
+
+/**
+ * zh-CN twin of `nested-folders.ts` — same node ids, slugs, positions and
+ * nesting, only the human-facing labels differ (the convention every other
+ * `*.zh-cn.ts` scenario in this folder follows). See the English file for
+ * why this deep branch exists at all.
+ */
+
+const folders: SeedFolderDef[] = [
+  {
+    ...nestedFolderShape.productOps,
+    name: "产品运营",
+    description: "一次发布是怎么跑的——先按项目分，再按工作流分。",
+  },
+  {
+    ...nestedFolderShape.launch,
+    name: "2026 发布",
+    description: "2026 发布的全部材料，每条工作流一个子文件夹。",
+  },
+  {
+    ...nestedFolderShape.launchAssets,
+    name: "发布物料",
+    description: "随发布一起上线的页面与视觉素材。",
+  },
+  {
+    ...nestedFolderShape.brandKit,
+    name: "品牌套件",
+    description: "Logo、配色，以及给合作伙伴的一页纸。",
+  },
+  {
+    ...nestedFolderShape.archive,
+    name: "归档",
+    description: "已结束的项目，留作参考。",
+  },
+  {
+    ...nestedFolderShape.retro,
+    name: "2025 复盘",
+    description: "上一次发布留下的经验。",
+  },
+];
+
+const richNodes: SeedRichNodeDef[] = [
+  {
+    nodeType: "html",
+    nodeId: "nod_nested_html_launch_checklist",
+    folderNodeId: NESTED_LAUNCH_FOLDER_NODE_ID,
+    slug: "launch-checklist",
+    name: "发布检查清单",
+    description: "发布当天的 go / no-go 清单。",
+    position: 1,
+    metadata: {
+      htmlDocument: {
+        version: 1,
+        source: nestedHtmlPage("2026 发布检查清单", "发布当天之前必须全部审核通过的事项。", [
+          "定价页已审核并合并",
+          "文档已跟上新的引导流程",
+          "客服话术已撰写并审核",
+          "状态页与回滚方案已确认",
+        ]),
+      },
+    },
+  },
+  {
+    nodeType: "html",
+    nodeId: "nod_nested_html_press_page",
+    folderNodeId: NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID,
+    slug: "launch-press-page",
+    name: "媒体页",
+    description: "发布周对外的媒体页草稿。",
+    position: 1,
+    metadata: {
+      htmlDocument: {
+        version: 1,
+        source: nestedHtmlPage("媒体页草稿", "发布当天媒体看到的内容。", [
+          "标题与一句话定位",
+          "三张产品截图并配说明",
+          "创始人引言（已经公关审核）",
+          "采访邀约的联系邮箱",
+        ]),
+      },
+    },
+  },
+  {
+    nodeType: "html",
+    nodeId: "nod_nested_html_one_pager",
+    folderNodeId: NESTED_BRAND_KIT_FOLDER_NODE_ID,
+    slug: "launch-one-pager",
+    name: "合作伙伴一页纸",
+    description: "合作伙伴问「这次发了什么」时，直接发这一页。",
+    position: 0,
+    metadata: {
+      htmlDocument: {
+        version: 1,
+        source: nestedHtmlPage(
+          "合作伙伴一页纸",
+          "不需要我们补充任何上下文就能在对方内部转发的一页。",
+          ["一句话说明改了什么", "适合谁，不适合谁", "Logo 与配色的使用规则", "问题往哪里提"],
+        ),
+      },
+    },
+  },
+  {
+    nodeType: "html",
+    nodeId: "nod_nested_html_retro_summary",
+    folderNodeId: NESTED_RETRO_FOLDER_NODE_ID,
+    slug: "retro-2025-summary",
+    name: "复盘小结",
+    description: "2025 发布留下的经验，一页写完。",
+    position: 0,
+    metadata: {
+      htmlDocument: {
+        version: 1,
+        source: nestedHtmlPage("2025 发布复盘", "刻意写短——只留四条。", [
+          "检查清单写得太晚，等于没写",
+          "文档和定价页上线时间对不上",
+          "第一天客服手里没有话术",
+          "回滚方案从来没有演练过",
+        ]),
+      },
+    },
+  },
+];
+
+export const nestedFoldersZhCnScenario: SeedScenario = { folders, richNodes };

--- a/packages/busabase-core/src/demo/scenarios/zh-cn.ts
+++ b/packages/busabase-core/src/demo/scenarios/zh-cn.ts
@@ -5,6 +5,7 @@ import { datasetZhCnScenario } from "./dataset.zh-cn";
 import { directoryListingZhCnScenario } from "./directory-listing.zh-cn";
 import { expandZhCnScenario } from "./expand.zh-cn";
 import { financeInvoiceZhCnScenario } from "./finance-invoice.zh-cn";
+import { nestedFoldersZhCnScenario } from "./nested-folders.zh-cn";
 import { zhCnNodeTypesScenario } from "./node-types.zh-cn";
 import { agentGalleryZhCnScenario } from "./product-gallery.zh-cn";
 import { roadmapZhCnScenario } from "./product-roadmap.zh-cn";
@@ -34,5 +35,6 @@ export const zhCnScenario: SeedScenario = withSeedNodeIcons(
     agentGalleryZhCnScenario,
     roadmapZhCnScenario,
     zhCnNodeTypesScenario,
+    nestedFoldersZhCnScenario,
   ),
 );

--- a/packages/busabase-core/src/demo/seed-types.ts
+++ b/packages/busabase-core/src/demo/seed-types.ts
@@ -15,6 +15,16 @@ export interface SeedFolderDef {
   slug: string;
   name: string;
   description: string;
+  /**
+   * Parent folder this one nests under — another `SeedFolderDef`'s `nodeId`.
+   * Omit for a folder that sits directly under the workspace root (the
+   * default, and what every folder was before nesting existed).
+   *
+   * Seeding resolves parents before children regardless of array order, so a
+   * scenario may list a subfolder before its parent — but keeping them in
+   * tree order still reads better.
+   */
+  parentNodeId?: string;
   /** Validated custom icon materialized by `withSeedNodeIcons`. */
   icon?: NodeIcon;
   /** Optional top-level node metadata merged into an existing seeded folder. */

--- a/packages/busabase-core/src/domains/agents/components/agents-add-view.tsx
+++ b/packages/busabase-core/src/domains/agents/components/agents-add-view.tsx
@@ -36,7 +36,12 @@ export function AgentsAddView({ orpc, onBack, onConnected, spaceId }: AgentsAddV
     ...orpc.agents.sessions.create.mutationOptions(),
     onSuccess: (session: AgentSessionVO) => {
       void Promise.all([
-        queryClient.invalidateQueries({ queryKey: orpc.agents.connections.list.queryKey() }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.agents.connections.list.queryKey({ input: { scope: "mine" } }),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.agents.connections.list.queryKey({ input: { scope: "space" } }),
+        }),
         queryClient.invalidateQueries({ queryKey: orpc.agents.sessions.list.queryKey() }),
       ]);
       onConnected(session.slug);

--- a/packages/busabase-core/src/domains/agents/components/agents-list-view.tsx
+++ b/packages/busabase-core/src/domains/agents/components/agents-list-view.tsx
@@ -2,7 +2,10 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
-import type { AgentConnectionVO } from "busabase-contract/domains/agents/types";
+import type {
+  AgentConnectionScope,
+  AgentConnectionVO,
+} from "busabase-contract/domains/agents/types";
 import { Button } from "kui/button";
 import {
   DropdownMenu,
@@ -10,9 +13,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "kui/dropdown-menu";
+import { Tabs, TabsList, TabsTrigger } from "kui/tabs";
 import { Bot, MoreHorizontal, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { fmt, useCoreI18n } from "../../../i18n";
 import { ConfirmActionDialog } from "../../dashboard/components/primitives";
 import { AgentLoadingState, AgentQueryErrorState } from "./agent-query-state";
 import { TransportBadge } from "./transport-badge";
@@ -30,10 +35,12 @@ interface AgentsListViewProps {
  * reads as one card, not three.
  */
 export function AgentsListView({ orpc, onSelectAgent, onAddAgent }: AgentsListViewProps) {
+  const messages = useCoreI18n();
   const queryClient = useQueryClient();
+  const [scope, setScope] = useState<AgentConnectionScope>("mine");
   const [disconnecting, setDisconnecting] = useState<AgentConnectionVO | null>(null);
   const connections = useQuery({
-    ...orpc.agents.connections.list.queryOptions(),
+    ...orpc.agents.connections.list.queryOptions({ input: { scope } }),
     refetchInterval: 4000,
   });
 
@@ -41,7 +48,12 @@ export function AgentsListView({ orpc, onSelectAgent, onAddAgent }: AgentsListVi
     ...orpc.agents.disconnect.mutationOptions(),
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: orpc.agents.connections.list.queryKey() }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.agents.connections.list.queryKey({ input: { scope: "mine" } }),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.agents.connections.list.queryKey({ input: { scope: "space" } }),
+        }),
         queryClient.invalidateQueries({ queryKey: orpc.agents.sessions.list.queryKey() }),
         queryClient.invalidateQueries({ queryKey: orpc.agents.catalog.queryKey() }),
       ]);
@@ -53,19 +65,11 @@ export function AgentsListView({ orpc, onSelectAgent, onAddAgent }: AgentsListVi
     },
   });
 
-  if (connections.isPending) {
-    return <AgentLoadingState />;
-  }
-
-  if (connections.isError) {
-    return (
-      <AgentQueryErrorState
-        error={connections.error}
-        onRetry={() => void connections.refetch()}
-        title="Couldn't load connected agents"
-      />
-    );
-  }
+  const connectionItems = connections.data ?? [];
+  const emptyTitle =
+    scope === "mine" ? messages.agents.mineEmptyTitle : messages.agents.spaceEmptyTitle;
+  const emptyBody =
+    scope === "mine" ? messages.agents.mineEmptyBody : messages.agents.spaceEmptyBody;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -78,28 +82,46 @@ export function AgentsListView({ orpc, onSelectAgent, onAddAgent }: AgentsListVi
         </div>
         <Button size="sm" onClick={onAddAgent}>
           <Plus className="size-4" />
-          Add agent
+          {messages.agents.addAgent}
         </Button>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-6">
-        {(connections.data ?? []).length === 0 ? (
+        <Tabs
+          value={scope}
+          onValueChange={(value) => {
+            if (value === "mine" || value === "space") setScope(value);
+          }}
+        >
+          <TabsList className="mb-6">
+            <TabsTrigger value="mine">{messages.agents.mineTab}</TabsTrigger>
+            <TabsTrigger value="space">{messages.agents.spaceTab}</TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        {connections.isPending ? (
+          <AgentLoadingState />
+        ) : connections.isError ? (
+          <AgentQueryErrorState
+            error={connections.error}
+            onRetry={() => void connections.refetch()}
+            title="Couldn't load connected agents"
+          />
+        ) : connectionItems.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
             <Bot className="size-8 text-muted-foreground" />
             <div>
-              <h2 className="font-medium">No agents connected yet</h2>
-              <p className="mt-1 text-muted-foreground text-sm">
-                Connect Claude Code, Codex, or a Buda AI Agent to get started.
-              </p>
+              <h2 className="font-medium">{emptyTitle}</h2>
+              <p className="mt-1 text-muted-foreground text-sm">{emptyBody}</p>
             </div>
             <Button onClick={onAddAgent}>
               <Plus className="size-4" />
-              Add agent
+              {messages.agents.addAgent}
             </Button>
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {(connections.data ?? []).map((group) => (
+            {connectionItems.map((group) => (
               <div key={group.slug} className="relative rounded-lg border hover:bg-accent">
                 <button
                   type="button"
@@ -118,28 +140,30 @@ export function AgentsListView({ orpc, onSelectAgent, onAddAgent }: AgentsListVi
                     {group.latest?.status ?? "not started"}
                   </p>
                 </button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      aria-label={`Actions for ${group.agentName}`}
-                      className="absolute right-2 bottom-2 size-8"
-                      size="icon"
-                      type="button"
-                      variant="ghost"
-                    >
-                      <MoreHorizontal className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      onSelect={() => setDisconnecting(group)}
-                      variant="destructive"
-                    >
-                      <Trash2 className="mr-2 size-4" />
-                      Delete connection
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                {group.ownedByCurrentUser ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        aria-label={fmt(messages.agents.actionsFor, { name: group.agentName })}
+                        className="absolute right-2 bottom-2 size-8"
+                        size="icon"
+                        type="button"
+                        variant="ghost"
+                      >
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onSelect={() => setDisconnecting(group)}
+                        variant="destructive"
+                      >
+                        <Trash2 className="mr-2 size-4" />
+                        {messages.agents.deleteConnection}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : null}
               </div>
             ))}
           </div>
@@ -151,7 +175,7 @@ export function AgentsListView({ orpc, onSelectAgent, onAddAgent }: AgentsListVi
             ? `Delete ${disconnecting.agentName} and its ${disconnecting.sessionCount} ${disconnecting.sessionCount === 1 ? "session" : "sessions"}? This removes the saved connection and conversation history. This cannot be undone.`
             : ""
         }
-        confirmLabel="Delete connection"
+        confirmLabel={messages.agents.deleteConnection}
         onCancel={() => setDisconnecting(null)}
         onConfirm={() => {
           if (disconnecting) disconnect.mutate({ slug: disconnecting.slug });

--- a/packages/busabase-core/src/domains/agents/hooks/use-agent-session.ts
+++ b/packages/busabase-core/src/domains/agents/hooks/use-agent-session.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { attachmentToContentBlock } from "@acp-ui/core/prompt";
 import type { AcpUiEvent } from "@acp-ui/core/reduce";
 import type { AcpSessionPort } from "@acp-ui/core/session";
 import { useAcpSession } from "@acp-ui/core/session";
@@ -85,17 +86,19 @@ function translate(event: AgentSessionEventVO): AcpUiEvent[] {
           content: { type: "text", text: update.text },
         } as never,
       },
+      // Built through the same helper the send path uses, rather than
+      // hand-rolling `{ type: attachment.kind }`: that shape is only a valid
+      // ACP content block for `image`/`audio`, so a `file` attachment would
+      // produce `{ type: "file" }`, be rejected by the reducer, and silently
+      // vanish from a replayed transcript — the very failure the comment
+      // above warns about, one kind later.
       ...attachments.map(
         (attachment): AcpUiEvent => ({
           type: "session_update",
           update: {
             sessionUpdate: "user_message_chunk",
-            content: {
-              type: attachment.kind,
-              data: attachment.data,
-              mimeType: attachment.mimeType,
-            },
-          } as never,
+            content: attachmentToContentBlock(attachment),
+          },
         }),
       ),
     ];

--- a/packages/busabase-core/src/domains/agents/logic/agent-catalog.test.ts
+++ b/packages/busabase-core/src/domains/agents/logic/agent-catalog.test.ts
@@ -39,6 +39,8 @@ import { listCatalog, resolveLaunch } from "./agent-catalog";
 
 describe("agent catalog availability", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.spawnSync.mockReturnValue({ status: 0 });
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response(JSON.stringify({ agents: [] }), { status: 200 })),
@@ -66,6 +68,8 @@ describe("agent catalog availability", () => {
       available: false,
       unavailableReason: expect.stringContaining("was not found on this machine"),
     });
+    expect(mocks.listBudaConnections).toHaveBeenCalledWith("space");
+    expect(mocks.spawnSync).toHaveBeenCalledTimes(2);
   });
 
   it("launches a local agent on a local host", async () => {

--- a/packages/busabase-core/src/domains/agents/logic/agent-catalog.ts
+++ b/packages/busabase-core/src/domains/agents/logic/agent-catalog.ts
@@ -193,7 +193,7 @@ async function fetchRegistryDisplayInfo(): Promise<
 export async function listCatalog(): Promise<AgentCatalogEntryVO[]> {
   const cloudHost = isCloudHost();
   const registryInfo = await fetchRegistryDisplayInfo();
-  const budaConnections = await listBudaConnections();
+  const budaConnections = await listBudaConnections("space");
 
   return CATALOG.map((spec) => {
     let available = false;

--- a/packages/busabase-core/src/domains/agents/logic/agent-connection-list.test.ts
+++ b/packages/busabase-core/src/domains/agents/logic/agent-connection-list.test.ts
@@ -2,12 +2,21 @@ import type { AgentSessionVO } from "busabase-contract/domains/agents/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  budaConnections: [] as Array<{ slug: string; agentId: string; agentName: string }>,
+  budaConnections: [] as Array<{
+    slug: string;
+    agentId: string;
+    agentName: string;
+    ownedByCurrentUser: boolean;
+  }>,
+  requestedScopes: [] as string[],
   sessions: [] as AgentSessionVO[],
 }));
 
 vi.mock("./buda-connection", () => ({
-  listBudaConnections: async () => mocks.budaConnections,
+  listBudaConnections: async (scope: string) => {
+    mocks.requestedScopes.push(scope);
+    return mocks.budaConnections;
+  },
 }));
 vi.mock("./agent-session-manager", () => ({
   listAgentSessions: async () => mocks.sessions,
@@ -30,22 +39,34 @@ const session = (over: Partial<AgentSessionVO> & { slug: string }): AgentSession
 describe("listAgentConnections", () => {
   beforeEach(() => {
     mocks.budaConnections.length = 0;
+    mocks.requestedScopes.length = 0;
     mocks.sessions.length = 0;
   });
 
   it("maps saved Buda connection rows to agent connections", async () => {
     mocks.budaConnections.push(
-      { slug: "buda:agent-2", agentId: "agent-2", agentName: "Ada" },
-      { slug: "buda:agent-1", agentId: "agent-1", agentName: "Rex" },
+      {
+        slug: "buda:agent-2",
+        agentId: "agent-2",
+        agentName: "Ada",
+        ownedByCurrentUser: false,
+      },
+      {
+        slug: "buda:agent-1",
+        agentId: "agent-1",
+        agentName: "Rex",
+        ownedByCurrentUser: true,
+      },
     );
 
-    await expect(listAgentConnections()).resolves.toEqual([
+    await expect(listAgentConnections("space")).resolves.toEqual([
       {
         slug: "buda:agent-2",
         agentName: "Ada",
         transport: "remote-websocket",
         sessionCount: 0,
         latest: null,
+        ownedByCurrentUser: false,
       },
       {
         slug: "buda:agent-1",
@@ -53,12 +74,15 @@ describe("listAgentConnections", () => {
         transport: "remote-websocket",
         sessionCount: 0,
         latest: null,
+        ownedByCurrentUser: true,
       },
     ]);
+    expect(mocks.requestedScopes).toEqual(["space"]);
   });
 
   it("returns no connections when nothing is connected", async () => {
     await expect(listAgentConnections()).resolves.toEqual([]);
+    expect(mocks.requestedScopes).toEqual(["mine"]);
   });
 
   /**
@@ -76,6 +100,7 @@ describe("listAgentConnections", () => {
         transport: "local-subprocess",
         sessionCount: 1,
         latest: mocks.sessions[0],
+        ownedByCurrentUser: true,
       },
     ]);
   });
@@ -99,7 +124,12 @@ describe("listAgentConnections", () => {
    * a Buda session must never produce a second entry beside it.
    */
   it("does not let a Buda session duplicate its own saved connection", async () => {
-    mocks.budaConnections.push({ slug: "buda:agent-1", agentId: "agent-1", agentName: "Rex" });
+    mocks.budaConnections.push({
+      slug: "buda:agent-1",
+      agentId: "agent-1",
+      agentName: "Rex",
+      ownedByCurrentUser: true,
+    });
     mocks.sessions.push(
       session({ slug: "buda:agent-1", agentName: "Rex", transport: "remote-websocket" }),
     );
@@ -110,7 +140,12 @@ describe("listAgentConnections", () => {
   });
 
   it("lists both transports together, sorted by name", async () => {
-    mocks.budaConnections.push({ slug: "buda:agent-1", agentId: "agent-1", agentName: "Rex" });
+    mocks.budaConnections.push({
+      slug: "buda:agent-1",
+      agentId: "agent-1",
+      agentName: "Rex",
+      ownedByCurrentUser: true,
+    });
     mocks.sessions.push(session({ slug: "codex-acp", agentName: "Codex CLI" }));
 
     const connections = await listAgentConnections();

--- a/packages/busabase-core/src/domains/agents/logic/agent-connection-list.ts
+++ b/packages/busabase-core/src/domains/agents/logic/agent-connection-list.ts
@@ -1,4 +1,7 @@
-import type { AgentConnectionVO } from "busabase-contract/domains/agents/types";
+import type {
+  AgentConnectionScope,
+  AgentConnectionVO,
+} from "busabase-contract/domains/agents/types";
 import { listAgentSessions } from "./agent-session-manager";
 import { listBudaConnections } from "./buda-connection";
 
@@ -24,9 +27,11 @@ import { listBudaConnections } from "./buda-connection";
  * made the difference observable: you could connect Codex, chat with it, and
  * then not find it in the very list that is supposed to show your agents.
  */
-export async function listAgentConnections(): Promise<AgentConnectionVO[]> {
+export async function listAgentConnections(
+  scope: AgentConnectionScope = "mine",
+): Promise<AgentConnectionVO[]> {
   const [budaConnections, sessions] = await Promise.all([
-    listBudaConnections(),
+    listBudaConnections(scope),
     listAgentSessions(),
   ]);
 
@@ -36,6 +41,7 @@ export async function listAgentConnections(): Promise<AgentConnectionVO[]> {
     transport: "remote-websocket" as const,
     sessionCount: 0,
     latest: null,
+    ownedByCurrentUser: connection.ownedByCurrentUser,
   }));
 
   // Grouped by slug so several conversations with one agent read as one entry,
@@ -53,6 +59,7 @@ export async function listAgentConnections(): Promise<AgentConnectionVO[]> {
       transport: "local-subprocess",
       sessionCount: sessions.filter((other) => other.slug === session.slug).length,
       latest: session,
+      ownedByCurrentUser: true,
     });
   }
 

--- a/packages/busabase-core/src/domains/agents/logic/agent-session-manager.ts
+++ b/packages/busabase-core/src/domains/agents/logic/agent-session-manager.ts
@@ -415,9 +415,27 @@ export async function createAgentSession({
           }
           setStatus(session, "busy");
           try {
+            // Negotiated the same way `mcpCapabilities.http` is above, and for
+            // the same reason: ACP makes `image`, `audio` and `embeddedContext`
+            // opt-in, so an attachment can be valid and still be unsendable to
+            // THIS agent. `buildPromptContent` drops or downgrades what the
+            // agent cannot take and reports each one, and those notes go to the
+            // user rather than leaving them with a reply that silently ignored
+            // the PDF they attached.
+            const { prompt, notes } = buildPromptContent(
+              text,
+              attachments,
+              initialized.agentCapabilities?.promptCapabilities ?? {},
+            );
+            for (const note of notes) {
+              emit(session, {
+                kind: "acpUpdate",
+                acpUpdate: { sessionUpdate: "note", text: note },
+              });
+            }
             await ctx.request(acp.methods.agent.session.prompt, {
               sessionId: created.sessionId,
-              prompt: buildPromptContent(text, attachments),
+              prompt,
             });
             setStatus(session, "idle");
           } catch (error) {
@@ -532,8 +550,8 @@ export async function listAgentSessions(): Promise<AgentSessionVO[]> {
  * ACP's `PromptRequest.prompt` is a `ContentBlock[]`, not a bare string — a
  * text block first (possibly empty, when the user sent only attachments;
  * the contract's refine already guarantees at least one of text/attachments
- * is real), then one image/audio block per attachment, in the order the
- * browser attached them.
+ * is real), then one image/audio/resource block per attachment the agent
+ * advertised it can accept, in the order the browser attached them.
  */
 export async function promptAgentSession(
   sessionId: string,

--- a/packages/busabase-core/src/domains/agents/logic/buda-connection-storage.test.ts
+++ b/packages/busabase-core/src/domains/agents/logic/buda-connection-storage.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  actorId: "actor-1",
   deleteCount: 0,
   rows: [] as Array<Record<string, unknown>>,
   nextId: 0,
@@ -10,7 +11,7 @@ vi.mock("openlib/nanoid", () => ({
   generateNanoID: () => `vlt_test_${++mocks.nextId}`,
 }));
 vi.mock("../../../context", () => ({
-  getContextActorId: () => "actor-1",
+  getContextActorId: () => mocks.actorId,
   getContextSpaceId: () => "space-1",
 }));
 vi.mock("../../vault/logic/vault-crypto", () => ({
@@ -37,7 +38,12 @@ vi.mock("../../../db", () => ({
   }),
 }));
 
-import { disconnectBuda, listBudaConnections, saveBudaConnection } from "./buda-connection";
+import {
+  disconnectBuda,
+  getBudaConnection,
+  listBudaConnections,
+  saveBudaConnection,
+} from "./buda-connection";
 
 const storedConnection = (agentId: string, agentName: string) => ({
   accessToken: `access-${agentId}`,
@@ -49,6 +55,7 @@ const storedConnection = (agentId: string, agentName: string) => ({
 
 describe("Buda connection storage", () => {
   beforeEach(() => {
+    mocks.actorId = "actor-1";
     mocks.deleteCount = 0;
     mocks.rows.length = 0;
     mocks.nextId = 0;
@@ -67,18 +74,126 @@ describe("Buda connection storage", () => {
     );
 
     await expect(listBudaConnections()).resolves.toEqual([
-      { slug: "buda:agent-1", agentId: "agent-1", agentName: "Rex" },
-      { slug: "buda:agent-2", agentId: "agent-2", agentName: "Ada" },
+      {
+        slug: "buda:agent-1",
+        agentId: "agent-1",
+        agentName: "Rex",
+        ownedByCurrentUser: true,
+      },
+      {
+        slug: "buda:agent-2",
+        agentId: "agent-2",
+        agentName: "Ada",
+        ownedByCurrentUser: true,
+      },
     ]);
     expect(mocks.rows).toEqual([
       expect.objectContaining({
         key: "BUDA_ACP_CONNECTION:agent-1",
-        access: { runtime: false, reveal: false, edit: false, share: false },
+        access: { runtime: false, reveal: false, edit: false, share: true },
       }),
       expect.objectContaining({
         key: "BUDA_ACP_CONNECTION:agent-2",
-        access: { runtime: false, reveal: false, edit: false, share: false },
+        access: { runtime: false, reveal: false, edit: false, share: true },
       }),
+    ]);
+  });
+
+  it("lists and resolves connections shared by another member in the same space", async () => {
+    await saveBudaConnection(storedConnection("agent-1", "Rex"));
+    mocks.actorId = "actor-2";
+    await saveBudaConnection(storedConnection("agent-2", "Ada"));
+    mocks.actorId = "actor-1";
+
+    await expect(listBudaConnections("mine")).resolves.toEqual([
+      {
+        slug: "buda:agent-1",
+        agentId: "agent-1",
+        agentName: "Rex",
+        ownedByCurrentUser: true,
+      },
+    ]);
+    await expect(listBudaConnections("space")).resolves.toEqual([
+      {
+        slug: "buda:agent-1",
+        agentId: "agent-1",
+        agentName: "Rex",
+        ownedByCurrentUser: true,
+      },
+      {
+        slug: "buda:agent-2",
+        agentId: "agent-2",
+        agentName: "Ada",
+        ownedByCurrentUser: false,
+      },
+    ]);
+    await expect(getBudaConnection("buda:agent-2")).resolves.toMatchObject({
+      slug: "buda:agent-2",
+      agentId: "agent-2",
+      agentName: "Ada",
+      accessToken: "access-agent-2",
+    });
+  });
+
+  it("does not let a member disconnect another member's shared connection", async () => {
+    mocks.actorId = "actor-2";
+    await saveBudaConnection(storedConnection("agent-2", "Ada"));
+    mocks.actorId = "actor-1";
+
+    await expect(disconnectBuda("buda:agent-2")).resolves.toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.deleteCount).toBe(0);
+  });
+
+  it("keeps another member's connection visible when both connected the same agent", async () => {
+    await saveBudaConnection({
+      ...storedConnection("agent-1", "Nimbus"),
+      refreshToken: "refresh-actor-1",
+    });
+    mocks.actorId = "actor-2";
+    await saveBudaConnection({
+      ...storedConnection("agent-1", "Nimbus"),
+      refreshToken: "refresh-actor-2",
+    });
+    mocks.actorId = "actor-1";
+
+    await expect(listBudaConnections("space")).resolves.toEqual([
+      {
+        slug: "buda:agent-1",
+        agentId: "agent-1",
+        agentName: "Nimbus",
+        ownedByCurrentUser: true,
+      },
+    ]);
+
+    await expect(disconnectBuda("buda:agent-1")).resolves.toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      new URL("https://dev.buda.im/api/oauth/revoke"),
+      expect.objectContaining({
+        body: new URLSearchParams({
+          token: "refresh-actor-1",
+          token_type_hint: "refresh_token",
+          client_id: "busabase-cloud",
+        }),
+      }),
+    );
+
+    // The test DB records delete calls but does not interpret Drizzle predicates.
+    // Mirror the confirmed owner-row deletion so the follow-up list assertion
+    // exercises the remaining member's visibility.
+    const deletedOwnerRow = mocks.rows.findIndex(
+      (row) => row.userId === "actor-1" && row.key === "BUDA_ACP_CONNECTION:agent-1",
+    );
+    expect(deletedOwnerRow).toBeGreaterThanOrEqual(0);
+    mocks.rows.splice(deletedOwnerRow, 1);
+
+    await expect(listBudaConnections("space")).resolves.toEqual([
+      {
+        slug: "buda:agent-1",
+        agentId: "agent-1",
+        agentName: "Nimbus",
+        ownedByCurrentUser: false,
+      },
     ]);
   });
 

--- a/packages/busabase-core/src/domains/agents/logic/buda-connection.ts
+++ b/packages/busabase-core/src/domains/agents/logic/buda-connection.ts
@@ -33,7 +33,10 @@ export interface BudaConnectionSummary {
   slug: string;
   agentId: string;
   agentName: string;
+  ownedByCurrentUser: boolean;
 }
+
+export type BudaConnectionScope = "mine" | "space";
 
 const ownerId = () => getContextActorId() ?? "local-user";
 
@@ -50,25 +53,46 @@ const getAgentIdFromBudaSessionSlug = (slug: string): string | null => {
   }
 };
 
-async function readRows() {
+async function readRows(scope: BudaConnectionScope) {
   const database = await getDb();
+  const actorId = ownerId();
+  const spaceId = getContextSpaceId();
   const rows = await database
     .select()
     .from(busabaseVaultItems)
     .where(
       and(
-        eq(busabaseVaultItems.userId, ownerId()),
         eq(busabaseVaultItems.scopeType, "workspace"),
-        eq(busabaseVaultItems.scopeId, getContextSpaceId()),
+        eq(busabaseVaultItems.scopeId, spaceId),
+        ...(scope === "mine" ? [eq(busabaseVaultItems.userId, actorId)] : []),
       ),
     );
   return rows.filter(
-    (row) => row.key === LEGACY_CONNECTION_KEY || row.key.startsWith(CONNECTION_KEY_PREFIX),
+    (row) =>
+      row.scopeType === "workspace" &&
+      row.scopeId === spaceId &&
+      (scope === "space" || row.userId === actorId) &&
+      (row.key === LEGACY_CONNECTION_KEY || row.key.startsWith(CONNECTION_KEY_PREFIX)),
   );
 }
 
-async function readRow(slug: string) {
-  const rows = await readRows();
+async function readUsableRow(slug: string) {
+  const actorId = ownerId();
+  const rows = (await readRows("space")).sort(
+    (a, b) => Number(b.userId === actorId) - Number(a.userId === actorId),
+  );
+  if (slug === "buda") {
+    return (
+      rows.find((row) => row.key === LEGACY_CONNECTION_KEY) ??
+      (rows.length === 1 ? rows[0] : undefined)
+    );
+  }
+  const agentId = getAgentIdFromBudaSessionSlug(slug);
+  return agentId ? rows.find((row) => row.key === connectionKey(agentId)) : undefined;
+}
+
+async function readOwnedRow(slug: string) {
+  const rows = await readRows("mine");
   if (slug === "buda") {
     return (
       rows.find((row) => row.key === LEGACY_CONNECTION_KEY) ??
@@ -95,7 +119,7 @@ function parseStored(value: string): StoredBudaConnection {
 
 export async function saveBudaConnection(connection: StoredBudaConnection): Promise<string> {
   const database = await getDb();
-  const rows = await readRows();
+  const rows = await readRows("mine");
   const existing = rows.find((row) => row.key === connectionKey(connection.agentId));
   const legacy = rows.find((row) => row.key === LEGACY_CONNECTION_KEY);
   const legacyConnection = legacy ? parseStored(decodeVaultValue(legacy.valuePayload)) : null;
@@ -110,6 +134,7 @@ export async function saveBudaConnection(connection: StoredBudaConnection): Prom
       .set({
         valuePayload,
         description: `Buda ACP: ${connection.agentName}`,
+        access: { ...target.access, share: true },
         updatedAt: new Date(),
       })
       .where(eq(busabaseVaultItems.id, target.id));
@@ -125,7 +150,7 @@ export async function saveBudaConnection(connection: StoredBudaConnection): Prom
     scopeId: getContextSpaceId(),
     environment: "production",
     description: `Buda ACP: ${connection.agentName}`,
-    access: { runtime: false, reveal: false, edit: false, share: false },
+    access: { runtime: false, reveal: false, edit: false, share: true },
   });
   return getBudaSessionSlug(connection.agentId);
 }
@@ -177,8 +202,11 @@ async function refresh(
   return next;
 }
 
-export async function listBudaConnections(): Promise<BudaConnectionSummary[]> {
-  const rows = await readRows();
+export async function listBudaConnections(
+  scope: BudaConnectionScope = "mine",
+): Promise<BudaConnectionSummary[]> {
+  const actorId = ownerId();
+  const rows = await readRows(scope);
   const byAgentId = new Map<string, BudaConnectionSummary>();
   for (const row of rows) {
     const connection = parseStored(decodeVaultValue(row.valuePayload));
@@ -186,15 +214,22 @@ export async function listBudaConnections(): Promise<BudaConnectionSummary[]> {
       slug: row.key === LEGACY_CONNECTION_KEY ? "buda" : getBudaSessionSlug(connection.agentId),
       agentId: connection.agentId,
       agentName: connection.agentName,
+      ownedByCurrentUser: row.userId === actorId,
     };
     const current = byAgentId.get(connection.agentId);
-    if (!current || summary.slug === "buda") byAgentId.set(connection.agentId, summary);
+    if (
+      !current ||
+      (summary.ownedByCurrentUser && !current.ownedByCurrentUser) ||
+      (summary.ownedByCurrentUser === current.ownedByCurrentUser && summary.slug === "buda")
+    ) {
+      byAgentId.set(connection.agentId, summary);
+    }
   }
   return [...byAgentId.values()];
 }
 
 export async function getBudaConnection(slug = "buda"): Promise<BudaConnection | null> {
-  const row = await readRow(slug);
+  const row = await readUsableRow(slug);
   if (!row) return null;
   let connection = parseStored(decodeVaultValue(row.valuePayload));
   if (new Date(connection.expiresAt).getTime() <= Date.now() + 60_000) {
@@ -210,7 +245,7 @@ export async function getBudaConnection(slug = "buda"): Promise<BudaConnection |
 
 export async function disconnectBuda(slug = "buda"): Promise<boolean> {
   const database = await getDb();
-  const row = await readRow(slug);
+  const row = await readOwnedRow(slug);
   if (!row) return false;
 
   const connection = parseStored(decodeVaultValue(row.valuePayload));

--- a/packages/busabase-core/src/domains/agents/router.ts
+++ b/packages/busabase-core/src/domains/agents/router.ts
@@ -26,7 +26,7 @@ export const agentsRouter = {
   catalog: os.agents.catalog.handler(() => listCatalog()),
 
   connections: {
-    list: os.agents.connections.list.handler(() => listAgentConnections()),
+    list: os.agents.connections.list.handler(({ input }) => listAgentConnections(input.scope)),
   },
 
   disconnect: os.agents.disconnect.handler(async ({ input }) => {

--- a/packages/busabase-core/src/domains/dashboard/components/agent-install-panel.test.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/agent-install-panel.test.tsx
@@ -1,0 +1,71 @@
+import type { InstallPlanVO } from "busabase-contract/domains/install/types";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { CoreI18nProvider } from "../../../i18n";
+import { AgentInstallPanel } from "./agent-install-panel";
+
+const getButtonClasses = (markup: string, label: string) => {
+  const button = [...markup.matchAll(/<button([^>]*)>([\s\S]*?)<\/button>/g)].find((match) =>
+    match[2]?.includes(label),
+  );
+  return button?.[1]?.match(/class="([^"]*)"/)?.[1] ?? "";
+};
+
+const plan: InstallPlanVO = {
+  package: {
+    name: "Kelly Email",
+    description: "Email workflow",
+    tags: [],
+  },
+  source: {
+    owner: "busabase",
+    repo: "skills",
+    subdir: "skills/kelly-email",
+  },
+  targetFolderSlug: "kelly-email",
+  nodes: [],
+  counts: {
+    folders: 0,
+    docs: 0,
+    bases: 0,
+    records: 0,
+    skills: 1,
+    airapps: 0,
+    drives: 0,
+    files: 0,
+  },
+  collisions: [],
+  warnings: [],
+  requiresAutoMerge: false,
+  applicable: true,
+};
+
+describe("AgentInstallPanel", () => {
+  it("keeps connection guidance inside the single copyable prompt", () => {
+    const markup = renderToStaticMarkup(
+      <CoreI18nProvider locale="en">
+        <AgentInstallPanel
+          agentIntegration={{
+            edition: "cloud",
+            defaultOrigin: "https://app.busabase.com",
+            targetSpaceId: "space_cloud",
+          }}
+          plan={plan}
+        />
+      </CoreI18nProvider>,
+    );
+
+    expect(markup).toContain("SETUP_SKILL.md");
+    expect(markup).toContain("space_cloud");
+    expect(markup).toContain("npx skills add busabase/skills --skill kelly-email");
+    expect(markup).not.toContain("Your agent still needs access to this space");
+    expect(markup).not.toContain("Connect your agent");
+
+    const copyPromptClasses = getButtonClasses(markup, "Copy prompt");
+    expect(copyPromptClasses).toContain("bg-primary");
+    expect(copyPromptClasses).toContain("text-primary-foreground");
+    expect(copyPromptClasses).toContain("hover:bg-primary/90");
+    expect(copyPromptClasses).not.toContain("bg-background");
+    expect(copyPromptClasses).not.toContain("border-input");
+  });
+});

--- a/packages/busabase-core/src/domains/dashboard/components/agent-install-panel.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/agent-install-panel.tsx
@@ -3,12 +3,12 @@
 import type { InstallPlanVO } from "busabase-contract/domains/install/types";
 import { Alert, AlertDescription, AlertTitle } from "kui/alert";
 import { Button } from "kui/button";
-import { Check, Copy, Sparkles, TriangleAlert } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
-import { fmt, useCoreI18n, useCoreLocale } from "../../../i18n";
+import { Check, Copy, TriangleAlert } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { fmt, useCoreI18n } from "../../../i18n";
 import { buildAgentInstallPrompt, skillNameForSource } from "../helpers/agent-install-prompt";
 import type { McpGuideEdition } from "./agent-mcp-guides";
-import { AgentIntegrationDialog } from "./agent-skill-button";
+import { createSetupSkillUrl } from "./agent-skill-button";
 
 /**
  * "Agent install" — the tab that installs nothing here.
@@ -24,11 +24,11 @@ import { AgentIntegrationDialog } from "./agent-skill-button";
  * panel says so and points at the other tab.
  */
 
-/** What `AgentIntegrationDialog` needs to give the right connection guidance. */
+/** What the copied prompt needs to give the right connection guidance. */
 export interface AgentIntegrationTarget {
   /** Cloud OAuth guidance vs Desktop's local no-auth guidance. */
   edition?: McpGuideEdition;
-  /** SSR fallback origin, before the dialog reads `window.location.origin`. */
+  /** SSR fallback origin, before the panel reads `window.location.origin`. */
   defaultOrigin?: string;
   /** Cloud only: pins the copied setup prompt to the space being installed into. */
   targetSpaceId?: string;
@@ -42,29 +42,38 @@ export function AgentInstallPanel({
   agentIntegration?: AgentIntegrationTarget;
 }) {
   const messages = useCoreI18n();
-  const locale = useCoreLocale();
   const [copied, setCopied] = useState(false);
-  const [connectOpen, setConnectOpen] = useState(false);
+  const [origin, setOrigin] = useState(agentIntegration?.defaultOrigin ?? "http://localhost:15419");
   const promptRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
 
   // A package with no skill node carries no manual — `counts.skills` is the
   // plan's own answer, so this stays true for packages the catalog never saw.
   const hasSkill = plan.counts.skills > 0;
   const appName = skillNameForSource(plan.source) ?? plan.package.name;
-  const prompt = useMemo(
-    () =>
-      buildAgentInstallPrompt({
-        source: plan.source,
-        packageName: plan.package.name,
-        template: messages.install.agentPromptBody,
-        fmt,
-      }),
-    [messages.install.agentPromptBody, plan.package.name, plan.source],
-  );
+  const edition = agentIntegration?.edition ?? "desktop";
+  // A stray targetSpaceId from a host must never leak into Desktop guidance.
+  const targetSpaceId = edition === "cloud" ? agentIntegration?.targetSpaceId : undefined;
+  const buildPromptForOrigin = (promptOrigin: string) =>
+    buildAgentInstallPrompt({
+      source: plan.source,
+      packageName: plan.package.name,
+      setupUrl: createSetupSkillUrl(promptOrigin, edition, true, targetSpaceId),
+      targetSpaceId,
+      template: messages.install.agentPromptBody,
+      fmt,
+    });
+  const prompt = buildPromptForOrigin(origin);
 
   const copy = async () => {
     try {
-      await navigator.clipboard.writeText(prompt);
+      // The textarea has an SSR-safe fallback URL. At the moment of copying,
+      // always rebuild from the browser origin so a host's placeholder dev URL
+      // can never reach the user's agent.
+      await navigator.clipboard.writeText(buildPromptForOrigin(window.location.origin));
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1800);
     } catch {
@@ -110,42 +119,12 @@ export function AgentInstallPanel({
           ) : (
             <span />
           )}
-          <Button className="shrink-0" onClick={() => void copy()} variant="outline">
+          <Button className="shrink-0" onClick={() => void copy()}>
             {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
             {copied ? messages.agentPrompts.copied : messages.agentPrompts.copy}
           </Button>
         </div>
       </div>
-
-      {/* The skill explains the app; it does not grant access to it. Someone who
-          pastes the prompt and stops here gets an agent that knows the manual and
-          cannot reach a single record — so the connection step is offered right
-          where that gap appears, not left to be discovered. */}
-      <div className="flex flex-col gap-2 rounded-md border border-border p-3">
-        <span className="font-medium text-foreground text-sm">
-          {messages.install.agentConnectTitle}
-        </span>
-        <span className="text-muted-foreground text-xs">{messages.install.agentConnectBody}</span>
-        <Button
-          className="w-fit"
-          onClick={() => setConnectOpen(true)}
-          type="button"
-          variant="outline"
-        >
-          <Sparkles className="size-4" />
-          {messages.install.agentConnectAction}
-        </Button>
-      </div>
-
-      <AgentIntegrationDialog
-        defaultOrigin={agentIntegration?.defaultOrigin}
-        edition={agentIntegration?.edition}
-        editionConfirmed
-        lang={locale}
-        onOpenChange={setConnectOpen}
-        open={connectOpen}
-        targetSpaceId={agentIntegration?.targetSpaceId}
-      />
     </div>
   );
 }

--- a/packages/busabase-core/src/domains/dashboard/components/agent-skill-button.test.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/agent-skill-button.test.tsx
@@ -1,6 +1,14 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { AgentIntegrationPluginCards } from "./agent-skill-button";
+import { CoreI18nProvider } from "../../../i18n";
+import { AgentIntegrationContent, AgentIntegrationPluginCards } from "./agent-skill-button";
+
+const getButtonClasses = (markup: string, label: string) => {
+  const button = [...markup.matchAll(/<button([^>]*)>([\s\S]*?)<\/button>/g)].find((match) =>
+    match[2]?.includes(label),
+  );
+  return button?.[1]?.match(/class="([^"]*)"/)?.[1] ?? "";
+};
 
 describe("AgentIntegrationPluginCards", () => {
   it("opens host-provided plugin destinations in a new tab", () => {
@@ -20,5 +28,25 @@ describe("AgentIntegrationPluginCards", () => {
     expect(markup).toContain('href="/codex-plugin"');
     expect(markup).toContain('target="_blank"');
     expect(markup).toContain('rel="noopener noreferrer"');
+  });
+
+  it("uses the primary action style for the shell prompt copy button", () => {
+    const markup = renderToStaticMarkup(
+      <CoreI18nProvider locale="en">
+        <AgentIntegrationContent
+          defaultOrigin="https://app.busabase.com"
+          edition="cloud"
+          editionConfirmed
+          targetSpaceId="space_cloud"
+        />
+      </CoreI18nProvider>,
+    );
+
+    const copyPromptClasses = getButtonClasses(markup, "Copy prompt");
+    expect(copyPromptClasses).toContain("bg-primary");
+    expect(copyPromptClasses).toContain("text-primary-foreground");
+    expect(copyPromptClasses).toContain("hover:bg-primary/90");
+    expect(copyPromptClasses).not.toContain("bg-card");
+    expect(copyPromptClasses).not.toContain("border-input");
   });
 });

--- a/packages/busabase-core/src/domains/dashboard/components/agent-skill-button.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/agent-skill-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Button } from "kui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "kui/dialog";
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "kui/sidebar";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "kui/tabs";
@@ -320,16 +321,12 @@ export function AgentIntegrationContent({
                 value={agentSkillPrompt}
               />
               <div className="flex justify-end">
-                <button
-                  className="inline-flex h-9 items-center gap-2 rounded-md border bg-card px-3 text-sm font-medium hover:bg-muted"
-                  onClick={() => copy(agentSkillPrompt, "prompt")}
-                  type="button"
-                >
+                <Button onClick={() => copy(agentSkillPrompt, "prompt")} size="sm" type="button">
                   {copied === "prompt" ? <Check size={16} /> : <Copy size={16} />}
                   {copied === "prompt"
                     ? messages.integration.copied
                     : messages.integration.copyPrompt}
-                </button>
+                </Button>
               </div>
             </>
           ) : (

--- a/packages/busabase-core/src/domains/dashboard/components/dashboard-shell.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/dashboard-shell.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
-import { hasCapability } from "busabase-contract/domains";
+import { hasCapability, publicAccessOf } from "busabase-contract/domains";
 import type { NodeVO } from "busabase-contract/types";
 import { Toaster } from "kui/sonner";
 import {
@@ -34,6 +34,7 @@ import { useLocation } from "wouter";
 import { CoreI18nProvider, coreMessagesByLocale } from "../../../i18n";
 import { nodeIconGlyph, resolveNodeIcon } from "../helpers/node-icons";
 import type { MoveNodePayload } from "../hooks/use-move-node";
+import { parseNodeDetailRoute } from "../utils/node-route";
 import { getSidebarTopLevelNodes } from "../utils/sidebar-node-tree";
 import { NodeDeleteDialog } from "./file-tree-browser";
 import { NodeAgentPromptsDialog } from "./node-agent-prompts-dialog";
@@ -49,6 +50,13 @@ import "./busabase-sidebar-nav.css";
 const DISABLED_FAVORITES_QUERY = {
   queryKey: ["busabase-dashboard-shell", "favorites-disabled"],
   queryFn: async () => [] as NodeVO[],
+  enabled: false,
+};
+
+/** Same always-disabled stand-in, for `orpc.nodes.ancestors` (see above). */
+const DISABLED_ANCESTORS_QUERY = {
+  queryKey: ["busabase-dashboard-shell", "ancestors-disabled"],
+  queryFn: async () => ({ ancestorIds: [] as string[] }),
   enabled: false,
 };
 
@@ -412,6 +420,35 @@ export function BusabaseDashboardShell({
   // in which case `DISABLED_FAVORITES_QUERY` keeps the `useQuery` call itself
   // unconditional (rules of hooks) while never firing a request.
   const queryClient = useQueryClient();
+  // The node the current route points at — the sidebar's own reading of the
+  // location, independent of whichever detail view is rendered.
+  const activeNodeRef = useMemo(() => parseNodeDetailRoute(location), [location]);
+
+  // Which folders sit on the path to that node. The sidebar cannot work this
+  // out from its own tree: the tree is depth-bounded and lazily expanded, so
+  // on a cold load (refresh / bookmark / shared link / "recently visited"
+  // jump) none of the ancestors have been fetched, and an ancestor that has
+  // not been fetched cannot be recognised as one. Asking the server once
+  // breaks that deadlock — NavMain opens each id it gets back, each expansion
+  // loads the next level, and the chain unrolls down to the active row.
+  const ancestorsQuery = useQuery(
+    orpc && activeNodeRef
+      ? {
+          ...orpc.nodes.ancestors.queryOptions({
+            input: { nodeId: activeNodeRef.slug, type: activeNodeRef.type },
+          }),
+          // A node's ancestry only changes when the node is MOVED, which
+          // invalidates the whole `nodes` family anyway — so this never needs
+          // a time-based refetch of its own.
+          staleTime: Number.POSITIVE_INFINITY,
+        }
+      : DISABLED_ANCESTORS_QUERY,
+  );
+  const activeAncestorIds = useMemo(
+    () => new Set(ancestorsQuery.data?.ancestorIds ?? []),
+    [ancestorsQuery.data],
+  );
+
   const favoritesQuery = useQuery(
     orpc ? orpc.nodes.listFavorites.queryOptions({}) : DISABLED_FAVORITES_QUERY,
   );
@@ -741,6 +778,7 @@ export function BusabaseDashboardShell({
                 onNodeDrop={onMoveNode ? handleNodeDrop : undefined}
                 isDropAllowed={onMoveNode ? isDropAllowed : undefined}
                 onExpand={onExpandNode ? (item) => item.id && onExpandNode(item.id) : undefined}
+                activeAncestorIds={activeAncestorIds}
               />
             </div>
           }
@@ -999,11 +1037,10 @@ function buildNavItem(node: NodeVO, ctx: NavItemContext): NavItem[] {
         onSelect: () => onOpenAgentPrompts(node),
       }
     : null;
-  // The "•••" Share action — opens the same public-link dialog the node-detail
-  // topbars use. Gated on `node.slug` because `NodeShareDialog` builds the
-  // public URL from it; a node without one has no link to hand out.
+  // The "•••" Share action — only types whose registry definition opts into a
+  // working anonymous detail route may produce a public link.
   const shareAction: NavItemAction | null =
-    onOpenShare && node.slug
+    onOpenShare && node.slug && publicAccessOf(node.type) !== "no"
       ? {
           title: labels.shareLabel,
           icon: Globe,

--- a/packages/busabase-core/src/domains/dashboard/components/install-from-github-modal.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/install-from-github-modal.tsx
@@ -22,9 +22,10 @@ import {
 } from "kui/dialog";
 import { Input } from "kui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "kui/tabs";
-import { CircleCheck, Github, LoaderCircle, Sparkles, TriangleAlert } from "lucide-react";
+import { CircleCheck, LoaderCircle, Sparkles, TriangleAlert } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { fmt, useCoreI18n } from "../../../i18n";
+import { GithubIcon } from "../helpers/brand-icons";
 import { nodeIconForType } from "../helpers/node-icons";
 import { AgentInstallPanel, type AgentIntegrationTarget } from "./agent-install-panel";
 
@@ -149,9 +150,9 @@ interface InstallFromGithubModalProps {
   /** Package name already known by catalog entry points, used in the dialog title. */
   initialPackageName?: string;
   /**
-   * Host configuration for the "Connect your agent" dialog offered on the Agent
-   * install tab — which edition's guidance to show, and which space to pin the
-   * copied setup prompt to. Omit and it falls back to Desktop's local guidance.
+   * Host configuration for the Agent install prompt — which edition's setup
+   * guidance to include, and which space to pin it to. Omit and it falls back to
+   * Desktop's local guidance.
    */
   agentIntegration?: AgentIntegrationTarget;
 }
@@ -385,7 +386,11 @@ export function InstallFromGithubModal({
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            {initialPackageName ? <Sparkles className="size-4" /> : <Github className="size-4" />}
+            {initialPackageName ? (
+              <Sparkles className="size-4" />
+            ) : (
+              <GithubIcon className="size-4" />
+            )}
             {initialPackageName
               ? fmt(messages.install.packageTitle, { name: initialPackageName })
               : messages.install.title}

--- a/packages/busabase-core/src/domains/dashboard/components/node-actions-menu.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/node-actions-menu.tsx
@@ -51,6 +51,7 @@
 // original ask for this button.
 
 import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
+import { publicAccessOf } from "busabase-contract/domains";
 import { Button } from "kui/button";
 import {
   DropdownMenu,
@@ -138,7 +139,7 @@ export function NodeActionsMenu({
   // NodeShareDialog requires a real slug (it builds the public URL from it);
   // this prop is optional here only because Rename can invalidate its
   // caller's query without one. Every current call site does pass it.
-  const canShare = Boolean(nodeSlug);
+  const canShare = Boolean(nodeSlug) && publicAccessOf(nodeType) !== "no";
   // The routed activity sub-page (`/base/:slug/activity` or
   // `/{type}/:slug/activity`, see routes.tsx + use-dashboard-routes.ts) keys
   // off the same slug-or-id every other detail route uses.

--- a/packages/busabase-core/src/domains/dashboard/components/node-share-button.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/node-share-button.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
+import { publicAccessOf } from "busabase-contract/domains";
 import { nodeWebUrl } from "busabase-contract/node-web-url";
 import { Button } from "kui/button";
 import {
@@ -17,11 +18,10 @@ import { Input } from "kui/input";
 import { Label } from "kui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "kui/select";
 import { Switch } from "kui/switch";
-import { Check, Copy, Globe, X } from "lucide-react";
+import { Check, Copy, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useCoreI18n } from "../../../i18n";
-import { useIsAnonymousVisitor } from "../visitor-context";
 
 type NodeShareCapability = "read" | "submit";
 
@@ -192,6 +192,11 @@ export function NodeShareDialog({
   }, [share?.expiresAt]);
 
   const busy = setShare.isPending || disableShare.isPending;
+
+  // Keep direct call sites fail-closed too. Menus apply the same capability
+  // before opening this dialog, but the dialog is a public component and must
+  // never mint a dead link for an unsupported node type on its own.
+  if (publicAccessOf(nodeType) === "no") return null;
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>

--- a/packages/busabase-core/src/domains/dashboard/components/search-dialog.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/search-dialog.tsx
@@ -187,6 +187,10 @@ export function SearchDialog({
     enabled: open && tab !== "recent" && debouncedQuery.length > 0,
   });
   const response = searchQuery.data ?? null;
+  // Node content is indexed only up to a cap, so a thin or empty result is not
+  // proof of absence. Surfaced in the empty state rather than swallowed —
+  // otherwise "no matches" quietly means two different things.
+  const contentTruncated = response?.contentTruncated ?? false;
   const allResults = response?.results ?? [];
   const isSearching = searchQuery.isFetching;
   const searchError = searchQuery.isError
@@ -504,7 +508,9 @@ export function SearchDialog({
                   body={
                     isRecentTab && !hasQuery
                       ? messages.search.noRecentBody
-                      : messages.search.noMatchesBody
+                      : contentTruncated
+                        ? messages.search.partialContentBody
+                        : messages.search.noMatchesBody
                   }
                 />
               )}

--- a/packages/busabase-core/src/domains/dashboard/components/side-panel-add-tab.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/side-panel-add-tab.tsx
@@ -64,7 +64,9 @@ export function SidePanelAddTab({
 
   // Connected agent backends, not the catalog of connectable ones — the menu
   // offers conversations, and you can only converse with something connected.
-  const connections = useQuery(orpc.agents.connections.list.queryOptions());
+  const connections = useQuery(
+    orpc.agents.connections.list.queryOptions({ input: { scope: "space" } }),
+  );
   const agents = connections.data ?? [];
 
   // A node page can be open on a type the panel has no renderer for, in which

--- a/packages/busabase-core/src/domains/dashboard/helpers/agent-install-prompt.ts
+++ b/packages/busabase-core/src/domains/dashboard/helpers/agent-install-prompt.ts
@@ -56,10 +56,14 @@ export interface AgentInstallPromptOptions {
   source: AgentInstallSource;
   /** The package's display name, used when the source carries no subdirectory. */
   packageName: string;
+  /** Credential-free onboarding guide for this host and target space. */
+  setupUrl: string;
+  /** Cloud only: the exact space the agent must verify before installing. */
+  targetSpaceId?: string;
   /**
-   * Localized body with `{name}` and `{command}` placeholders — the dialog passes
-   * `messages.install.agentPromptBody`, so the pasted text follows the UI
-   * language the way `createAgentSkillPrompt` already does.
+   * Localized body with `{name}`, `{command}`, `{setupUrl}`, and `{targetSpace}`
+   * placeholders — the dialog passes `messages.install.agentPromptBody`, so the
+   * pasted text follows the UI language the way `createAgentSkillPrompt` does.
    */
   template: string;
   fmt: (template: string, values: Record<string, string>) => string;
@@ -69,10 +73,14 @@ export interface AgentInstallPromptOptions {
 export const buildAgentInstallPrompt = ({
   source,
   packageName,
+  setupUrl,
+  targetSpaceId,
   template,
   fmt,
 }: AgentInstallPromptOptions): string =>
   fmt(template, {
     name: skillNameForSource(source) ?? packageName,
     command: buildAgentInstallCommand(source),
+    setupUrl,
+    targetSpace: targetSpaceId ? ` (${targetSpaceId})` : "",
   });

--- a/packages/busabase-core/src/domains/dashboard/helpers/brand-icons.tsx
+++ b/packages/busabase-core/src/domains/dashboard/helpers/brand-icons.tsx
@@ -1,0 +1,32 @@
+import type { SVGProps } from "react";
+import { forwardRef } from "react";
+
+/**
+ * lucide-react 1.0 permanently removed all brand/logo icons (GitHub, Twitter,
+ * etc. — see lucide-icons/lucide#3639). This preserves the exact GitHub glyph
+ * geometry from the last version that shipped it (lucide-react@0.556.0) so
+ * existing UI (install-from-github-modal, dashboard shells) renders unchanged.
+ */
+export const GithubIcon = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(
+  ({ className, ...props }, ref) => (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  ),
+);
+GithubIcon.displayName = "GithubIcon";

--- a/packages/busabase-core/src/domains/dashboard/helpers/search.tsx
+++ b/packages/busabase-core/src/domains/dashboard/helpers/search.tsx
@@ -1,5 +1,5 @@
 import type { SearchResultKind } from "busabase-contract/types";
-import { File, FileText, Folder, GitMerge } from "lucide-react";
+import { File, FileText, Folder, GitMerge, NotebookText } from "lucide-react";
 import type { ReactNode } from "react";
 
 export const normalizeSearchText = (value: string) => value.trim().toLowerCase();
@@ -9,6 +9,8 @@ export const searchKindIcon: Record<SearchResultKind, ReactNode> = {
   change_request: <GitMerge className="size-4" />,
   file: <File className="size-4" />,
   record: <FileText className="size-4" />,
+  // A content match inside a doc/html/whiteboard/workflow node.
+  node: <NotebookText className="size-4" />,
 };
 
 export const isConflictErrorMessage = (message: string) =>

--- a/packages/busabase-core/src/domains/dashboard/hooks/use-dashboard-routes.ts
+++ b/packages/busabase-core/src/domains/dashboard/hooks/use-dashboard-routes.ts
@@ -1,6 +1,6 @@
-import { getNodeType } from "busabase-contract/domains";
 import { useMemo } from "react";
 import { useLocation, useRoute } from "wouter";
+import { parseNodeActivityRoute, parseNodeDetailRoute } from "../utils/node-route";
 
 /**
  * Parse the wouter route table for the dashboard SPA into a flat set of route
@@ -57,34 +57,9 @@ export function useDashboardRoutes() {
   const selectedFileSlug = isFileRoute ? (fileParams?.slug ?? null) : null;
   const selectedDocSlug = isDocRoute ? (docParams?.slug ?? null) : null;
   const selectedFolderSlug = isFolderRoute ? (folderParams?.slug ?? null) : null;
-  const nodeDetailRoute = useMemo(() => {
-    const pathname = location.split("?", 1)[0] ?? "";
-    const match = pathname.match(/^\/([^/]+)\/([^/]+)$/);
-    if (!match) return null;
-    const [, type, encodedSlug] = match;
-    const definition = getNodeType(type);
-    if (!definition?.capabilities.hasDetail || type === "base") return null;
-    try {
-      return { type, slug: decodeURIComponent(encodedSlug) };
-    } catch {
-      return { type, slug: encodedSlug };
-    }
-  }, [location]);
-  // Same shape as `nodeDetailRoute` above, but for `/{type}/:slug/activity`.
-  // `base` is excluded here too — it's already covered by `isBaseActivityRoute`.
-  const nodeActivityRoute = useMemo(() => {
-    const pathname = location.split("?", 1)[0] ?? "";
-    const match = pathname.match(/^\/([^/]+)\/([^/]+)\/activity$/);
-    if (!match) return null;
-    const [, type, encodedSlug] = match;
-    const definition = getNodeType(type);
-    if (!definition?.capabilities.hasDetail || type === "base") return null;
-    try {
-      return { type, slug: decodeURIComponent(encodedSlug) };
-    } catch {
-      return { type, slug: encodedSlug };
-    }
-  }, [location]);
+  const nodeDetailRoute = useMemo(() => parseNodeDetailRoute(location), [location]);
+  // Same shape, for `/{type}/:slug/activity`.
+  const nodeActivityRoute = useMemo(() => parseNodeActivityRoute(location), [location]);
   const selectedChangeRequestId =
     operationParams?.changeRequestId ?? changeRequestParams?.changeRequestId ?? null;
 

--- a/packages/busabase-core/src/domains/dashboard/utils/node-route.test.ts
+++ b/packages/busabase-core/src/domains/dashboard/utils/node-route.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { parseNodeActivityRoute, parseNodeDetailRoute } from "./node-route";
+
+describe("parseNodeDetailRoute", () => {
+  it("reads `/{type}/{slug}` for a type that has a detail screen", () => {
+    expect(parseNodeDetailRoute("/folder/brand-kit")).toEqual({
+      type: "folder",
+      slug: "brand-kit",
+    });
+    expect(parseNodeDetailRoute("/doc/launch-plan")).toEqual({ type: "doc", slug: "launch-plan" });
+  });
+
+  it("ignores the query string", () => {
+    expect(parseNodeDetailRoute("/folder/brand-kit?demo=1&lang=zh-CN")).toEqual({
+      type: "folder",
+      slug: "brand-kit",
+    });
+  });
+
+  it("decodes a percent-escaped slug, and keeps a malformed one as-is", () => {
+    expect(parseNodeDetailRoute("/doc/q3%20plan")).toEqual({ type: "doc", slug: "q3 plan" });
+    // `%zz` is not a valid escape — `decodeURIComponent` throws on it, and the
+    // route must still resolve rather than being dropped entirely.
+    expect(parseNodeDetailRoute("/doc/q3%zz")).toEqual({ type: "doc", slug: "q3%zz" });
+  });
+
+  it("rejects Bases — their own deeper routes share this two-segment shape", () => {
+    expect(parseNodeDetailRoute("/base/blog-posts")).toBeNull();
+  });
+
+  it("rejects routes that merely look like a node route", () => {
+    // Same shape, not a node type.
+    expect(parseNodeDetailRoute("/inbox/cr_123")).toBeNull();
+    expect(parseNodeDetailRoute("/agents/some-agent")).toBeNull();
+    // Wrong segment count.
+    expect(parseNodeDetailRoute("/folder")).toBeNull();
+    expect(parseNodeDetailRoute("/folder/brand-kit/activity")).toBeNull();
+    expect(parseNodeDetailRoute("/")).toBeNull();
+  });
+});
+
+describe("parseNodeActivityRoute", () => {
+  it("reads `/{type}/{slug}/activity` and nothing else", () => {
+    expect(parseNodeActivityRoute("/folder/brand-kit/activity")).toEqual({
+      type: "folder",
+      slug: "brand-kit",
+    });
+    expect(parseNodeActivityRoute("/folder/brand-kit")).toBeNull();
+    expect(parseNodeActivityRoute("/base/blog-posts/activity")).toBeNull();
+  });
+});

--- a/packages/busabase-core/src/domains/dashboard/utils/node-route.ts
+++ b/packages/busabase-core/src/domains/dashboard/utils/node-route.ts
@@ -1,0 +1,50 @@
+import { getNodeType, type NodeType } from "busabase-contract/domains";
+
+/** A node addressed by the url: `/{type}/{slug}`. */
+export interface NodeRouteRef {
+  /** Narrowed, not merely parsed: a shape that is not a real node type is rejected below. */
+  type: NodeType;
+  slug: string;
+}
+
+/**
+ * `/{type}/{slug}` and `/{type}/{slug}/activity` — the two url shapes that
+ * address a single node, parsed in one place.
+ *
+ * `base` is excluded from both: a Base owns a whole family of deeper routes
+ * (`/base/{slug}/{viewId}`, `/{recordId}/edit`, `/design`, ...) that this
+ * two-segment shape would silently mis-read, and every caller resolves Bases
+ * through their own dedicated route match instead.
+ *
+ * A type with no detail screen is rejected for the same reason: `/inbox/{id}`
+ * and `/agents/{slug}` are the same SHAPE but are not nodes, so matching on
+ * shape alone would hand callers a node ref for a route that has no node
+ * behind it.
+ */
+const parseNodeRoute = (location: string, expectActivity: boolean): NodeRouteRef | null => {
+  const pathname = location.split("?", 1)[0] ?? "";
+  const match = pathname.match(
+    expectActivity ? /^\/([^/]+)\/([^/]+)\/activity$/ : /^\/([^/]+)\/([^/]+)$/,
+  );
+  if (!match) return null;
+  const [, rawType, encodedSlug] = match;
+  if (rawType === "base") return null;
+  const definition = getNodeType(rawType);
+  if (!definition?.capabilities.hasDetail) return null;
+  const type = definition.type;
+  try {
+    return { type, slug: decodeURIComponent(encodedSlug) };
+  } catch {
+    // A malformed percent-escape is still a usable slug — the server resolves
+    // it (and 404s) far better than throwing away the whole route here.
+    return { type, slug: encodedSlug };
+  }
+};
+
+/** The node a `/{type}/{slug}` location addresses, or null if it addresses none. */
+export const parseNodeDetailRoute = (location: string): NodeRouteRef | null =>
+  parseNodeRoute(location, false);
+
+/** The node a `/{type}/{slug}/activity` location addresses, or null. */
+export const parseNodeActivityRoute = (location: string): NodeRouteRef | null =>
+  parseNodeRoute(location, true);

--- a/packages/busabase-core/src/domains/dump/logic/import-logic.ts
+++ b/packages/busabase-core/src/domains/dump/logic/import-logic.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { ORPCError } from "@orpc/server";
 import type {
+  ImportBeginInput,
   ImportCommitVO,
   ImportTablesInput,
   ImportTablesVO,
@@ -40,6 +41,14 @@ import { DUMP_IMPORT_ORDER, DUMP_TABLE_REGISTRY } from "./table-registry";
 interface ImportSession {
   id: string;
   spaceId: string;
+  /**
+   * The archive's ORIGINAL space id (`manifest.spaceId`) — needed to compute
+   * the source's root-node id deterministically (`rootNodeIdForSpace`) when
+   * remapping `nodes` rows, instead of scanning each batch for "the row with
+   * a null `parentId`". See the matching comment on `ImportBeginInputSchema`
+   * for why that scan is unsound once a space has more nodes than one page.
+   */
+  sourceSpaceId: string;
   createdAt: number;
   insertedIds: Map<string, Set<string>>;
 }
@@ -65,7 +74,9 @@ const requireSession = (sessionId: string): ImportSession => {
   return session;
 };
 
-export const beginImportSession = async (): Promise<{ sessionId: string }> => {
+export const beginImportSession = async (
+  input: ImportBeginInput,
+): Promise<{ sessionId: string }> => {
   requireSpaceManagerForDump();
   sweepExpiredSessions();
   // A target space reached only through the dump routes (never touched by any
@@ -102,6 +113,7 @@ export const beginImportSession = async (): Promise<{ sessionId: string }> => {
   sessions.set(sessionId, {
     id: sessionId,
     spaceId,
+    sourceSpaceId: input.sourceSpaceId,
     createdAt: Date.now(),
     insertedIds: new Map(),
   });
@@ -209,19 +221,26 @@ export const importTableRows = async (input: ImportTablesInput): Promise<ImportT
     // an unrelated pre-existing row sharing that literal id (ids are a global
     // PK, not scoped per space) or, once genuinely fresh, leave every
     // top-level child's `parentId` dangling (still pointing at the never
-    // re-inserted source root id), which fails the `parentId` FK. Detect the
-    // root row structurally instead (the one node with `parentId === null` —
-    // true for exactly one row per space by construction), drop it
+    // re-inserted source root id), which fails the `parentId` FK. Drop it
     // unconditionally, and remap any child that pointed at it to the
     // target's own (already-existing) root id.
+    //
+    // The source root id is computed DETERMINISTICALLY from
+    // `session.sourceSpaceId` (`rootNodeIdForSpace`), not by scanning THIS
+    // batch's rows for "the one with a null `parentId`" — `dump.exportTables`
+    // pages are id-ordered, not tree-ordered, so for any space with more
+    // nodes than one page, the root row and its direct children can land in
+    // DIFFERENT `importTables` calls. A per-batch scan only finds the root
+    // when it happens to share a batch with the children pointing at it;
+    // every other batch's top-level children silently kept their stale
+    // source-root parentId and failed the FK constraint on insert — a real
+    // crash reproduced restoring a 225-node production space (2 pages) into
+    // an empty one. A deterministic id has no such luck-of-the-cursor gap.
     const rootId = rootNodeIdForSpace(spaceId);
-    const sourceRoot = rows.find((row) => row.parentId == null);
-    const sourceRootId = sourceRoot?.id as string | undefined;
+    const sourceRootId = rootNodeIdForSpace(session.sourceSpaceId);
     rows = rows
       .filter((row) => row.id !== sourceRootId && row.id !== rootId)
-      .map((row) =>
-        sourceRootId && row.parentId === sourceRootId ? { ...row, parentId: rootId } : row,
-      );
+      .map((row) => (row.parentId === sourceRootId ? { ...row, parentId: rootId } : row));
   }
   if (input.table === "nodePrincipals") {
     // A `principalType: "space"` grant means "everyone in this space", and
@@ -241,13 +260,62 @@ export const importTableRows = async (input: ImportTablesInput): Promise<ImportT
   );
   if (stampedRows.length === 0) return { inserted: 0 };
 
-  await db.insert(table as never).values(stampedRows as never[]);
+  try {
+    await db.insert(table as never).values(stampedRows as never[]);
+  } catch (error) {
+    const pgCode = (error as { cause?: { code?: string } } | undefined)?.cause?.code;
+    if (pgCode === "23505") {
+      // Every dump table's `id` is a bare, database-wide primary key (not
+      // scoped per space — see table-registry.ts). A restore replays the
+      // archive's original ids verbatim, so it can only ever succeed against
+      // ids that have never been used before anywhere in this database. That
+      // holds for disaster recovery (the source space is gone) or a truly
+      // fresh database, but NOT for cloning a still-live space into a second
+      // one on the same server — the source's own rows still hold those ids.
+      // Postgres's raw "duplicate key" 500 gave no hint of this; spell it out.
+      throw new ORPCError("CONFLICT", {
+        message:
+          `Restore failed: table "${input.table}" has rows whose id already exists somewhere in ` +
+          "this database. A full-fidelity restore replays the archive's original ids, so the target " +
+          "database must never have used those ids before — this works for disaster recovery (restoring " +
+          "into a fresh database, or back into the space it came from after that space's data was " +
+          "removed) but NOT for cloning a space that is still live elsewhere in the same database. To " +
+          "copy this space's current content into another space, use `busabase-cli export` (writes a " +
+          "readable package) followed by `busabase-cli install` (installs it as reviewable Change " +
+          "Requests) instead.",
+      });
+    }
+    throw error;
+  }
 
   const seen = session.insertedIds.get(input.table) ?? new Set<string>();
   for (const row of stampedRows) seen.add((row as Record<string, unknown>).id as string);
   session.insertedIds.set(input.table, seen);
 
   return { inserted: stampedRows.length };
+};
+
+/**
+ * `inArray(column, ids)` with `ids` in the hundreds of thousands blows the
+ * SQL query builder's own call stack (`RangeError: Maximum call stack size
+ * exceeded`, reproduced live committing a real production restore with
+ * 1,080,685 `fieldValues` rows — every check below queries by exactly the
+ * full set of ids a session just inserted). Chunk the id list and run one
+ * query per chunk instead of one query for everything; a bounded loop, not
+ * a query builder that has to be stack-safe for arbitrary input.
+ */
+const ORPHAN_CHECK_CHUNK_SIZE = 2000;
+
+// Exported for `dump-logic.test.ts` only.
+export const queryInChunks = async <Row>(
+  ids: string[],
+  runQuery: (idsChunk: string[]) => Promise<Row[]>,
+): Promise<Row[]> => {
+  const rows: Row[] = [];
+  for (let i = 0; i < ids.length; i += ORPHAN_CHECK_CHUNK_SIZE) {
+    rows.push(...(await runQuery(ids.slice(i, i + ORPHAN_CHECK_CHUNK_SIZE))));
+  }
+  return rows;
 };
 
 /**
@@ -286,15 +354,14 @@ const checkFieldValueOrphans = async (
   fieldValueIds: Set<string>,
 ): Promise<string[]> => {
   if (fieldValueIds.size === 0) return [];
-  const rows = await db
-    .select({ id: busabaseFieldValues.id, fieldId: busabaseFieldValues.fieldId })
-    .from(busabaseFieldValues)
-    .where(
-      and(
-        eq(busabaseFieldValues.spaceId, spaceId),
-        inArray(busabaseFieldValues.id, [...fieldValueIds]),
+  const rows = await queryInChunks([...fieldValueIds], (idsChunk) =>
+    db
+      .select({ id: busabaseFieldValues.id, fieldId: busabaseFieldValues.fieldId })
+      .from(busabaseFieldValues)
+      .where(
+        and(eq(busabaseFieldValues.spaceId, spaceId), inArray(busabaseFieldValues.id, idsChunk)),
       ),
-    );
+  );
   const orphanCount = rows.filter((row) => !row.fieldId).length;
   return orphanCount > 0
     ? [
@@ -309,26 +376,30 @@ const checkRecordLinkOrphans = async (
   linkIds: Set<string>,
 ): Promise<string[]> => {
   if (linkIds.size === 0) return [];
-  const links = await db
-    .select({
-      id: busabaseRecordLinks.id,
-      sourceRecordId: busabaseRecordLinks.sourceRecordId,
-      targetRecordId: busabaseRecordLinks.targetRecordId,
-    })
-    .from(busabaseRecordLinks)
-    .where(
-      and(eq(busabaseRecordLinks.spaceId, spaceId), inArray(busabaseRecordLinks.id, [...linkIds])),
-    );
+  const links = await queryInChunks([...linkIds], (idsChunk) =>
+    db
+      .select({
+        id: busabaseRecordLinks.id,
+        sourceRecordId: busabaseRecordLinks.sourceRecordId,
+        targetRecordId: busabaseRecordLinks.targetRecordId,
+      })
+      .from(busabaseRecordLinks)
+      .where(
+        and(eq(busabaseRecordLinks.spaceId, spaceId), inArray(busabaseRecordLinks.id, idsChunk)),
+      ),
+  );
   if (links.length === 0) return [];
   const recordIds = new Set<string>();
   for (const link of links) {
     recordIds.add(link.sourceRecordId);
     recordIds.add(link.targetRecordId);
   }
-  const existing = await db
-    .select({ id: busabaseRecords.id })
-    .from(busabaseRecords)
-    .where(and(eq(busabaseRecords.spaceId, spaceId), inArray(busabaseRecords.id, [...recordIds])));
+  const existing = await queryInChunks([...recordIds], (idsChunk) =>
+    db
+      .select({ id: busabaseRecords.id })
+      .from(busabaseRecords)
+      .where(and(eq(busabaseRecords.spaceId, spaceId), inArray(busabaseRecords.id, idsChunk))),
+  );
   const existingIds = new Set(existing.map((row) => row.id));
   const orphanCount = links.filter(
     (link) => !existingIds.has(link.sourceRecordId) || !existingIds.has(link.targetRecordId),
@@ -344,16 +415,17 @@ const checkAssetAttachmentOrphans = async (
   assetIds: Set<string>,
 ): Promise<string[]> => {
   if (assetIds.size === 0) return [];
-  const assets = await db
-    .select({ id: busabaseAssets.id, attachmentId: busabaseAssets.attachmentId })
-    .from(busabaseAssets)
-    .where(and(eq(busabaseAssets.spaceId, spaceId), inArray(busabaseAssets.id, [...assetIds])));
+  const assets = await queryInChunks([...assetIds], (idsChunk) =>
+    db
+      .select({ id: busabaseAssets.id, attachmentId: busabaseAssets.attachmentId })
+      .from(busabaseAssets)
+      .where(and(eq(busabaseAssets.spaceId, spaceId), inArray(busabaseAssets.id, idsChunk))),
+  );
   if (assets.length === 0) return [];
   const attachmentIds = [...new Set(assets.map((asset) => asset.attachmentId))];
-  const existing = await db
-    .select({ id: attachments.id })
-    .from(attachments)
-    .where(inArray(attachments.id, attachmentIds));
+  const existing = await queryInChunks(attachmentIds, (idsChunk) =>
+    db.select({ id: attachments.id }).from(attachments).where(inArray(attachments.id, idsChunk)),
+  );
   const existingIds = new Set(existing.map((row) => row.id));
   const orphanCount = assets.filter((asset) => !existingIds.has(asset.attachmentId)).length;
   return orphanCount > 0
@@ -366,10 +438,12 @@ const checkBlobCompleteness = async (
   attachmentIds: Set<string>,
 ): Promise<string[]> => {
   if (attachmentIds.size === 0) return [];
-  const rows = await db
-    .select({ id: attachments.id, storageKey: attachments.storageKey })
-    .from(attachments)
-    .where(inArray(attachments.id, [...attachmentIds]));
+  const rows = await queryInChunks([...attachmentIds], (idsChunk) =>
+    db
+      .select({ id: attachments.id, storageKey: attachments.storageKey })
+      .from(attachments)
+      .where(inArray(attachments.id, idsChunk)),
+  );
   const missing: string[] = [];
   for (const row of rows) {
     const exists = await storage.objectExists(row.storageKey);
@@ -394,19 +468,18 @@ const checkAssetTextBlobCompleteness = async (
   assetTextIds: Set<string>,
 ): Promise<string[]> => {
   if (assetTextIds.size === 0) return [];
-  const rows = await db
-    .select({
-      id: busabaseAssetTexts.id,
-      status: busabaseAssetTexts.status,
-      textStorageKey: busabaseAssetTexts.textStorageKey,
-    })
-    .from(busabaseAssetTexts)
-    .where(
-      and(
-        eq(busabaseAssetTexts.spaceId, spaceId),
-        inArray(busabaseAssetTexts.id, [...assetTextIds]),
+  const rows = await queryInChunks([...assetTextIds], (idsChunk) =>
+    db
+      .select({
+        id: busabaseAssetTexts.id,
+        status: busabaseAssetTexts.status,
+        textStorageKey: busabaseAssetTexts.textStorageKey,
+      })
+      .from(busabaseAssetTexts)
+      .where(
+        and(eq(busabaseAssetTexts.spaceId, spaceId), inArray(busabaseAssetTexts.id, idsChunk)),
       ),
-    );
+  );
   const missing: string[] = [];
   for (const row of rows) {
     if (row.status === "none" || row.textStorageKey === "") continue;

--- a/packages/busabase-core/src/domains/dump/router.ts
+++ b/packages/busabase-core/src/domains/dump/router.ts
@@ -16,7 +16,7 @@ const os = implement(busabaseContract);
 export const dumpRouter = {
   exportTables: os.dump.exportTables.handler(async ({ input }) => exportTableRows(input)),
   exportAssetText: os.dump.exportAssetText.handler(async ({ input }) => exportAssetTextBlob(input)),
-  importBegin: os.dump.importBegin.handler(async () => beginImportSession()),
+  importBegin: os.dump.importBegin.handler(async ({ input }) => beginImportSession(input)),
   importTables: os.dump.importTables.handler(async ({ input }) => importTableRows(input)),
   importCommit: os.dump.importCommit.handler(async ({ input }) =>
     commitImportSession(input.sessionId),

--- a/packages/busabase-core/src/domains/rich-node/components/graph-detail-view.tsx
+++ b/packages/busabase-core/src/domains/rich-node/components/graph-detail-view.tsx
@@ -49,6 +49,7 @@ import { NodeDetailSkeleton } from "../../dashboard/components/skeletons";
 import { asNodeDetail } from "../../dashboard/helpers/node-detail";
 import { useReportLoadedNode } from "../../dashboard/hooks/use-report-loaded-node";
 import type { NodeDetailProps } from "../../dashboard/node-detail-registry";
+import { useIsAnonymousVisitor } from "../../dashboard/visitor-context";
 import {
   RichNodeNotFound,
   RichNodeShell,
@@ -236,6 +237,7 @@ interface GraphEditorProps {
 
 function GraphEditor({ document: workflowDocument, node, orpc }: GraphEditorProps) {
   const messages = useCoreI18n();
+  const isAnonymous = useIsAnonymousVisitor();
   const initialNodes = useMemo<WorkflowFlowNode[]>(
     () =>
       workflowDocument.nodes.map((workflowNode) => ({
@@ -460,7 +462,13 @@ function GraphEditor({ document: workflowDocument, node, orpc }: GraphEditorProp
       orpc={orpc}
       status={status}
     >
-      <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)_17rem] max-md:grid-cols-1 max-md:grid-rows-[minmax(18rem,1fr)_auto]">
+      <div
+        className={
+          isAnonymous
+            ? "grid h-full min-h-0 grid-cols-1"
+            : "grid h-full min-h-0 grid-cols-[minmax(0,1fr)_17rem] max-md:grid-cols-1 max-md:grid-rows-[minmax(18rem,1fr)_auto]"
+        }
+      >
         <div className="min-h-0 bg-muted/20">
           <ReactFlow
             colorMode="system"
@@ -468,6 +476,8 @@ function GraphEditor({ document: workflowDocument, node, orpc }: GraphEditorProp
             fitView
             maxZoom={1.8}
             minZoom={0.2}
+            nodesConnectable={!isAnonymous}
+            nodesDraggable={!isAnonymous}
             nodeTypes={nodeTypes}
             nodes={nodes}
             onConnect={(connection) => {
@@ -499,7 +509,13 @@ function GraphEditor({ document: workflowDocument, node, orpc }: GraphEditorProp
             <Controls showInteractive={false} />
           </ReactFlow>
         </div>
-        <aside className="min-h-0 overflow-y-auto border-border/60 border-l bg-background p-3 max-md:max-h-64 max-md:border-l-0 max-md:border-t">
+        <aside
+          className={
+            isAnonymous
+              ? "hidden"
+              : "min-h-0 overflow-y-auto border-border/60 border-l bg-background p-3 max-md:max-h-64 max-md:border-l-0 max-md:border-t"
+          }
+        >
           <h2 className="mb-3 font-medium text-foreground text-xs">
             {messages.richNodes.configuration}
           </h2>

--- a/packages/busabase-core/src/domains/rich-node/components/html-detail-view.tsx
+++ b/packages/busabase-core/src/domains/rich-node/components/html-detail-view.tsx
@@ -14,6 +14,7 @@ import { NodeDetailSkeleton } from "../../dashboard/components/skeletons";
 import { asNodeDetail } from "../../dashboard/helpers/node-detail";
 import { useReportLoadedNode } from "../../dashboard/hooks/use-report-loaded-node";
 import type { NodeDetailProps } from "../../dashboard/node-detail-registry";
+import { useIsAnonymousVisitor } from "../../dashboard/visitor-context";
 import {
   RichNodeNotFound,
   RichNodeShell,
@@ -29,6 +30,7 @@ interface HtmlDetailViewProps {
 
 export function HtmlDetailView({ orpc, slug, onNodeLoaded }: HtmlDetailViewProps) {
   const messages = useCoreI18n();
+  const isAnonymous = useIsAnonymousVisitor();
   const detailQuery = useQuery({
     ...orpc.nodes.get.queryOptions({ input: { nodeId: slug ?? "", type: "html" } }),
     enabled: Boolean(slug),
@@ -64,7 +66,10 @@ export function HtmlDetailView({ orpc, slug, onNodeLoaded }: HtmlDetailViewProps
       orpc={orpc}
       status={status}
     >
-      <Tabs className="flex h-full min-h-0 flex-col" defaultValue="source">
+      <Tabs
+        className="flex h-full min-h-0 flex-col"
+        defaultValue={isAnonymous ? "preview" : "source"}
+      >
         <div className="flex h-10 shrink-0 items-center border-border/60 border-b px-3">
           <TabsList className="h-8">
             <TabsTrigger className="gap-1.5 px-2.5 text-xs" value="source">
@@ -86,6 +91,7 @@ export function HtmlDetailView({ orpc, slug, onNodeLoaded }: HtmlDetailViewProps
               markDirty();
             }}
             spellCheck={false}
+            readOnly={isAnonymous}
             value={source}
           />
         </TabsContent>

--- a/packages/busabase-core/src/domains/rich-node/components/rich-node-shell.tsx
+++ b/packages/busabase-core/src/domains/rich-node/components/rich-node-shell.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { fmt, useCoreI18n } from "../../../i18n";
 import { NodeActionsMenu } from "../../dashboard/components/node-actions-menu";
 import { NodeAgentPromptsButton } from "../../dashboard/components/node-agent-prompts-button";
+import { useIsAnonymousVisitor } from "../../dashboard/visitor-context";
 import { stableStringify } from "../utils/stable-json";
 
 export type SaveStatus = "saved" | "dirty" | "saving" | "error";
@@ -158,6 +159,7 @@ export function RichNodeShell({
   actions,
 }: RichNodeShellProps) {
   const messages = useCoreI18n();
+  const isAnonymous = useIsAnonymousVisitor();
   const statusLabel =
     status === "saving"
       ? messages.richNodes.saving
@@ -170,18 +172,22 @@ export function RichNodeShell({
       <header className="flex h-12 shrink-0 items-center gap-2 border-border/60 border-b px-3 md:px-4">
         <Icon className="size-4 shrink-0 text-muted-foreground" />
         <h1 className="min-w-0 flex-1 truncate font-medium text-foreground text-sm">{node.name}</h1>
-        <span
-          className={
-            status === "error"
-              ? "hidden max-w-48 truncate text-destructive text-xs sm:block"
-              : "hidden text-muted-foreground text-xs sm:block"
-          }
-          title={error ?? statusLabel}
-        >
-          {error ?? statusLabel}
-        </span>
-        {actions}
-        <NodeAgentPromptsButton nodeId={node.id} nodeName={node.name} nodeType={nodeType} />
+        {!isAnonymous && (
+          <span
+            className={
+              status === "error"
+                ? "hidden max-w-48 truncate text-destructive text-xs sm:block"
+                : "hidden text-muted-foreground text-xs sm:block"
+            }
+            title={error ?? statusLabel}
+          >
+            {error ?? statusLabel}
+          </span>
+        )}
+        {!isAnonymous && actions}
+        {!isAnonymous && (
+          <NodeAgentPromptsButton nodeId={node.id} nodeName={node.name} nodeType={nodeType} />
+        )}
         {/* One "•••" menu instead of the Permissions + Delete button pair this
             header used to render — same set of actions (plus Rename/Share,
             which this header never offered at all), same dialogs, and it
@@ -189,24 +195,28 @@ export function RichNodeShell({
             responsive split the Permissions button needed is gone with it: the
             trigger is a fixed-size icon at every breakpoint. Agent prompts sits
             outside as its own button (see `NodeAgentPromptsButton`). */}
-        <NodeActionsMenu
-          nodeId={node.id}
-          nodeName={node.name}
-          nodeSlug={node.slug}
-          nodeType={nodeType}
-          orpc={orpc}
-        />
-        <Button
-          aria-label={messages.richNodes.save}
-          disabled={status === "saving" || status === "saved"}
-          onClick={onSave}
-          size="icon-sm"
-          title={messages.richNodes.save}
-          type="button"
-          variant="default"
-        >
-          <Save className="size-3.5" />
-        </Button>
+        {!isAnonymous && (
+          <>
+            <NodeActionsMenu
+              nodeId={node.id}
+              nodeName={node.name}
+              nodeSlug={node.slug}
+              nodeType={nodeType}
+              orpc={orpc}
+            />
+            <Button
+              aria-label={messages.richNodes.save}
+              disabled={status === "saving" || status === "saved"}
+              onClick={onSave}
+              size="icon-sm"
+              title={messages.richNodes.save}
+              type="button"
+              variant="default"
+            >
+              <Save className="size-3.5" />
+            </Button>
+          </>
+        )}
       </header>
       <div className="min-h-0 flex-1">{children}</div>
     </div>

--- a/packages/busabase-core/src/domains/rich-node/components/whiteboard-detail-view.tsx
+++ b/packages/busabase-core/src/domains/rich-node/components/whiteboard-detail-view.tsx
@@ -23,6 +23,7 @@ import {
 import { asNodeDetail } from "../../dashboard/helpers/node-detail";
 import { useReportLoadedNode } from "../../dashboard/hooks/use-report-loaded-node";
 import type { NodeDetailProps } from "../../dashboard/node-detail-registry";
+import { useIsAnonymousVisitor } from "../../dashboard/visitor-context";
 import {
   RichNodeNotFound,
   RichNodeShell,
@@ -50,6 +51,7 @@ interface WhiteboardDetailViewProps {
 export function WhiteboardDetailView({ orpc, slug, onNodeLoaded }: WhiteboardDetailViewProps) {
   const messages = useCoreI18n();
   const locale = useCoreLocale();
+  const isAnonymous = useIsAnonymousVisitor();
   const detailQuery = useQuery({
     ...orpc.nodes.get.queryOptions({ input: { nodeId: slug ?? "", type: "whiteboard" } }),
     enabled: Boolean(slug),
@@ -184,6 +186,7 @@ export function WhiteboardDetailView({ orpc, slug, onNodeLoaded }: WhiteboardDet
             key={detail.node.id}
             langCode={locale}
             name={detail.node.name}
+            viewModeEnabled={isAnonymous}
             onChange={(elements, appState) => {
               const nextScene: WhiteboardDocument = {
                 version: 1,

--- a/packages/busabase-core/src/domains/templates/components/template-detail-content.test.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-detail-content.test.tsx
@@ -1,0 +1,63 @@
+import type { TemplateCardVO } from "busabase-contract/domains/templates/types";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { TemplateDetailContent } from "./template-detail-content";
+
+Object.assign(globalThis, { React });
+
+const template: TemplateCardVO = {
+  id: "busabase/templates/templates/busa-email",
+  name: "busa-email",
+  description: "Email operations workspace",
+  category: "Operations",
+  tags: [],
+  screenshots: [],
+  agentPrompts: ["Draft a reply to the latest customer email"],
+  stats: {
+    folders: 1,
+    docs: 1,
+    bases: 2,
+    records: 3,
+    files: 0,
+    airapps: 1,
+    skill: true,
+  },
+  install: {
+    repoUrl: "https://github.com/busabase/templates/tree/main/templates/busa-email",
+    intoFolder: "busa-email",
+  },
+  sourceUrl: "https://github.com/busabase/templates/tree/main/templates/busa-email",
+};
+
+const getHeading = (markup: string, title: string) =>
+  [...markup.matchAll(/<h2([^>]*)>([\s\S]*?)<\/h2>/g)].find((match) => match[2]?.includes(title));
+
+describe("TemplateDetailContent", () => {
+  it("renders large section headings with matching-size icons and Busabase terms", () => {
+    const markup = renderToStaticMarkup(<TemplateDetailContent template={template} />);
+    const promptsHeading = getHeading(markup, "What you can ask an agent, once it is installed");
+    const contentsHeading = getHeading(markup, "What installing this creates");
+
+    expect(markup).toMatch(/^<div class="flex flex-col gap-12">/);
+    expect(markup).not.toMatch(/^<div class="flex flex-col gap-6">/);
+
+    expect(promptsHeading?.[1]).toContain("text-lg");
+    expect(promptsHeading?.[1]).not.toContain("text-sm");
+    expect(promptsHeading?.[1]).toContain("items-center");
+    expect(promptsHeading?.[1]).not.toContain("items-baseline");
+    expect(promptsHeading?.[2]).toContain("lucide-message-square");
+    expect(promptsHeading?.[2]).toContain("size-[1em]");
+
+    expect(contentsHeading?.[1]).toContain("text-lg");
+    expect(contentsHeading?.[1]).not.toContain("text-sm");
+    expect(contentsHeading?.[1]).toContain("items-center");
+    expect(contentsHeading?.[1]).not.toContain("items-baseline");
+    expect(contentsHeading?.[2]).toContain("lucide-package-open");
+    expect(contentsHeading?.[2]).toContain("size-[1em]");
+
+    expect(markup).toContain("lucide-external-link size-3");
+    expect(markup).toContain(">Bases</dt>");
+    expect(markup).not.toContain(">Tables</dt>");
+  });
+});

--- a/packages/busabase-core/src/domains/templates/components/template-detail-content.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-detail-content.tsx
@@ -9,7 +9,7 @@ export interface TemplateDetailLabels {
   promptsDescription: string;
   contentsTitle: string;
   contentsDescription: string;
-  tables: string;
+  bases: string;
   apps: string;
   documents: string;
   sampleRows: string;
@@ -22,17 +22,23 @@ export interface TemplateDetailLabels {
   tags: string;
   previousScreenshot: string;
   nextScreenshot: string;
+  closePreview: string;
+  zoomOut: string;
+  zoomIn: string;
+  resetView: string;
+  rotateClockwise: string;
+  downloadImage: string;
   screenshot: (index: number) => string;
 }
 
 const defaultLabels: TemplateDetailLabels = {
   promptsTitle: "What you can ask an agent, once it is installed",
   promptsDescription:
-    "The agent can answer these because the template installs its author's manual alongside its tables. It does not have to guess your schema.",
+    "The agent can answer these because the template installs its author's manual alongside its Bases. It does not have to guess your schema.",
   contentsTitle: "What installing this creates",
   contentsDescription:
-    "Tables, fields, and sample rows are created straight away. App code and the agent manual are proposed as change requests for you to review first.",
-  tables: "Tables",
+    "Bases, fields, and sample rows are created straight away. App code and the agent manual are proposed as change requests for you to review first.",
+  bases: "Bases",
   apps: "Apps",
   documents: "Documents",
   sampleRows: "Sample rows",
@@ -45,6 +51,12 @@ const defaultLabels: TemplateDetailLabels = {
   tags: "Tags",
   previousScreenshot: "Previous screenshot",
   nextScreenshot: "Next screenshot",
+  closePreview: "Close preview",
+  zoomOut: "Zoom out",
+  zoomIn: "Zoom in",
+  resetView: "Reset view",
+  rotateClockwise: "Rotate clockwise",
+  downloadImage: "Download image",
   screenshot: (index) => (index === 0 ? "Template screenshots" : `Template screenshot ${index}`),
 };
 
@@ -65,7 +77,7 @@ export function TemplateDetailContent({
 }: TemplateDetailContentProps) {
   const { stats } = template;
   const contents = [
-    [labels.tables, stats.bases],
+    [labels.bases, stats.bases],
     [labels.apps, stats.airapps],
     [labels.documents, stats.docs],
     [labels.sampleRows, stats.records],
@@ -78,7 +90,7 @@ export function TemplateDetailContent({
   }));
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-12">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div className="flex max-w-2xl flex-col gap-2">
           <div className="flex flex-wrap items-center gap-2">
@@ -114,13 +126,19 @@ export function TemplateDetailContent({
           label={labels.screenshot(0)}
           previousLabel={labels.previousScreenshot}
           nextLabel={labels.nextScreenshot}
+          closeLabel={labels.closePreview}
+          zoomOutLabel={labels.zoomOut}
+          zoomInLabel={labels.zoomIn}
+          resetLabel={labels.resetView}
+          rotateLabel={labels.rotateClockwise}
+          downloadLabel={labels.downloadImage}
         />
       ) : null}
 
       {template.agentPrompts.length > 0 ? (
         <section className="flex flex-col gap-2">
-          <h2 className="flex items-center gap-2 text-sm font-medium">
-            <MessageSquare className="size-4" aria-hidden="true" />
+          <h2 className="flex items-center gap-2 text-lg font-medium">
+            <MessageSquare className="size-[1em]" aria-hidden="true" />
             {labels.promptsTitle}
           </h2>
           <ul className="flex flex-col gap-2">
@@ -138,8 +156,8 @@ export function TemplateDetailContent({
       ) : null}
 
       <section className="flex flex-col gap-2">
-        <h2 className="flex items-center gap-2 text-sm font-medium">
-          <PackageOpen className="size-4" aria-hidden="true" />
+        <h2 className="flex items-center gap-2 text-lg font-medium">
+          <PackageOpen className="size-[1em]" aria-hidden="true" />
           {labels.contentsTitle}
         </h2>
         <dl className="grid gap-x-6 gap-y-1 text-sm sm:grid-cols-2">

--- a/packages/busabase-core/src/domains/templates/components/template-detail-image.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-detail-image.tsx
@@ -6,18 +6,30 @@ import { useState } from "react";
 interface Props {
   src: string;
   alt: string;
+  fit?: "cover" | "contain";
+  rotation?: number;
+  scale?: number;
 }
 
+export const isScreenshotQuarterTurn = (rotation: number): boolean =>
+  Math.abs(rotation % 180) === 90;
+
 /** Keeps a broken remote catalog image from leaving an empty gallery tile. */
-export function TemplateDetailImage({ src, alt }: Props) {
+export function TemplateDetailImage({ src, alt, fit = "cover", rotation = 0, scale = 1 }: Props) {
   const [failed, setFailed] = useState(false);
+  const isPreview = fit === "contain";
+  const isQuarterTurn = isScreenshotQuarterTurn(rotation);
 
   if (failed) {
     return (
       <div
         role="img"
         aria-label={alt}
-        className="flex aspect-[16/10] items-center justify-center bg-muted"
+        className={
+          isPreview
+            ? "flex h-full w-full items-center justify-center bg-muted"
+            : "flex aspect-[16/10] items-center justify-center bg-muted"
+        }
       >
         <ImageOff className="size-8 text-muted-foreground" aria-hidden="true" />
       </div>
@@ -28,8 +40,15 @@ export function TemplateDetailImage({ src, alt }: Props) {
     <img
       src={src}
       alt={alt}
-      loading="lazy"
-      className="aspect-[16/10] w-full object-cover object-top"
+      loading={isPreview ? "eager" : "lazy"}
+      className={
+        isPreview
+          ? `${
+              isQuarterTurn ? "max-h-[100cqw] max-w-[100cqh]" : "max-h-full max-w-full"
+            } object-contain transition-transform duration-200 motion-reduce:transition-none`
+          : "aspect-[16/10] w-full object-cover object-top"
+      }
+      style={isPreview ? { transform: `rotate(${rotation}deg) scale(${scale})` } : undefined}
       onError={() => setFailed(true)}
     />
   );

--- a/packages/busabase-core/src/domains/templates/components/template-detail-view.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-detail-view.tsx
@@ -20,7 +20,8 @@ interface TemplateDetailViewProps {
  * what an agent will be able to do with it, then — last — how many tables it
  * has. The prompts are not decoration; they are the shortest honest answer to
  * "what would I even ask it", which is the question that decides whether an
- * installed app gets used or sits there.
+ * installed app gets used or sits there. The final summary uses Busabase's
+ * Base terminology rather than generic table vocabulary.
  */
 export function TemplateDetailView({
   template,

--- a/packages/busabase-core/src/domains/templates/components/template-screenshot-showcase.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-screenshot-showcase.tsx
@@ -1,7 +1,18 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { type KeyboardEvent, useCallback, useEffect, useId, useRef, useState } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  Expand,
+  RotateCwSquare,
+  Scan,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import { type KeyboardEvent, useCallback, useEffect, useRef, useState } from "react";
 import { TemplateDetailImage } from "./template-detail-image";
 
 export interface TemplateScreenshot {
@@ -14,7 +25,52 @@ interface TemplateScreenshotShowcaseProps {
   label: string;
   previousLabel: string;
   nextLabel: string;
+  closeLabel: string;
+  zoomOutLabel: string;
+  zoomInLabel: string;
+  resetLabel: string;
+  rotateLabel: string;
+  downloadLabel: string;
 }
+
+export const clampScreenshotIndex = (index: number, screenshotCount: number): number =>
+  Math.min(Math.max(index, 0), Math.max(screenshotCount - 1, 0));
+
+export const MIN_SCREENSHOT_ZOOM = 50;
+export const MAX_SCREENSHOT_ZOOM = 300;
+export const SCREENSHOT_ZOOM_STEP = 25;
+
+export const clampScreenshotZoom = (zoom: number): number =>
+  Math.min(Math.max(zoom, MIN_SCREENSHOT_ZOOM), MAX_SCREENSHOT_ZOOM);
+
+export const adjustScreenshotZoom = (zoom: number, direction: -1 | 1): number =>
+  clampScreenshotZoom(zoom + direction * SCREENSHOT_ZOOM_STEP);
+
+export const rotateScreenshotClockwise = (rotation: number): number => (rotation + 90) % 360;
+
+export const getScreenshotDownloadName = (src: string, index: number): string => {
+  try {
+    const pathname = new URL(src).pathname;
+    const filename = decodeURIComponent(pathname.split("/").filter(Boolean).at(-1) ?? "");
+    if (filename) return filename;
+  } catch {
+    // Fall through to a stable filename for relative or malformed catalog URLs.
+  }
+  return `template-screenshot-${index + 1}.png`;
+};
+
+const clickDownloadLink = (href: string, filename: string, openInNewTab = false) => {
+  const link = document.createElement("a");
+  link.href = href;
+  link.download = filename;
+  if (openInNewTab) {
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+  }
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+};
 
 /** Compact, touch-friendly screenshot shelf shared by website and Dashboard details. */
 export function TemplateScreenshotShowcase({
@@ -22,11 +78,32 @@ export function TemplateScreenshotShowcase({
   label,
   previousLabel,
   nextLabel,
+  closeLabel,
+  zoomOutLabel,
+  zoomInLabel,
+  resetLabel,
+  rotateLabel,
+  downloadLabel,
 }: TemplateScreenshotShowcaseProps) {
-  const showcaseId = useId();
   const scrollerRef = useRef<HTMLDivElement>(null);
   const frameRefs = useRef<Array<HTMLDivElement | null>>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const [zoom, setZoom] = useState(100);
+  const [rotation, setRotation] = useState(0);
+
+  const resetPreviewView = useCallback(() => {
+    setZoom(100);
+    setRotation(0);
+  }, []);
+
+  const selectPreview = useCallback(
+    (index: number) => {
+      setPreviewIndex(clampScreenshotIndex(index, screenshots.length));
+      resetPreviewView();
+    },
+    [resetPreviewView, screenshots.length],
+  );
 
   const syncCurrentIndex = useCallback(() => {
     const scroller = scrollerRef.current;
@@ -62,7 +139,7 @@ export function TemplateScreenshotShowcase({
   const scrollToIndex = useCallback(
     (index: number) => {
       const scroller = scrollerRef.current;
-      const targetIndex = Math.min(Math.max(index, 0), screenshots.length - 1);
+      const targetIndex = clampScreenshotIndex(index, screenshots.length);
       const frame = frameRefs.current[targetIndex];
       if (!scroller || !frame) return;
 
@@ -72,39 +149,71 @@ export function TemplateScreenshotShowcase({
     [screenshots.length],
   );
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+  const handlePreviewKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (previewIndex === null || (event.key !== "ArrowLeft" && event.key !== "ArrowRight")) {
+      return;
+    }
     event.preventDefault();
-    scrollToIndex(currentIndex + (event.key === "ArrowRight" ? 1 : -1));
+    selectPreview(previewIndex + (event.key === "ArrowRight" ? 1 : -1));
   };
 
   const isFirst = currentIndex === 0;
   const isLast = currentIndex === screenshots.length - 1;
+  const activePreviewIndex = previewIndex ?? 0;
+  const preview = previewIndex === null ? null : screenshots[activePreviewIndex];
+  const isPreviewFirst = activePreviewIndex === 0;
+  const isPreviewLast = activePreviewIndex === screenshots.length - 1;
+
+  const handleDownload = async () => {
+    if (!preview) return;
+    const filename = getScreenshotDownloadName(preview.src, activePreviewIndex);
+
+    try {
+      const response = await fetch(preview.src);
+      if (!response.ok) throw new Error(`Image download failed with ${response.status}`);
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      clickDownloadLink(objectUrl, filename);
+      window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1_000);
+    } catch {
+      clickDownloadLink(preview.src, filename, true);
+    }
+  };
+
+  const overlayButtonClass =
+    "inline-flex size-8 shrink-0 items-center justify-center rounded-md text-background/70 transition-colors hover:bg-background/15 hover:text-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background/70 disabled:cursor-not-allowed disabled:opacity-35";
 
   return (
     <section className="flex min-w-0 flex-col gap-3">
       <div
         ref={scrollerRef}
-        className="relative flex min-w-0 snap-x snap-mandatory gap-3 overflow-x-auto scroll-smooth pb-1 outline-none [scrollbar-width:none] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&::-webkit-scrollbar]:hidden"
-        aria-activedescendant={`${showcaseId}-${currentIndex}`}
+        className="relative flex min-w-0 snap-x snap-mandatory gap-3 overflow-x-auto scroll-smooth pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         aria-label={label}
-        onKeyDown={handleKeyDown}
-        role="listbox"
-        tabIndex={0}
+        role="list"
       >
         {screenshots.map((screenshot, index) => (
           <div
             key={`${screenshot.src}-${index}`}
-            id={`${showcaseId}-${index}`}
             ref={(frame) => {
               frameRefs.current[index] = frame;
             }}
             className="w-[88%] shrink-0 snap-start overflow-hidden rounded-md border border-border bg-muted sm:w-[46%]"
-            aria-selected={index === currentIndex}
-            role="option"
-            tabIndex={-1}
+            role="listitem"
           >
-            <TemplateDetailImage src={screenshot.src} alt={screenshot.alt} />
+            <button
+              type="button"
+              className="group relative block w-full cursor-zoom-in overflow-hidden text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              aria-label={screenshot.alt}
+              onClick={() => {
+                setCurrentIndex(index);
+                selectPreview(index);
+              }}
+            >
+              <TemplateDetailImage src={screenshot.src} alt={screenshot.alt} />
+              <span className="pointer-events-none absolute end-2 top-2 inline-flex size-8 items-center justify-center rounded-md bg-background/90 text-foreground opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+                <Expand className="size-4" aria-hidden="true" />
+              </span>
+            </button>
           </div>
         ))}
         <div aria-hidden="true" className="w-[12%] shrink-0 sm:w-[54%]" />
@@ -138,6 +247,135 @@ export function TemplateScreenshotShowcase({
           <ChevronRight className="size-4" aria-hidden="true" />
         </button>
       </div>
+
+      <DialogPrimitive.Root
+        open={preview !== null}
+        onOpenChange={(open) => !open && setPreviewIndex(null)}
+      >
+        <DialogPrimitive.Portal>
+          <DialogPrimitive.Overlay
+            className="fixed inset-0 z-50 bg-muted-foreground/30 backdrop-blur-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+            onClick={() => setPreviewIndex(null)}
+          />
+          <DialogPrimitive.Content
+            className="!pointer-events-none fixed inset-0 z-50 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+            onKeyDown={handlePreviewKeyDown}
+          >
+            {preview ? (
+              <>
+                <DialogPrimitive.Title className="sr-only">{preview.alt}</DialogPrimitive.Title>
+                <DialogPrimitive.Description className="sr-only">
+                  {label}, {activePreviewIndex + 1} / {screenshots.length}
+                </DialogPrimitive.Description>
+                <div className="pointer-events-none absolute start-1/2 top-[47%] flex h-[calc(100dvh-8rem)] w-[calc(100vw-2rem)] max-w-6xl -translate-x-1/2 -translate-y-1/2 items-center justify-center overflow-hidden [container-type:size] [&>*]:pointer-events-auto sm:h-[calc(100dvh-10rem)]">
+                  <TemplateDetailImage
+                    key={preview.src}
+                    src={preview.src}
+                    alt={preview.alt}
+                    fit="contain"
+                    rotation={rotation}
+                    scale={zoom / 100}
+                  />
+                </div>
+                <div className="pointer-events-auto fixed bottom-4 start-1/2 z-10 flex max-w-[calc(100vw-1rem)] -translate-x-1/2 items-center rounded-lg bg-foreground/80 p-1 text-background shadow-lg backdrop-blur-md sm:bottom-6">
+                  {screenshots.length > 1 ? (
+                    <>
+                      <button
+                        type="button"
+                        className={overlayButtonClass}
+                        aria-label={previousLabel}
+                        title={previousLabel}
+                        disabled={isPreviewFirst}
+                        onClick={() => selectPreview(activePreviewIndex - 1)}
+                      >
+                        <ChevronLeft className="size-4" aria-hidden="true" />
+                      </button>
+                      <span
+                        className="min-w-12 shrink-0 px-1 text-center text-xs tabular-nums text-background/80"
+                        aria-live="polite"
+                      >
+                        {activePreviewIndex + 1} / {screenshots.length}
+                      </span>
+                      <button
+                        type="button"
+                        className={overlayButtonClass}
+                        aria-label={nextLabel}
+                        title={nextLabel}
+                        disabled={isPreviewLast}
+                        onClick={() => selectPreview(activePreviewIndex + 1)}
+                      >
+                        <ChevronRight className="size-4" aria-hidden="true" />
+                      </button>
+                      <span
+                        aria-hidden="true"
+                        className="mx-1 h-5 w-px shrink-0 bg-background/20"
+                      />
+                    </>
+                  ) : null}
+                  <button
+                    type="button"
+                    className={overlayButtonClass}
+                    aria-label={zoomOutLabel}
+                    title={zoomOutLabel}
+                    disabled={zoom <= MIN_SCREENSHOT_ZOOM}
+                    onClick={() => setZoom((value) => adjustScreenshotZoom(value, -1))}
+                  >
+                    <ZoomOut className="size-4" aria-hidden="true" />
+                  </button>
+                  <span
+                    className="min-w-10 shrink-0 text-center text-xs tabular-nums text-background/80"
+                    aria-live="polite"
+                  >
+                    {zoom}%
+                  </span>
+                  <button
+                    type="button"
+                    className={overlayButtonClass}
+                    aria-label={zoomInLabel}
+                    title={zoomInLabel}
+                    disabled={zoom >= MAX_SCREENSHOT_ZOOM}
+                    onClick={() => setZoom((value) => adjustScreenshotZoom(value, 1))}
+                  >
+                    <ZoomIn className="size-4" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    className={overlayButtonClass}
+                    aria-label={resetLabel}
+                    title={resetLabel}
+                    onClick={resetPreviewView}
+                  >
+                    <Scan className="size-4" aria-hidden="true" />
+                  </button>
+                  <span aria-hidden="true" className="mx-1 h-5 w-px shrink-0 bg-background/20" />
+                  <button
+                    type="button"
+                    className={overlayButtonClass}
+                    aria-label={rotateLabel}
+                    title={rotateLabel}
+                    onClick={() => setRotation((value) => rotateScreenshotClockwise(value))}
+                  >
+                    <RotateCwSquare className="size-4" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    className={overlayButtonClass}
+                    aria-label={downloadLabel}
+                    title={downloadLabel}
+                    onClick={() => void handleDownload()}
+                  >
+                    <Download className="size-4" aria-hidden="true" />
+                  </button>
+                </div>
+                <DialogPrimitive.Close className="pointer-events-auto fixed start-4 top-4 z-10 inline-flex size-9 items-center justify-center rounded-full bg-foreground/65 text-background/80 shadow-sm backdrop-blur-md transition-colors hover:bg-foreground/80 hover:text-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:start-6 sm:top-6">
+                  <X className="size-4" aria-hidden="true" />
+                  <span className="sr-only">{closeLabel}</span>
+                </DialogPrimitive.Close>
+              </>
+            ) : null}
+          </DialogPrimitive.Content>
+        </DialogPrimitive.Portal>
+      </DialogPrimitive.Root>
     </section>
   );
 }

--- a/packages/busabase-core/src/i18n/ja.ts
+++ b/packages/busabase-core/src/i18n/ja.ts
@@ -268,6 +268,17 @@ export const dashboardJa: CoreI18nMessages = {
         "AirApp プレビューの Service Worker がこのページを制御できませんでした。この AirApp をもう一度実行してください。",
     },
   },
+  agents: {
+    addAgent: "エージェントを追加",
+    actionsFor: "{name} の操作",
+    deleteConnection: "接続を削除",
+    mineTab: "自分の",
+    spaceTab: "スペース",
+    mineEmptyTitle: "接続済みエージェントはまだありません",
+    mineEmptyBody: "Claude Code、Codex、または Buda AI Agent を接続してください。",
+    spaceEmptyTitle: "このスペースには共有エージェントがまだありません",
+    spaceEmptyBody: "スペースのメンバーが追加したエージェントをチームで利用できます。",
+  },
   form: {
     alreadyExists:
       "このノードにはフォームが既にあります。新規作成せず、既存のフォームを更新してください。",
@@ -563,6 +574,8 @@ export const dashboardJa: CoreI18nMessages = {
     loadMore: "さらに読み込む",
     noMatchesTitle: "一致する結果はありません",
     noMatchesBody: "タイトル、フィールド名、チャンネル、またはベースを試してください。",
+    partialContentBody:
+      "一部の長いドキュメントは冒頭のみが検索索引に入っているため、これがすべてとは限りません。全文を走査するには grep を使用してください。",
     noRecentTitle: "最近開いたものはまだありません",
     noRecentBody: "開いたベースやドキュメントなどがここに表示され、すぐ戻れるようになります。",
     typeToSearchTitle: "コンテンツ内を検索",
@@ -1371,13 +1384,9 @@ export const dashboardJa: CoreI18nMessages = {
       "すでに使っているエージェント（Claude Code、Codex、Cursor）に「{name}」のマニュアルを渡します。このアプリの使い方を覚えますが、このスペースには何も作成・変更されません。",
     agentPromptLabel: "これをエージェントに貼り付けてください",
     agentPromptBody:
-      "Busabase アプリスキル「{name}」を導入して、後で操作できるようにしてください：\n\n{command}\n\nスキルの導入だけを行い、私の Busabase スペースにはまだ何も作成・変更・削除しないでください。導入できたら、このアプリが何をするものか、セットアップを頒んだら何が作られるかを数行で教えてください。",
+      "Busabase アプリスキル「{name}」を導入して、後で操作できるようにしてください。\n\n導入前に、この環境が Busabase に接続済みで、正しい対象スペース{targetSpace}に接続されていることを確認してください。Busabase の接続が未設定、または別のスペースを参照している場合は、先に次の接続ガイドを読んで従ってください：\n\n{setupUrl}\n\n接続の準備ができたら、次を実行してください：\n\n{command}\n\nスキルの導入だけを行い、私の Busabase スペースにはまだ何も作成・変更・削除しないでください。導入できたら、このアプリが何をするものか、セットアップを頼んだら何が作られるかを数行で教えてください。",
     agentRefHint:
       "リポジトリの既定ブランチを導入します。このカタログ項目は {ref} から読み取られました。",
-    agentConnectTitle: "エージェントにはこのスペースへのアクセスも必要です",
-    agentConnectBody:
-      "スキルは使い方を伝えるもので、実際にデータを読み書きするには Busabase への接続が必要です。設定は一度だけです。",
-    agentConnectAction: "エージェントを接続",
     agentNoSkillTitle: "このパッケージにはエージェント向けマニュアルがありません",
     agentNoSkillBody:
       "SKILL.md がないためエージェントに導入するものがなく、テーブル構造を推測するしかありません。UI に導入し、後からノードの「•••」メニューからプロンプトを渡してください。",

--- a/packages/busabase-core/src/i18n/messages.ts
+++ b/packages/busabase-core/src/i18n/messages.ts
@@ -285,6 +285,17 @@ export const coreMessagesEn = {
         "AirApp preview's Service Worker could not take control of this page. Try running the AirApp again.",
     },
   },
+  agents: {
+    addAgent: "Add agent",
+    actionsFor: "Actions for {name}",
+    deleteConnection: "Delete connection",
+    mineTab: "Mine",
+    spaceTab: "Space",
+    mineEmptyTitle: "No agents connected yet",
+    mineEmptyBody: "Connect Claude Code, Codex, or a Buda AI Agent to get started.",
+    spaceEmptyTitle: "No shared agents in this space yet",
+    spaceEmptyBody: "Agents added by space members will appear here for the team to use.",
+  },
   form: {
     alreadyExists:
       "A form already exists for this node. Update the existing form instead of creating another one.",
@@ -585,6 +596,10 @@ export const coreMessagesEn = {
     loadMore: "Load more",
     noMatchesTitle: "No matches",
     noMatchesBody: "Try a title, field name, channel, or Base.",
+    /** Shown when node content was indexed only up to the projection cap, so
+     *  an empty result cannot be read as "the workspace does not contain this". */
+    partialContentBody:
+      "Some documents are long enough that only their beginning is indexed for search, so this may not be the whole story. Use grep to scan every document in full.",
     noRecentTitle: "Nothing recent yet",
     noRecentBody: "Bases, docs, and other things you open will show up here for a quick jump back.",
     typeToSearchTitle: "Search inside content",
@@ -1398,12 +1413,8 @@ export const coreMessagesEn = {
       "Hand the manual for “{name}” to an agent you already use — Claude Code, Codex, Cursor. It learns how this app works; nothing in this space is created or changed.",
     agentPromptLabel: "Paste this to your agent",
     agentPromptBody:
-      'Install the Busabase app skill "{name}" so you can operate it later:\n\n{command}\n\nInstall the skill only — do not create, change or delete anything in my Busabase space yet. Once it is installed, tell me in a few lines what this app does and what it would create if I asked you to set it up.',
+      'Install the Busabase app skill "{name}" so you can operate it later.\n\nBefore installing, confirm that this environment is connected to Busabase and points to the correct target space{targetSpace}. If the Busabase connection is not configured or points to another space, read and follow this setup guide first:\n\n{setupUrl}\n\nOnce the connection is ready, run:\n\n{command}\n\nInstall the skill only — do not create, change or delete anything in my Busabase space yet. Once it is installed, tell me in a few lines what this app does and what it would create if I asked you to set it up.',
     agentRefHint: "Installs the repository's default branch. This entry was read from {ref}.",
-    agentConnectTitle: "Your agent still needs access to this space",
-    agentConnectBody:
-      "The skill tells an agent how this app works; connecting Busabase is what lets it actually read and write your data. It is a one-time setup.",
-    agentConnectAction: "Connect your agent",
     agentNoSkillTitle: "This package carries no agent manual",
     agentNoSkillBody:
       "There is no SKILL.md here, so an agent has nothing to install — it would have to infer your tables. Install it into the UI instead; you can still hand an agent that node's own prompts afterwards.",

--- a/packages/busabase-core/src/i18n/zh-CN.ts
+++ b/packages/busabase-core/src/i18n/zh-CN.ts
@@ -261,6 +261,17 @@ export const dashboardZhCN: CoreI18nMessages = {
       SW_CONTROL_TIMEOUT: "AirApp 预览的 Service Worker 未能接管当前页面。请重新运行此 AirApp。",
     },
   },
+  agents: {
+    addAgent: "添加 Agent",
+    actionsFor: "{name} 的操作",
+    deleteConnection: "删除连接",
+    mineTab: "我的",
+    spaceTab: "空间站",
+    mineEmptyTitle: "还没有连接 Agent",
+    mineEmptyBody: "连接 Claude Code、Codex 或 Buda AI Agent 后即可开始使用。",
+    spaceEmptyTitle: "此空间站还没有共享 Agent",
+    spaceEmptyBody: "空间站成员添加的 Agent 会显示在这里，供团队共同使用。",
+  },
   form: {
     alreadyExists: "这个节点已经存在表单，请更新现有表单，不要重复创建。",
     invalidCursor: "表单分页链接无效，请刷新后重试。",
@@ -554,6 +565,8 @@ export const dashboardZhCN: CoreI18nMessages = {
     loadMore: "加载更多",
     noMatchesTitle: "没有匹配结果",
     noMatchesBody: "试试标题、字段名、频道或数据库。",
+    partialContentBody:
+      "部分文档较长，搜索只索引了开头部分，所以这里未必是全部结果。用 grep 可以完整扫描每篇文档。",
     noRecentTitle: "暂无最近访问",
     noRecentBody: "打开过的数据库、文档等会显示在这里，方便快速跳转。",
     typeToSearchTitle: "搜索内容",
@@ -1332,12 +1345,8 @@ export const dashboardZhCN: CoreI18nMessages = {
       "把「{name}」的操作手册交给你已经在用的 Agent（Claude Code、Codex、Cursor）。它会学会这个 App 怎么用；这个空间里不会创建或改动任何东西。",
     agentPromptLabel: "把这段粘贴给你的 Agent",
     agentPromptBody:
-      "安装 Busabase 应用技能「{name}」，以便你之后可以操作它：\n\n{command}\n\n只安装技能——先不要在我的 Busabase 空间里创建、修改或删除任何东西。装好之后，用几句话告诉我这个 App 是做什么的，以及如果我让你去搭建它，会创建些什么。",
+      "安装 Busabase 应用技能「{name}」，以便你之后可以操作它。\n\n安装前，先确认当前环境已经连接 Busabase，并且连接的是正确的目标空间{targetSpace}。如果当前环境尚未配置 Busabase 连接，或连接指向其他空间，请先阅读并遵循下面的连接引导：\n\n{setupUrl}\n\n连接就绪后，执行：\n\n{command}\n\n只安装技能——先不要在我的 Busabase 空间里创建、修改或删除任何东西。装好之后，用几句话告诉我这个 App 是做什么的，以及如果我让你去搭建它，会创建些什么。",
     agentRefHint: "安装的是仓库默认分支。这条目录读取自 {ref}。",
-    agentConnectTitle: "还要让 Agent 能访问这个空间",
-    agentConnectBody:
-      "技能告诉 Agent 这个 App 怎么用；连接 Busabase 才让它真的能读写你的数据。只需设置一次。",
-    agentConnectAction: "连接你的 Agent",
     agentNoSkillTitle: "这个包不带 Agent 手册",
     agentNoSkillBody:
       "这里没有 SKILL.md，Agent 无从安装，只能靠猜你的表结构。请改用界面安装；装完仍可以在节点的「•••」菜单里把该节点的提示词交给 Agent。",

--- a/packages/busabase-core/src/i18n/zh-TW.ts
+++ b/packages/busabase-core/src/i18n/zh-TW.ts
@@ -305,12 +305,8 @@ export const dashboardZhTW: CoreI18nMessages = {
       "把「{name}」的操作手冊交給你已經在用的 Agent（Claude Code、Codex、Cursor）。它會學會這個 App 怎麼用；這個空間裡不會建立或更動任何東西。",
     agentPromptLabel: "把這段貼上給你的 Agent",
     agentPromptBody:
-      "安裝 Busabase 應用技能「{name}」，以便你之後可以操作它：\n\n{command}\n\n只安裝技能——先不要在我的 Busabase 空間裡建立、修改或刪除任何東西。裝好之後，用幾句話告訴我這個 App 是做什麼的，以及如果我讓你去建置它，會建立些什麼。",
+      "安裝 Busabase 應用技能「{name}」，以便你之後可以操作它。\n\n安裝前，先確認目前環境已經連接 Busabase，並且連接的是正確的目標空間{targetSpace}。如果目前環境尚未設定 Busabase 連接，或連接指向其他空間，請先閱讀並遵循下方的連接指引：\n\n{setupUrl}\n\n連接就緒後，執行：\n\n{command}\n\n只安裝技能——先不要在我的 Busabase 空間裡建立、修改或刪除任何東西。裝好之後，用幾句話告訴我這個 App 是做什麼的，以及如果我讓你去建置它，會建立些什麼。",
     agentRefHint: "安裝的是倉庫預設分支。這條目錄讀取自 {ref}。",
-    agentConnectTitle: "還要讓 Agent 能存取這個空間",
-    agentConnectBody:
-      "技能告訴 Agent 這個 App 怎麼用；連接 Busabase 才讓它真的能讀寫你的資料。只需設定一次。",
-    agentConnectAction: "連接你的 Agent",
     agentNoSkillTitle: "這個套件不帶 Agent 手冊",
     agentNoSkillBody:
       "這裡沒有 SKILL.md，Agent 無從安裝，只能靠猜你的表結構。請改用介面安裝；裝完仍可以在節點的「•••」選單裡把該節點的提示詞交給 Agent。",

--- a/packages/busabase-core/src/logic/ancestor-chain.test.ts
+++ b/packages/busabase-core/src/logic/ancestor-chain.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { collectAncestorIds, MAX_ANCESTOR_DEPTH } from "./ancestor-chain";
+
+/** `root` has no parent, standing in for the workspace root. */
+const tree: Record<string, string | null> = {
+  root: null,
+  a: "root",
+  b: "a",
+  c: "b",
+  leaf: "c",
+  other: "root",
+};
+const parentOf = (id: string) => tree[id];
+
+describe("collectAncestorIds", () => {
+  it("returns the chain root-first, excluding the node itself and the root", async () => {
+    expect(await collectAncestorIds("leaf", parentOf)).toEqual(["a", "b", "c"]);
+    expect(await collectAncestorIds("c", parentOf)).toEqual(["a", "b"]);
+  });
+
+  it("returns [] for a node sitting directly under the root", async () => {
+    expect(await collectAncestorIds("a", parentOf)).toEqual([]);
+    expect(await collectAncestorIds("other", parentOf)).toEqual([]);
+  });
+
+  it("returns [] for an unknown node rather than inventing a chain", async () => {
+    expect(await collectAncestorIds("nope", parentOf)).toEqual([]);
+  });
+
+  it("drops an ancestor whose own row is missing instead of emitting a dangling id", async () => {
+    // `orphan`'s parent points at an id with no row behind it. `ghost` must not
+    // be emitted — a caller could do nothing with it.
+    const broken: Record<string, string | null | undefined> = {
+      orphan: "ghost",
+      ghost: undefined,
+    };
+    expect(await collectAncestorIds("orphan", (id) => broken[id])).toEqual([]);
+  });
+
+  it("survives a cycle instead of spinning", async () => {
+    const cyclic: Record<string, string> = { x: "y", y: "z", z: "x" };
+    // Every hop is a real parent, so only the visited-set guard can stop this.
+    const chain = await collectAncestorIds("x", (id) => cyclic[id]);
+    expect(chain.length).toBeLessThanOrEqual(3);
+  });
+
+  it("stops at the depth bound on a pathologically long chain", async () => {
+    // Each node's parent is the next one up, forever — no cycle, so only the
+    // bound can stop it.
+    const endless = (id: string) => `n${Number(id.slice(1)) + 1}`;
+    const chain = await collectAncestorIds("n0", endless);
+    expect(chain).toHaveLength(MAX_ANCESTOR_DEPTH);
+  });
+
+  it("accepts an async resolver, so a database lookup fits the same walk", async () => {
+    const asyncParent = async (id: string) => tree[id];
+    expect(await collectAncestorIds("leaf", asyncParent)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/packages/busabase-core/src/logic/ancestor-chain.ts
+++ b/packages/busabase-core/src/logic/ancestor-chain.ts
@@ -1,0 +1,57 @@
+/**
+ * One definition of "walk a node's parent chain", shared by the real store and
+ * the demo store so the two cannot drift.
+ *
+ * They already did drift once: the real implementation emitted the workspace
+ * root while its own doc comment (and the demo twin) said it did not. The rule
+ * is subtle enough — root-first, self excluded, root excluded, cycle-safe —
+ * that stating it twice was never going to hold.
+ *
+ * Deliberately dependency-free: both `logic/node-detail.ts` and
+ * `logic/demo-store.ts` import it, and `logic/store.ts` re-exports
+ * `logic/nodes.ts`, so anything with imports risks a cycle here.
+ */
+
+/**
+ * Hard bound on how far the walk climbs. Real trees are a handful of levels
+ * deep; this exists so corrupt data cannot turn one navigation into an
+ * unbounded run of sequential lookups. The cycle guard below already catches
+ * a *loop*, but not a pathologically long (or maliciously deep) chain.
+ */
+export const MAX_ANCESTOR_DEPTH = 64;
+
+/**
+ * `nodeId`'s ancestors, ROOT-FIRST, excluding the node itself and excluding
+ * the workspace root.
+ *
+ * `parentOf` returns the given node's parent id, or `null`/`undefined` when
+ * there is none — which covers both "this is the workspace root" and "no such
+ * node". Both stop the walk WITHOUT contributing an entry: the root is not a
+ * sidebar row (the tree lifts its children to the top level and drops it), and
+ * an id with no row behind it is not something a caller could act on either.
+ *
+ * It may be sync or async; the walk awaits it either way, so an in-memory map
+ * and a database both fit without a second copy of this function.
+ */
+export const collectAncestorIds = async (
+  nodeId: string,
+  parentOf: (id: string) => Promise<string | null | undefined> | string | null | undefined,
+): Promise<string[]> => {
+  const ancestorIds: string[] = [];
+  const visited = new Set<string>([nodeId]);
+  let cursorId = await parentOf(nodeId);
+
+  while (cursorId && ancestorIds.length < MAX_ANCESTOR_DEPTH) {
+    // Cycle guard against corrupt data — a self- or mutually-parented row must
+    // not spin here.
+    if (visited.has(cursorId)) break;
+    visited.add(cursorId);
+    const nextId = await parentOf(cursorId);
+    if (nextId === null || nextId === undefined) break;
+    ancestorIds.push(cursorId);
+    cursorId = nextId;
+  }
+
+  // Collected leaf-first while climbing; callers want root-first.
+  return ancestorIds.reverse();
+};

--- a/packages/busabase-core/src/logic/anonymous-allowlist.ts
+++ b/packages/busabase-core/src/logic/anonymous-allowlist.ts
@@ -34,6 +34,7 @@
  */
 
 import { ORPCError } from "@orpc/server";
+import { isPubliclyReadableNodeType, listNodeTypes } from "busabase-contract/domains";
 
 /** A procedure path (`["records", "list"]`) as a stable dotted key. */
 export const toProcedureKey = (path: readonly string[]): string => path.join(".");
@@ -125,36 +126,16 @@ export const isEmbedProcedureAllowed = (path: readonly string[]): boolean =>
 const ANONYMOUS_SUBMIT_ALLOWLIST: ReadonlySet<string> = new Set(["forms.submit"]);
 
 /**
- * Node types an anonymous (public-link) visitor may read through `nodes.get`.
+ * Whether an anonymous (public-link) visitor may read a node through `nodes.get`.
  *
- * An ALLOWLIST, not a denylist of the three file-tree types, for the same
- * reason `ANONYMOUS_READ_ALLOWLIST` is one: a node type registered later —
- * including one a build-time plugin adds via `registerNodeType()` — must fail
- * closed rather than inherit anonymous access because nobody remembered to deny
- * it. Opening a type up has to be a deliberate edit here.
- *
- * What is in and why:
- *   - `folder` / `doc` / `file` — exactly the three that `folders.get`,
- *     `docs.get`, and `files.get` served anonymously before the merge.
- *   - `base`   — already reachable anonymously via `bases.get`; withholding the
- *     strictly smaller node row from `nodes.get` would be arbitrary.
- *
- * What is deliberately out:
- *   - `skill` / `drive` / `airapp` — `fileTrees.get` was never on the anonymous
- *     allowlist. A public share must not become a way to read an agent's source.
- *   - `form` / `whiteboard` / `workflow` / `html` — no anonymous surface exists
- *     for them yet; when one does, it lands as a deliberate addition here.
+ * The node registry is the single source of truth for this decision. New and
+ * plugin-provided types still fail closed because `publicAccess` is opt-in;
+ * setting it is the deliberate review point for public behavior. Only `detail`
+ * and `submit` enter this hydration gate; runtime and source types stay out.
  */
-const ANONYMOUS_READABLE_NODE_TYPES: ReadonlySet<string> = new Set([
-  "folder",
-  "doc",
-  "file",
-  "base",
-]);
-
 /** Whether an anonymous visitor may read this node type's detail at all. */
 export const isAnonymousReadableNodeType = (type: string): boolean =>
-  ANONYMOUS_READABLE_NODE_TYPES.has(type);
+  isPubliclyReadableNodeType(type);
 
 /**
  * Refuse a node type that is off the anonymous surface. Same FORBIDDEN code and
@@ -230,6 +211,9 @@ export const anonymousAllowlistSnapshot = (): {
 } => ({
   read: [...ANONYMOUS_READ_ALLOWLIST].sort(),
   submit: [...ANONYMOUS_SUBMIT_ALLOWLIST].sort(),
-  nodeTypes: [...ANONYMOUS_READABLE_NODE_TYPES].sort(),
+  nodeTypes: listNodeTypes()
+    .filter((definition) => isPubliclyReadableNodeType(definition.type))
+    .map((definition) => definition.type)
+    .sort(),
   embed: [...EMBED_READ_ALLOWLIST].sort(),
 });

--- a/packages/busabase-core/src/logic/cr-lifecycle.ts
+++ b/packages/busabase-core/src/logic/cr-lifecycle.ts
@@ -101,6 +101,34 @@ import {
 import { mergeDocUpdate } from "../domains/doc/handlers";
 import { mergeFileTreeFile, mergeFileTreeMetadata } from "../domains/filetree/handlers";
 import { mergeRichNodeDocumentUpdate } from "../domains/rich-node/handlers";
+import { isSearchableNodeType, reindexNodeContent } from "./node-content";
+
+/**
+ * Refresh a node's search projection right after its content merge, inside the
+ * SAME transaction — so a phrase the user just approved is findable the moment
+ * they see the change land, with no indexing lag to explain away.
+ *
+ * Re-reads the merged content from storage rather than taking it from the
+ * commit payload: that guarantees the projection holds exactly what
+ * `openNodeContentSource` (and therefore grep) would read, instead of a second,
+ * possibly-diverging copy of the same text.
+ *
+ * Fail-soft by construction (`reindexNodeContent` swallows): an indexing
+ * problem must never roll back a merge the reviewer already approved. The node
+ * simply stays unindexed and the lazy self-heal in `logic/search.ts` retries.
+ */
+const refreshNodeContentSearch = async (
+  db: MergeCtx["db"],
+  node: { id: string; spaceId: string; type: string },
+): Promise<void> => {
+  if (!isSearchableNodeType(node.type)) return;
+  await reindexNodeContent(db, {
+    nodeId: node.id,
+    spaceId: node.spaceId,
+    nodeType: node.type,
+  });
+};
+
 import { dispatchWebhookEvent, hasWebhookRuleFor } from "../domains/webhook/logic/dispatch";
 import { insertAuditEvent } from "./audit";
 import { parseCommitPayload } from "./commit-payload-schemas";
@@ -1495,6 +1523,8 @@ type InboxCandidateRow = {
   submittedBy: string;
 };
 
+const CHANGE_REQUEST_ACL_BATCH_SIZE = 5_000;
+
 const matchesInboxFilter = (
   row: InboxCandidateRow,
   input: z.output<typeof inboxSnapshotInputSchema>,
@@ -1684,36 +1714,28 @@ export const countChangeRequests = async () => {
     );
   }
 
-  // Non-managers: whether a change request is visible depends on the node scope
-  // its operations resolve to, which cannot be expressed as a SQL aggregate — so
-  // the walk stays. It now reads only the three columns the tally actually uses,
-  // instead of whole rows.
-  const statusCount = new Map<string, number>();
-  let created = 0;
-  let offset = 0;
-  const batchSize = 100;
-  for (;;) {
-    const rows = await db
-      .select({
-        id: busabaseChangeRequests.id,
-        status: busabaseChangeRequests.status,
-        submittedBy: busabaseChangeRequests.submittedBy,
-      })
-      .from(busabaseChangeRequests)
-      .where(eq(busabaseChangeRequests.spaceId, spaceId))
-      .orderBy(desc(busabaseChangeRequests.createdAt), desc(busabaseChangeRequests.id))
-      .limit(batchSize)
-      .offset(offset);
-    const visibleRows = await filterVisibleChangeRequestRows(rows);
-    for (const row of visibleRows) {
-      statusCount.set(row.status, (statusCount.get(row.status) ?? 0) + 1);
-      if (row.submittedBy === mineActorId()) created += 1;
-    }
-    if (rows.length < batchSize) break;
-    offset += rows.length;
+  // Non-managers: visibility depends on the node scope resolved from each
+  // change request's operations. Read the lightweight candidate shape once;
+  // ordering is irrelevant to a tally. Bound each ACL query so unusually large
+  // spaces do not create an unbounded IN list or Operations result set.
+  const rows = await db
+    .select({
+      id: busabaseChangeRequests.id,
+      status: busabaseChangeRequests.status,
+      submittedBy: busabaseChangeRequests.submittedBy,
+    })
+    .from(busabaseChangeRequests)
+    .where(eq(busabaseChangeRequests.spaceId, spaceId));
+  const visibleRows: InboxCandidateRow[] = [];
+  for (let offset = 0; offset < rows.length; offset += CHANGE_REQUEST_ACL_BATCH_SIZE) {
+    visibleRows.push(
+      ...(await filterVisibleChangeRequestRows(
+        rows.slice(offset, offset + CHANGE_REQUEST_ACL_BATCH_SIZE),
+      )),
+    );
   }
 
-  return toInboxCounts(statusCount, created);
+  return countInboxCandidateRows(visibleRows);
 };
 
 export const getChangeRequest = async (changeRequestId: string) => {
@@ -2059,6 +2081,15 @@ const canViewChangeRequest = async (changeRequestId: string): Promise<boolean> =
   return true;
 };
 
+const CHANGE_REQUEST_SCOPE_HINT_BATCH_SIZE = 5_000;
+
+interface ChangeRequestScopeHint {
+  id: string;
+  parentNodeId: string | null;
+  parentNodeRef: string | null;
+  ref: string | null;
+}
+
 // Constrained to `{ id }` rather than the full ChangeRequestPO on purpose: the
 // body only ever reads `row.id`, and callers that are merely tallying should be
 // free to select three columns instead of paying for whole rows.
@@ -2073,28 +2104,11 @@ export const filterVisibleChangeRequestRows = async <T extends { id: string }>(
       changeRequestId: busabaseOperations.changeRequestId,
       nodeId: busabaseOperations.nodeId,
       baseId: busabaseOperations.baseId,
-      // Visibility needs only these three scalar scope hints. Selecting the
-      // complete payload made one ACL pass decode every AirApp source tree.
-      // Keep the previous `typeof value === "string"` semantics. Bare `->>`
-      // would stringify malformed numeric/object values and could accidentally
-      // turn them into permission-scope identifiers.
-      parentNodeId: sql<string | null>`case
-        when jsonb_typeof(${busabaseCommits.payload}->'parentNodeId') = 'string'
-          then ${busabaseCommits.payload}->>'parentNodeId'
-        end`,
-      parentNodeRef: sql<string | null>`case
-        when jsonb_typeof(${busabaseCommits.payload}->'parentNodeRef') = 'string'
-          then ${busabaseCommits.payload}->>'parentNodeRef'
-        end`,
-      ref: sql<string | null>`case
-        when jsonb_typeof(${busabaseCommits.payload}->'ref') = 'string'
-          then ${busabaseCommits.payload}->>'ref'
-        end`,
+      headCommitId: busabaseOperations.headCommitId,
       operation: busabaseOperations.operation,
       position: busabaseOperations.position,
     })
     .from(busabaseOperations)
-    .leftJoin(busabaseCommits, eq(busabaseCommits.id, busabaseOperations.headCommitId))
     .where(
       and(
         eq(busabaseOperations.spaceId, getContextSpaceId()),
@@ -2115,29 +2129,79 @@ export const filterVisibleChangeRequestRows = async <T extends { id: string }>(
           )
       : [];
   const baseNodeById = new Map(baseRows.map((base) => [base.id, base.nodeId]));
+  // Most operations already resolve through nodeId or baseId. Only unresolved
+  // operations (normally pending node creates) need scope hints from the head
+  // commit. Keeping this as a second query prevents record/file payloads from
+  // being joined, detoasted and inspected during every inbox ACL pass.
+  const scopeCommitIds = [
+    ...new Set(
+      operations.flatMap((operation) => {
+        const directNodeId =
+          operation.nodeId ?? (operation.baseId ? baseNodeById.get(operation.baseId) : undefined);
+        return directNodeId ? [] : [operation.headCommitId];
+      }),
+    ),
+  ];
+  const scopeHintRows: ChangeRequestScopeHint[] = [];
+  for (
+    let offset = 0;
+    offset < scopeCommitIds.length;
+    offset += CHANGE_REQUEST_SCOPE_HINT_BATCH_SIZE
+  ) {
+    const commitIds = scopeCommitIds.slice(offset, offset + CHANGE_REQUEST_SCOPE_HINT_BATCH_SIZE);
+    scopeHintRows.push(
+      ...(await db
+        .select({
+          id: busabaseCommits.id,
+          // Keep the previous `typeof value === "string"` semantics. Bare
+          // `->>` would stringify malformed values into scope identifiers.
+          parentNodeId: sql<string | null>`case
+            when jsonb_typeof(${busabaseCommits.payload}->'parentNodeId') = 'string'
+              then ${busabaseCommits.payload}->>'parentNodeId'
+            end`,
+          parentNodeRef: sql<string | null>`case
+            when jsonb_typeof(${busabaseCommits.payload}->'parentNodeRef') = 'string'
+              then ${busabaseCommits.payload}->>'parentNodeRef'
+            end`,
+          ref: sql<string | null>`case
+            when jsonb_typeof(${busabaseCommits.payload}->'ref') = 'string'
+              then ${busabaseCommits.payload}->>'ref'
+            end`,
+        })
+        .from(busabaseCommits)
+        .where(
+          and(
+            eq(busabaseCommits.spaceId, getContextSpaceId()),
+            inArray(busabaseCommits.id, commitIds),
+          ),
+        )),
+    );
+  }
+  const scopeHintsByCommitId = new Map(scopeHintRows.map((row) => [row.id, row]));
   const scopes = new Map<string, Set<string>>();
   const unresolved = new Set<string>();
   const refsByChangeRequest = new Map<string, Set<string>>();
   for (const operation of operations) {
     const scope = scopes.get(operation.changeRequestId) ?? new Set<string>();
     const refs = refsByChangeRequest.get(operation.changeRequestId) ?? new Set<string>();
+    const scopeHints = scopeHintsByCommitId.get(operation.headCommitId);
     const nodeId =
       operation.nodeId ??
       (operation.baseId ? baseNodeById.get(operation.baseId) : undefined) ??
-      operation.parentNodeId ??
+      scopeHints?.parentNodeId ??
       undefined;
     if (nodeId) scope.add(nodeId);
-    else if (operation.parentNodeRef && refs.has(operation.parentNodeRef)) {
+    else if (scopeHints?.parentNodeRef && refs.has(scopeHints.parentNodeRef)) {
       // The earlier declaration's existing parent already anchors this new subtree.
     } else if (
       operation.operation === "node_create" &&
       !operation.nodeId &&
       !operation.baseId &&
-      !operation.parentNodeRef
+      !scopeHints?.parentNodeRef
     ) {
       scope.add(rootNodeIdForSpace(getContextSpaceId()));
     } else unresolved.add(operation.changeRequestId);
-    if (operation.ref) refs.add(operation.ref);
+    if (scopeHints?.ref) refs.add(scopeHints.ref);
     scopes.set(operation.changeRequestId, scope);
     refsByChangeRequest.set(operation.changeRequestId, refs);
   }
@@ -3131,8 +3195,10 @@ const _mergeChangeRequest = async (changeRequestId: string) => {
           // types (spec D2/D3). `doc_update` below is unaffected — Doc keeps its own
           // merge handler.
           await mergeRichNodeDocumentUpdate(ctx, item, node, headCommit);
+          await refreshNodeContentSearch(ctx.db, node);
         } else if (item.operation === "doc_update") {
           await mergeDocUpdate(ctx, item, node, headCommit);
+          await refreshNodeContentSearch(ctx.db, node);
         } else {
           throw new Error(`Unsupported node operation: ${item.operation}`);
         }

--- a/packages/busabase-core/src/logic/demo-store.ts
+++ b/packages/busabase-core/src/logic/demo-store.ts
@@ -50,6 +50,7 @@ import {
 import { zhCnScenario } from "../demo/scenarios/zh-cn";
 import { getPrimaryField } from "../domains/base/utils/primary-field";
 import { type DocLinesResult, sliceDocLinesRange, splitDocLines } from "../domains/doc/handlers";
+import { collectAncestorIds } from "./ancestor-chain";
 import { isSearchableNodeType, NODE_CONTENT_ADAPTERS } from "./node-content";
 import { toPublicAuditMetadata, toPublicSourceMetadata } from "./source-attribution";
 
@@ -173,6 +174,32 @@ export const demoIsDescendant = (nodeId: string, potentialAncestorId: string): b
     cursorId = ancestorId;
   }
   return false;
+};
+
+/**
+ * Demo counterpart to `listNodeAncestorIds` — same root-first, self-excluded
+ * contract, resolved against the in-memory seeded tree. `nodeIdOrSlug` accepts
+ * either, mirroring the real one (whose `resolveVisibleNode` does the same).
+ */
+export const demoNodeAncestorIds = async (
+  nodeIdOrSlug: string,
+): Promise<{ ancestorIds: string[] }> => {
+  const parentById = new Map<string, string | null>();
+  const idBySlug = new Map<string, string>();
+  const visit = (nodes: NodeVO[], parentId: string | null) => {
+    for (const node of nodes) {
+      parentById.set(node.id, parentId);
+      if (node.slug && !idBySlug.has(node.slug)) idBySlug.set(node.slug, node.id);
+      if (node.children.length > 0) visit(node.children, node.id);
+    }
+  };
+  visit(dataset().nodes, null);
+
+  // Accepts an id or a slug, mirroring the real one (whose `resolveVisibleNode`
+  // does the same).
+  const nodeId = parentById.has(nodeIdOrSlug) ? nodeIdOrSlug : idBySlug.get(nodeIdOrSlug);
+  if (!nodeId) return { ancestorIds: [] };
+  return { ancestorIds: await collectAncestorIds(nodeId, (id) => parentById.get(id)) };
 };
 
 /**
@@ -753,7 +780,7 @@ export const demoSearch = (input: {
   query: string;
   limit?: number;
   offset?: number;
-  sources?: ("records" | "files" | "names")[];
+  sources?: ("records" | "files" | "names" | "nodes")[];
 }): SearchResponseVO => {
   const query = (input.query ?? "").trim();
   const limit = input.limit ?? 20;
@@ -763,7 +790,9 @@ export const demoSearch = (input: {
   const match = (haystack: string) => needle === "" || haystack.toLowerCase().includes(needle);
   // No `sources` means every caller before this parameter existed — search
   // everything, same default as the real (non-demo) searchBusabase.
-  const wantsSource = (source: "records" | "files" | "names") =>
+  // `nodes` (node content) has no demo projection — the stateless demo
+  // dataset has no object storage to index. Accepted and ignored.
+  const wantsSource = (source: "records" | "files" | "names" | "nodes") =>
     !input.sources || input.sources.includes(source);
   // Demo mode has no separate file-content search — `files` has nothing to
   // additionally include or exclude here (mirrors real search's own "no
@@ -838,6 +867,9 @@ export const demoSearch = (input: {
     offset + limit,
   );
   return {
+    // The stateless demo dataset has no content projection, so it never
+    // reports partial content coverage.
+    contentTruncated: false,
     hasMore:
       recordResults.length + changeRequestResults.length + baseResults.length > offset + limit,
     limit,

--- a/packages/busabase-core/src/logic/node-content.ts
+++ b/packages/busabase-core/src/logic/node-content.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
+
 import { ORPCError } from "@orpc/server";
 /**
  * The registry of node types whose content lives as ONE object in storage —
@@ -20,7 +22,7 @@ import { ORPCError } from "@orpc/server";
 import { and, eq, isNull, or } from "drizzle-orm";
 import { getContextSpaceId } from "../context";
 import { getDb } from "../db";
-import { busabaseNodes } from "../db/schema";
+import { busabaseNodeContentSearch, busabaseNodes } from "../db/schema";
 import type { MutableTextSource } from "../domains/assets/logic/text-cache";
 import { openMutableTextSource } from "../domains/assets/logic/text-cache";
 import {
@@ -36,6 +38,9 @@ import {
 } from "../domains/rich-node/utils/searchable-text";
 import { buildNodeVisibilityCondition } from "./node-acl";
 import { ensureReady } from "./seed";
+import { VALUE_TEXT_INDEX_LIMIT } from "./vo";
+
+type Db = Awaited<ReturnType<typeof getDb>>;
 
 export interface NodeContentAdapter {
   /** The storage key holding this node's content. */
@@ -60,7 +65,14 @@ export interface NodeContentAdapter {
 }
 
 export const NODE_CONTENT_ADAPTERS = {
-  doc: { storageKey: docBodyKey },
+  // MUST stay a lazy arrow, never a bare `storageKey: docBodyKey` reference.
+  // This module sits in an import cycle (…-> cr-lifecycle -> node-content ->
+  // domains/doc/handlers -> …), so a direct value reference is read while
+  // `doc/handlers` is still initializing and binds `undefined` — which shows up
+  // far away as `storageKey is not a function` at the first read, with every
+  // OTHER node type working (the rich types were already arrows). Calling
+  // through an arrow defers the lookup to call time, when the cycle has settled.
+  doc: { storageKey: (nodeId: string) => docBodyKey(nodeId) },
   html: { storageKey: (nodeId: string) => richNodeDocumentKey(nodeId, "html") },
   whiteboard: {
     storageKey: (nodeId: string) => richNodeDocumentKey(nodeId, "whiteboard"),
@@ -199,4 +211,83 @@ export const readNodeLines = async (
     lines.push(line);
   }
   return sliceDocLinesRange(lines, startLine, endLine);
+};
+
+// ── Search projection ────────────────────────────────────────────────────────
+//
+// `search` cannot scan object storage, so a node's searchable text is
+// materialized into `busabase_node_content_search`. Everything below is the one
+// path that writes it — see `content/spec/node-content-search.md`.
+
+/**
+ * Project `text` for search: the SAME extracted text grep scans, truncated to
+ * `VALUE_TEXT_INDEX_LIMIT`.
+ *
+ * Returns `truncated` so the caller can persist it. The cap makes "no results"
+ * ambiguous ("absent" vs "past the cap"), and the product resolves that by
+ * telling the user rather than hiding it (spec D2b) — a projection that
+ * truncated silently would quietly break the promise that an empty search
+ * result means the workspace does not contain the phrase.
+ */
+export const projectSearchText = (
+  text: string,
+): { contentText: string; contentHash: string; truncated: boolean } => ({
+  contentText: text.length > VALUE_TEXT_INDEX_LIMIT ? text.slice(0, VALUE_TEXT_INDEX_LIMIT) : text,
+  // Hash the FULL text, not the truncated prefix: two documents differing only
+  // past the cap must still count as changed, or an edit beyond it would never
+  // refresh `truncated`/`indexedAt`.
+  contentHash: createHash("sha256").update(text, "utf8").digest("hex"),
+  truncated: text.length > VALUE_TEXT_INDEX_LIMIT,
+});
+
+/**
+ * Write (or refresh) one node's search projection from text already in hand.
+ *
+ * Called from the content write path so an approved edit is searchable the
+ * instant the user sees it land — indexing asynchronously would buy little
+ * (this is a string operation on bytes already in memory) and would cost the
+ * one property people actually notice.
+ */
+export const upsertNodeContentProjection = async (
+  db: Db,
+  params: { nodeId: string; spaceId: string; nodeType: SearchableNodeType; text: string },
+): Promise<void> => {
+  const projected = projectSearchText(params.text);
+  await db
+    .insert(busabaseNodeContentSearch)
+    .values({
+      nodeId: params.nodeId,
+      spaceId: params.spaceId,
+      nodeType: params.nodeType,
+      ...projected,
+      indexedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: busabaseNodeContentSearch.nodeId,
+      set: { nodeType: params.nodeType, ...projected, indexedAt: new Date() },
+    });
+};
+
+/**
+ * Re-read a node's content from storage and refresh its projection.
+ *
+ * Two callers: the lazy self-heal (a node predating this feature has no row
+ * yet) and the operator backfill script. Deliberately fail-soft — a node whose
+ * content object is missing must not break the search request that touched it;
+ * it stays unindexed and is retried next time.
+ */
+export const reindexNodeContent = async (
+  db: Db,
+  params: { nodeId: string; spaceId: string; nodeType: SearchableNodeType },
+): Promise<boolean> => {
+  try {
+    const source = await openNodeContentSource(params.nodeType, params.nodeId);
+    const adapter = NODE_CONTENT_ADAPTERS[params.nodeType] as NodeContentAdapter;
+    const raw = await source.readText();
+    const text = adapter.toSearchableText ? adapter.toSearchableText(raw) : raw;
+    await upsertNodeContentProjection(db, { ...params, text });
+    return true;
+  } catch {
+    return false;
+  }
 };

--- a/packages/busabase-core/src/logic/node-detail.ts
+++ b/packages/busabase-core/src/logic/node-detail.ts
@@ -7,6 +7,7 @@ import { and, asc, eq, isNull } from "drizzle-orm";
 import { getContextSpaceId, isAnonymousVisitor } from "../context";
 import { getDb } from "../db";
 import { busabaseNodes, type NodePO } from "../db/schema";
+import { collectAncestorIds } from "./ancestor-chain";
 import { denyAnonymousNodeType, isAnonymousReadableNodeType } from "./anonymous-allowlist";
 // Side-effect import: guarantees every builtin node type has registered its
 // server-side behaviour before the dispatch below reads the registry. Importing
@@ -117,6 +118,46 @@ const buildGenericDetail = async (node: NodePO): Promise<NodeDetailVO> => {
     type: node.type,
     node: nodeMap.get(node.id) ?? toNodeVO(node, null),
   } as NodeDetailVO;
+};
+
+/**
+ * The ancestor chain of `nodeIdOrSlug`, ROOT-FIRST and excluding the node
+ * itself (`[]` for a node sitting directly under the workspace root).
+ *
+ * Exists because the sidebar cannot work this out on its own. Its tree is
+ * fetched depth-bounded and expanded lazily, so on a cold load — a refresh, a
+ * bookmark, a shared link, a "recently visited" jump — the ancestors of a
+ * deep node have simply never been fetched. Walking `parentId` client-side
+ * would be one round trip per level and still could not see past the first
+ * unloaded ancestor. This walks the same `parentId` chain `isDescendantOf`
+ * does, server-side, in one call, so the sidebar can expand straight to the
+ * active node.
+ *
+ * Resolution and ACL go through `resolveVisibleNode`, exactly as
+ * `getNodeDetail` does, so a slug in the URL works and an invisible node is a
+ * 404 rather than a leaked chain of ancestor ids.
+ */
+export const listNodeAncestorIds = async (
+  nodeIdOrSlug: string,
+  typeHint?: NodeType,
+): Promise<{ ancestorIds: string[] }> => {
+  await ensureReady();
+  const node = await resolveVisibleNode(nodeIdOrSlug, typeHint);
+  const db = await getDb();
+  const spaceId = getContextSpaceId();
+
+  const ancestorIds = await collectAncestorIds(node.id, async (id) => {
+    // The starting node is already resolved — reuse it instead of paying a
+    // second lookup for a row we are holding.
+    if (id === node.id) return node.parentId;
+    const [row] = await db
+      .select({ parentId: busabaseNodes.parentId })
+      .from(busabaseNodes)
+      .where(and(eq(busabaseNodes.id, id), eq(busabaseNodes.spaceId, spaceId)))
+      .limit(1);
+    return row?.parentId;
+  });
+  return { ancestorIds };
 };
 
 export const getNodeDetail = async (

--- a/packages/busabase-core/src/logic/search.ts
+++ b/packages/busabase-core/src/logic/search.ts
@@ -6,11 +6,11 @@ import type {
   SearchResponseVO,
   SearchResultVO,
 } from "busabase-contract/types";
-import { and, desc, eq, ilike, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { and, desc, eq, ilike, inArray, isNotNull, isNull, notExists, or, sql } from "drizzle-orm";
 import { iStringConcat, iStringParse, iStringSchema } from "openlib/i18n/i-string";
 import { z } from "zod";
 import { getContextSpaceId } from "../context";
-import { getDb } from "../db";
+import { type DbInstance, getDb } from "../db";
 import {
   attachments,
   busabaseAssets,
@@ -19,6 +19,7 @@ import {
   busabaseBases,
   busabaseChangeRequests,
   busabaseFieldValues,
+  busabaseNodeContentSearch,
   busabaseNodes,
   busabaseRecords,
 } from "../db/schema";
@@ -34,10 +35,13 @@ import {
   buildNodeVisibilityCondition,
   buildNodeVisibilityExists,
 } from "./node-acl";
+import { isSearchableNodeType, reindexNodeContent, SEARCHABLE_NODE_TYPES } from "./node-content";
 import { ensureReady } from "./seed";
 import { toBaseVO } from "./vo";
 
-export const SEARCH_SOURCES = ["records", "files", "names"] as const;
+// Mirrors `contract/schemas.ts`s SEARCH_SOURCES; `nodes` searches node CONTENT
+// and is named to match grep's `nodes` source.
+export const SEARCH_SOURCES = ["records", "files", "names", "nodes"] as const;
 export type SearchSource = (typeof SEARCH_SOURCES)[number];
 
 // Schema defined locally to avoid circular deps with store.ts
@@ -132,6 +136,155 @@ const fileResultHref = (nodeType: string, nodeSlug: string) => {
   if (nodeType === "doc") return `/doc/${nodeSlug}`;
   if (nodeType === "base") return `/base/${nodeSlug}`;
   return `/${nodeType}/${nodeSlug}`;
+};
+
+/**
+ * Node CONTENT search — the human counterpart to grep's `nodes` source.
+ *
+ * Reads the `busabase_node_content_search` projection, which holds exactly the
+ * text grep scans (same `NODE_CONTENT_ADAPTERS` extraction), truncated to
+ * `VALUE_TEXT_INDEX_LIMIT`. See `content/spec/node-content-search.md`.
+ */
+const NODE_SNIPPET_RADIUS = 60;
+/**
+ * How many unindexed nodes one search request will index before querying.
+ *
+ * Bounded on purpose: a workspace upgraded from before this feature has no
+ * projection rows, and indexing them all in the first search would make that
+ * one request arbitrarily slow — worst on the largest workspaces, which are
+ * exactly the ones that need search most. A small batch per request lets the
+ * index fill in across a few searches instead (spec D3: gradually, never a
+ * stalled request).
+ */
+const NODE_SELF_HEAL_BATCH = 25;
+
+/** A snippet centred on the match, so the user can tell near-identical docs apart (spec S1). */
+const buildNodeSnippet = (content: string, query: string): string => {
+  const at = content.toLowerCase().indexOf(query.toLowerCase());
+  if (at < 0)
+    return content
+      .slice(0, NODE_SNIPPET_RADIUS * 2)
+      .replace(/\s+/g, " ")
+      .trim();
+  const start = Math.max(0, at - NODE_SNIPPET_RADIUS);
+  const end = Math.min(content.length, at + query.length + NODE_SNIPPET_RADIUS);
+  const core = content.slice(start, end).replace(/\s+/g, " ").trim();
+  return `${start > 0 ? "…" : ""}${core}${end < content.length ? "…" : ""}`;
+};
+
+const NODE_KIND_LABEL: Record<string, string> = {
+  doc: "Doc",
+  html: "Page",
+  whiteboard: "Whiteboard",
+  workflow: "Workflow",
+};
+
+/**
+ * Index up to `NODE_SELF_HEAL_BATCH` content-bearing nodes that have no
+ * projection row yet — the lazy backfill for workspaces that predate this
+ * feature (spec D3). Fail-soft per node: a missing content object leaves that
+ * node unindexed and retried next time rather than failing the search.
+ */
+const selfHealNodeProjections = async (db: DbInstance, spaceId: string): Promise<void> => {
+  const stale = await db
+    .select({ id: busabaseNodes.id, type: busabaseNodes.type })
+    .from(busabaseNodes)
+    .where(
+      and(
+        eq(busabaseNodes.spaceId, spaceId),
+        isNull(busabaseNodes.archivedAt),
+        inArray(busabaseNodes.type, SEARCHABLE_NODE_TYPES),
+        notExists(
+          db
+            .select({ one: sql`1` })
+            .from(busabaseNodeContentSearch)
+            .where(eq(busabaseNodeContentSearch.nodeId, busabaseNodes.id)),
+        ),
+      ),
+    )
+    .limit(NODE_SELF_HEAL_BATCH);
+  for (const node of stale) {
+    if (!isSearchableNodeType(node.type)) continue;
+    await reindexNodeContent(db, { nodeId: node.id, spaceId, nodeType: node.type });
+  }
+};
+
+/**
+ * Search node content. Node ACL is applied INSIDE this query, never after —
+ * post-filtering would both over-count `hasMore` and let a caller infer that
+ * hidden nodes exist (spec D4).
+ */
+const searchNodeContent = async (
+  db: DbInstance,
+  spaceId: string,
+  query: string,
+  limit: number,
+): Promise<{ results: SearchResultVO[]; truncated: boolean }> => {
+  await selfHealNodeProjections(db, spaceId);
+  const pattern = `%${query}%`;
+  const rows = await db
+    .select({
+      nodeId: busabaseNodeContentSearch.nodeId,
+      nodeType: busabaseNodeContentSearch.nodeType,
+      contentText: busabaseNodeContentSearch.contentText,
+      truncated: busabaseNodeContentSearch.truncated,
+      name: busabaseNodes.name,
+      slug: busabaseNodes.slug,
+      updatedAt: busabaseNodes.updatedAt,
+    })
+    .from(busabaseNodeContentSearch)
+    .innerJoin(busabaseNodes, eq(busabaseNodeContentSearch.nodeId, busabaseNodes.id))
+    .where(
+      and(
+        eq(busabaseNodeContentSearch.spaceId, spaceId),
+        isNull(busabaseNodes.archivedAt),
+        buildNodeVisibilityCondition(db),
+        or(
+          // Whole-lexeme match. Contributes nothing for CJK — Postgres has no
+          // segmenter there, so a Chinese run becomes one oversized lexeme that
+          // is dropped from the index entirely (spec D2a). Kept because it IS
+          // the good branch for English/mixed content.
+          sql`to_tsvector('simple', coalesce(${busabaseNodeContentSearch.contentText}, '')) @@ plainto_tsquery('simple', ${query})`,
+          // Substring match, trigram-indexed. This is the branch that carries
+          // CJK search entirely — never drop its index to save space.
+          ilike(busabaseNodeContentSearch.contentText, pattern),
+        ),
+      ),
+    )
+    .orderBy(desc(busabaseNodes.updatedAt))
+    .limit(limit);
+
+  // Whether the ANSWER may be incomplete — deliberately NOT derived from the
+  // matched rows. The case this exists for is precisely the one with zero
+  // matches: a phrase living past the cap of some in-scope document produces no
+  // hits at all, so asking the hits whether anything was truncated always says
+  // "no" exactly when the user most needs to be told otherwise.
+  const [truncatedInScope] = await db
+    .select({ nodeId: busabaseNodeContentSearch.nodeId })
+    .from(busabaseNodeContentSearch)
+    .innerJoin(busabaseNodes, eq(busabaseNodeContentSearch.nodeId, busabaseNodes.id))
+    .where(
+      and(
+        eq(busabaseNodeContentSearch.spaceId, spaceId),
+        eq(busabaseNodeContentSearch.truncated, true),
+        isNull(busabaseNodes.archivedAt),
+        buildNodeVisibilityCondition(db),
+      ),
+    )
+    .limit(1);
+
+  return {
+    results: rows.map((row) => ({
+      id: row.nodeId,
+      kind: "node" as const,
+      title: row.name,
+      body: buildNodeSnippet(row.contentText ?? "", query),
+      eyebrow: NODE_KIND_LABEL[row.nodeType] ?? row.nodeType,
+      href: fileResultHref(row.nodeType, row.slug),
+      updatedAt: row.updatedAt?.toISOString() ?? null,
+    })),
+    truncated: truncatedInScope !== undefined,
+  };
 };
 
 const fileMatchesQuery = (query: string, ...values: (string | null | undefined)[]) => {
@@ -320,6 +473,7 @@ export const searchBusabase = async (
   const query = parsed.query.trim();
   if (!query) {
     return {
+      contentTruncated: false,
       hasMore: false,
       limit: parsed.limit,
       offset: parsed.offset,
@@ -339,6 +493,7 @@ export const searchBusabase = async (
   const wantsRecords = wantsSource("records");
   const wantsFiles = wantsSource("files");
   const wantsNames = wantsSource("names");
+  const wantsNodes = wantsSource("nodes");
 
   const projectionRows = wantsRecords
     ? await db
@@ -472,6 +627,14 @@ export const searchBusabase = async (
     wantsFiles ? searchAssetBackedFiles(query, parsed.limit) : Promise.resolve([]),
   ]);
 
+  // Node CONTENT. Only on the first page: like `names`, these are not part of
+  // the `projectionRows` pagination cursor, so emitting them again on every
+  // page would duplicate them.
+  const nodeContent =
+    wantsNodes && parsed.offset === 0
+      ? await searchNodeContent(db, spaceId, query, parsed.limit)
+      : { results: [] as SearchResultVO[], truncated: false };
+
   const baseResults = [...baseRowsById.values()].map((base) =>
     toBaseSearchResult(
       toBaseVO(
@@ -482,12 +645,21 @@ export const searchBusabase = async (
   );
 
   const dedupedResults = new Map<string, SearchResultVO>();
-  for (const result of [...projectionResults, ...baseResults, ...fileResults]) {
+  for (const result of [
+    ...projectionResults,
+    ...baseResults,
+    ...fileResults,
+    ...nodeContent.results,
+  ]) {
     dedupedResults.set(`${result.kind}:${result.id}`, result);
   }
   const results = [...dedupedResults.values()].slice(0, parsed.limit);
 
   return {
+    // Reported even when this page has hits: it says the ANSWER may be
+    // incomplete, which is exactly what a caller needs in order to describe an
+    // empty or thin result honestly (spec D2b).
+    contentTruncated: nodeContent.truncated,
     hasMore: projectionRows.length > parsed.limit,
     limit: parsed.limit,
     offset: parsed.offset,

--- a/packages/busabase-core/src/logic/seed.ts
+++ b/packages/busabase-core/src/logic/seed.ts
@@ -43,6 +43,7 @@ import type {
   SeedDocDef,
   SeedFileDef,
   SeedFileTreeDef,
+  SeedFolderDef,
   SeedFormDef,
   SeedRichNodeDef,
   SeedScenario,
@@ -538,19 +539,28 @@ const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef
   }
   ensureDefaultStorageUrl();
   const db = await getDb();
+  const spaceId = getContextSpaceId();
 
   const neededFolderTypes = new Set(defs.map((def) => def.nodeType));
+  const actualFolderIdByNodeType = new Map<SeedFileTreeDef["nodeType"], string>();
   for (const nodeType of neededFolderTypes) {
     const folderConfig = FILE_TREE_FOLDER_CONFIG[nodeType];
     const [existingFolder] = await db
-      .select()
+      .select({ id: busabaseNodes.id })
       .from(busabaseNodes)
-      .where(eq(busabaseNodes.id, folderConfig.folderNodeId))
+      .where(
+        and(
+          eq(busabaseNodes.spaceId, spaceId),
+          eq(busabaseNodes.type, "folder"),
+          eq(busabaseNodes.slug, folderConfig.slug),
+          isNull(busabaseNodes.archivedAt),
+        ),
+      )
       .limit(1);
     if (!existingFolder) {
       await db.insert(busabaseNodes).values({
         id: folderConfig.folderNodeId,
-        parentId: ROOT_NODE_ID,
+        parentId: rootNodeIdForSpace(spaceId),
         type: "folder",
         slug: folderConfig.slug,
         name: folderConfig.name,
@@ -567,12 +577,14 @@ const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef
           icon: seedNodeIcon({ ...folderConfig, nodeType: "folder" }),
           updatedAt: createdAt,
         })
-        .where(eq(busabaseNodes.id, folderConfig.folderNodeId));
+        .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, existingFolder.id)));
     }
+    actualFolderIdByNodeType.set(nodeType, existingFolder?.id ?? folderConfig.folderNodeId);
   }
 
   for (const def of defs) {
     const folderConfig = FILE_TREE_FOLDER_CONFIG[def.nodeType];
+    const folderNodeId = actualFolderIdByNodeType.get(def.nodeType) ?? folderConfig.folderNodeId;
     const metadata = {
       entryFile: folderConfig.entryFile,
       visibility: "workspace" as const,
@@ -581,13 +593,13 @@ const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef
     const [existingNode] = await db
       .select()
       .from(busabaseNodes)
-      .where(eq(busabaseNodes.id, def.nodeId))
+      .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, def.nodeId)))
       .limit(1);
     if (existingNode) {
       await db
         .update(busabaseNodes)
         .set({
-          parentId: folderConfig.folderNodeId,
+          parentId: folderNodeId,
           type: def.nodeType,
           slug: def.slug,
           name: def.name,
@@ -596,11 +608,11 @@ const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef
           metadata,
           updatedAt: createdAt,
         })
-        .where(eq(busabaseNodes.id, def.nodeId));
+        .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, def.nodeId)));
     } else {
       await db.insert(busabaseNodes).values({
         id: def.nodeId,
-        parentId: folderConfig.folderNodeId,
+        parentId: folderNodeId,
         type: def.nodeType,
         slug: def.slug,
         name: def.name,
@@ -616,7 +628,7 @@ const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef
     const [node] = await db
       .select()
       .from(busabaseNodes)
-      .where(eq(busabaseNodes.id, def.nodeId))
+      .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, def.nodeId)))
       .limit(1);
     if (!node) {
       throw new Error(`Failed to seed ${def.nodeType} node: ${def.nodeId}`);
@@ -1497,6 +1509,42 @@ export const ensureReady = async () => {
   return ready;
 };
 
+/**
+ * Seeded folders sorted so a parent is always processed before any child that
+ * declares it via `parentNodeId` — the insert below needs the parent's
+ * resolved (possibly adopted) node id to exist in `actualFolderIdBySeedId`
+ * already. Depth-first from the roots, preserving the scenario's own order
+ * within each level; any folder left over (a `parentNodeId` pointing outside
+ * this scenario, or a cycle someone hand-wrote) is appended unchanged rather
+ * than silently dropped — it then falls back to its literal `parentNodeId`,
+ * which is exactly what happened before nesting existed.
+ */
+const orderFoldersParentsFirst = (folders: SeedFolderDef[]): SeedFolderDef[] => {
+  const childrenByParent = new Map<string, SeedFolderDef[]>();
+  const seedIds = new Set(folders.map((folder) => folder.nodeId));
+  const roots: SeedFolderDef[] = [];
+  for (const folder of folders) {
+    if (folder.parentNodeId && seedIds.has(folder.parentNodeId)) {
+      const siblings = childrenByParent.get(folder.parentNodeId) ?? [];
+      siblings.push(folder);
+      childrenByParent.set(folder.parentNodeId, siblings);
+    } else {
+      roots.push(folder);
+    }
+  }
+  const ordered: SeedFolderDef[] = [];
+  const visited = new Set<string>();
+  const visit = (folder: SeedFolderDef) => {
+    if (visited.has(folder.nodeId)) return;
+    visited.add(folder.nodeId);
+    ordered.push(folder);
+    for (const child of childrenByParent.get(folder.nodeId) ?? []) visit(child);
+  };
+  roots.forEach(visit);
+  for (const folder of folders) if (!visited.has(folder.nodeId)) ordered.push(folder);
+  return ordered;
+};
+
 const applySeedScenario = async (scenario: SeedScenario) => {
   const db = await getDb();
   const createdAt = now();
@@ -1514,11 +1562,24 @@ const applySeedScenario = async (scenario: SeedScenario) => {
   const actualFolderIdBySeedId = new Map<string, string>();
   const existingFolderMetadataBySeedId = new Map<string, Record<string, unknown>>();
 
-  for (const folder of scenario.folders ?? []) {
+  for (const folder of orderFoldersParentsFirst(scenario.folders ?? [])) {
+    // A folder nests under another seeded folder when it declares
+    // `parentNodeId`; everything else sits directly under the workspace root.
+    // `actualFolderIdBySeedId` is consulted because an adopted legacy folder
+    // may live under a different id than the scenario's — `orderFoldersParentsFirst`
+    // is what guarantees the parent has already been through this loop.
+    const parentNodeId = folder.parentNodeId
+      ? (actualFolderIdBySeedId.get(folder.parentNodeId) ?? folder.parentNodeId)
+      : ROOT_NODE_ID;
     const existingFolder =
       existingNodeById.get(folder.nodeId) ??
-      existingNodeByParentSlug.get(`${ROOT_NODE_ID}:${folder.slug}`);
+      existingNodeByParentSlug.get(`${parentNodeId}:${folder.slug}`);
     if (existingFolder) {
+      // `parentId` is deliberately NOT re-applied on an existing folder:
+      // re-seeding an already-populated workspace would otherwise yank a
+      // folder the user has since moved back to where the scenario put it.
+      // Nesting therefore takes effect on the insert path (a fresh workspace,
+      // or a folder this scenario is adding for the first time).
       await db
         .update(busabaseNodes)
         .set({
@@ -1534,7 +1595,7 @@ const applySeedScenario = async (scenario: SeedScenario) => {
     } else {
       await db.insert(busabaseNodes).values({
         id: folder.nodeId,
-        parentId: ROOT_NODE_ID,
+        parentId: parentNodeId,
         type: "folder",
         slug: folder.slug,
         name: folder.name,

--- a/packages/busabase-core/src/mcp-skill.ts
+++ b/packages/busabase-core/src/mcp-skill.ts
@@ -279,6 +279,7 @@ to pass — every tool already acts on it. \`auth_verify\` confirms the current 
 | Skill / Drive / AirApp nodes and their files | \`node_list_files_trees\`, \`node_get_file_tree\`, \`node_files_list\`, \`node_file_read\` — all take \`kind\` (\`skill\`/\`drive\`/\`airapp\`) |
 | Change files inside a Skill / Drive / AirApp | \`node_files_change_request\` (pass \`baseContentHash\` from \`node_file_read\` so a concurrent edit is caught) |
 | The review queue | \`change_request_query\` (\`countsOnly\` for per-tab totals), \`change_requests_get\` |
+| Does anything unfinished already target THIS node | \`change_request_query\` with \`affectsNodeId\` + \`limit: 1\` — matches the node directly, its Base, or any of the request's operations, so an empty result is conclusive. Check this before proposing, or you may overwrite pending work. Counts stay space-wide. |
 | Propose one record | \`bases_create_change_request\` |
 | Propose many records as ONE review | \`bases_create_bulk_change_request\` |
 | Update many existing records as ONE atomic review | \`record_bulk_update_change_request\` (each \`fields\` is a partial patch; omitted keys stay, \`null\` clears) |

--- a/packages/busabase-core/src/router-demo.ts
+++ b/packages/busabase-core/src/router-demo.ts
@@ -34,6 +34,7 @@ import {
   demoListRecordsByFieldText,
   demoListViews,
   demoMergeChangeRequest,
+  demoNodeAncestorIds,
   demoReadFileTreeFile,
   demoReadNodeLines,
   demoReviewChangeRequest,
@@ -154,6 +155,7 @@ export const busabaseDemoRouter = os.router({
     isDescendant: os.nodes.isDescendant.handler(({ input }) => ({
       isDescendant: demoIsDescendant(input.nodeId, input.potentialAncestorId),
     })),
+    ancestors: os.nodes.ancestors.handler(({ input }) => demoNodeAncestorIds(input.nodeId)),
     createChangeRequest: os.nodes.createChangeRequest.handler(() => {
       throw demoUnsupported("Node tree change request");
     }),

--- a/packages/busabase-core/src/router.ts
+++ b/packages/busabase-core/src/router.ts
@@ -39,7 +39,7 @@ import {
 } from "./logic/node-acl";
 import { listNodeActivity, listRecordActivity } from "./logic/node-activity";
 import { readNodeLines } from "./logic/node-content";
-import { getNodeDetail } from "./logic/node-detail";
+import { getNodeDetail, listNodeAncestorIds } from "./logic/node-detail";
 import { disableNodeShare, getNodeShare, setNodeShare } from "./logic/node-share";
 import {
   closeChangeRequest,
@@ -130,6 +130,9 @@ const busabaseRouterImpl = busabase.router({
         input.potentialAncestorId,
       ),
     })),
+    ancestors: busabase.nodes.ancestors.handler(async ({ input }) =>
+      listNodeAncestorIds(input.nodeId, input.type),
+    ),
     createChangeRequest: busabase.nodes.createChangeRequest.handler(async ({ input }) =>
       createNodeChangeRequest(input),
     ),

--- a/packages/busabase-core/tests/agent-install-prompt.test.ts
+++ b/packages/busabase-core/tests/agent-install-prompt.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { createSetupSkillUrl } from "../src/domains/dashboard/components/agent-skill-button";
 import {
   buildAgentInstallCommand,
   buildAgentInstallPrompt,
   skillNameForSource,
 } from "../src/domains/dashboard/helpers/agent-install-prompt";
+import { coreMessagesByLocale } from "../src/i18n";
 import { fmt } from "../src/i18n/fmt";
 import { coreMessagesEn } from "../src/i18n/messages";
 
@@ -41,26 +43,81 @@ describe("agent install prompt", () => {
   });
 
   it("builds a prompt that carries the command and tells the agent not to write", () => {
+    const setupUrl = createSetupSkillUrl("https://app.busabase.com", "cloud", true, "space_target");
     const prompt = buildAgentInstallPrompt({
       source: catalogSource,
       packageName: "Kelly Email",
+      setupUrl,
+      targetSpaceId: "space_target",
       template: coreMessagesEn.install.agentPromptBody,
       fmt,
     });
     expect(prompt).toContain("npx skills add busabase/skills --skill kelly-email");
     expect(prompt).toContain("kelly-email");
+    expect(prompt).toContain("space_target");
+    expect(prompt).toContain(setupUrl);
+    expect(prompt).toContain("edition=cloud");
+    expect(prompt).toContain("editionConfirmed=1");
+    expect(prompt).toContain("space=space_target");
     expect(prompt).toMatch(/do not create, change or delete anything/i);
-    expect(prompt).not.toContain("{command}");
-    expect(prompt).not.toContain("{name}");
+    expect(prompt).not.toMatch(/\{[a-zA-Z]+\}/);
+    expect(prompt).not.toMatch(/api[_ -]?key|access[_ -]?token|secret/i);
   });
 
   it("falls back to the package name when there is no subdirectory to name", () => {
     const prompt = buildAgentInstallPrompt({
       source: { owner: "acme", repo: "crm-package" },
       packageName: "Acme CRM",
+      setupUrl: createSetupSkillUrl("http://localhost:15419", "desktop", true),
       template: coreMessagesEn.install.agentPromptBody,
       fmt,
     });
     expect(prompt).toContain("Acme CRM");
+  });
+
+  it("keeps Cloud space information out of Desktop setup guidance", () => {
+    const setupUrl = createSetupSkillUrl(
+      "http://localhost:15419",
+      "desktop",
+      true,
+      "must_not_leak",
+    );
+    const prompt = buildAgentInstallPrompt({
+      source: catalogSource,
+      packageName: "Kelly Email",
+      setupUrl,
+      template: coreMessagesEn.install.agentPromptBody,
+      fmt,
+    });
+
+    expect(prompt).toContain("edition=desktop");
+    expect(prompt).toContain("editionConfirmed=1");
+    expect(prompt).not.toContain("space=");
+    expect(prompt).not.toContain("must_not_leak");
+  });
+
+  it("resolves every connection placeholder in every supported locale", () => {
+    const setupUrl = createSetupSkillUrl(
+      "https://app.busabase.com",
+      "cloud",
+      true,
+      "space_localized",
+    );
+
+    for (const messages of Object.values(coreMessagesByLocale)) {
+      const prompt = buildAgentInstallPrompt({
+        source: catalogSource,
+        packageName: "Kelly Email",
+        setupUrl,
+        targetSpaceId: "space_localized",
+        template: messages.install.agentPromptBody,
+        fmt,
+      });
+
+      expect(prompt).toContain(setupUrl);
+      expect(prompt).toContain("space_localized");
+      expect(prompt).not.toMatch(/\{[a-zA-Z]+\}/);
+      expect(prompt).not.toMatch(/api[_ -]?key|access[_ -]?token|secret/i);
+    }
   });
 });

--- a/packages/busabase-core/tests/anonymous-allowlist.test.ts
+++ b/packages/busabase-core/tests/anonymous-allowlist.test.ts
@@ -101,12 +101,20 @@ describe("anonymous allowlist (unit)", () => {
    * the boundary moved onto the resolved node type. If this list ever grows a
    * file-tree type, that protection is gone.
    */
-  it("keeps Skills, Drives, and AirApps off the anonymous node-type surface", () => {
-    expect(anonymousAllowlistSnapshot().nodeTypes).toEqual(["base", "doc", "file", "folder"]);
+  it("keeps source nodes private while exposing every public-detail type", () => {
+    expect(anonymousAllowlistSnapshot().nodeTypes).toEqual([
+      "base",
+      "doc",
+      "file",
+      "folder",
+      "form",
+      "whiteboard",
+      "workflow",
+    ]);
     for (const type of ["skill", "drive", "airapp"]) {
       expect(isAnonymousReadableNodeType(type), `${type} must stay non-anonymous`).toBe(false);
     }
-    for (const type of ["folder", "doc", "file", "base"]) {
+    for (const type of ["folder", "doc", "file", "base", "form", "whiteboard", "workflow"]) {
       expect(isAnonymousReadableNodeType(type), `${type} must stay anonymous-readable`).toBe(true);
     }
   });
@@ -114,10 +122,7 @@ describe("anonymous allowlist (unit)", () => {
   it("fails closed on a node type nobody has decided about", () => {
     // A late `registerNodeType()` plugin type must not inherit public access.
     expect(isAnonymousReadableNodeType("brand-new-plugin-type")).toBe(false);
-    // Registered-but-undecided built-ins are refused for the same reason.
-    for (const type of ["form", "whiteboard", "workflow", "html"]) {
-      expect(isAnonymousReadableNodeType(type)).toBe(false);
-    }
+    expect(isAnonymousReadableNodeType("skill")).toBe(false);
   });
 
   it("classifies forms.submit as submit-only, never as read", () => {

--- a/packages/busabase-core/tests/dump-logic.test.ts
+++ b/packages/busabase-core/tests/dump-logic.test.ts
@@ -4,7 +4,34 @@ import path from "node:path";
 import { createRouterClient } from "@orpc/server";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { runWithBusabaseContext } from "../src/context";
+import { queryInChunks } from "../src/domains/dump/logic/import-logic";
+import { rootNodeIdForSpace } from "../src/logic/kernel";
 import { busabaseRouter } from "../src/router";
+
+describe("queryInChunks", () => {
+  it("batches a large id list instead of passing it to one query — the actual bug reproduced live: committing a real production restore with 1,080,685 fieldValues rows blew the SQL query builder's call stack building one inArray(...) with all of them", async () => {
+    const ids = Array.from({ length: 12_345 }, (_, i) => `id_${i}`);
+    const seenChunkSizes: number[] = [];
+    const rows = await queryInChunks(ids, async (idsChunk) => {
+      seenChunkSizes.push(idsChunk.length);
+      return idsChunk.map((id) => ({ id }));
+    });
+
+    expect(rows).toEqual(ids.map((id) => ({ id })));
+    expect(seenChunkSizes.every((size) => size <= 2000)).toBe(true);
+    expect(seenChunkSizes.length).toBeGreaterThan(1); // the batching path genuinely ran more than once
+  });
+
+  it("makes zero queries for an empty id list", async () => {
+    let calls = 0;
+    const rows = await queryInChunks([], async () => {
+      calls += 1;
+      return [];
+    });
+    expect(rows).toEqual([]);
+    expect(calls).toBe(0);
+  });
+});
 
 /**
  * Integration tests for the `dump` domain's business logic layer
@@ -54,12 +81,16 @@ describe("dump domain logic — oRPC integration", () => {
     await inSpace(spaceId, () =>
       client.docs.create({ autoMerge: true, slug: "seed-doc", name: "Seed Doc", body: "hi\n" }),
     );
-    await expect(inSpace(spaceId, () => client.dump.importBegin())).rejects.toThrow(/empty/i);
+    await expect(
+      inSpace(spaceId, () => client.dump.importBegin({ sourceSpaceId: spaceId })),
+    ).rejects.toThrow(/empty/i);
   });
 
   // ── importBegin succeeds on a truly empty space (only the auto-seeded root) ─
   it("importBegin succeeds on a fresh space and returns a sessionId", async () => {
-    const { sessionId } = await inSpace("space_dump_empty_begin", () => client.dump.importBegin());
+    const { sessionId } = await inSpace("space_dump_empty_begin", () =>
+      client.dump.importBegin({ sourceSpaceId: "space_dump_empty_begin" }),
+    );
     expect(sessionId).toBeTruthy();
     await inSpace("space_dump_empty_begin", () => client.dump.importAbort({ sessionId }));
   });
@@ -82,7 +113,13 @@ describe("dump domain logic — oRPC integration", () => {
     const sourceSpace = "space_dump_source_a";
     const targetSpace = "space_dump_target_a";
     const nodeId = "nod_fabricated_doc_for_import_test";
-    const fabricatedSourceRootId = "nod_root_space_dump_source_a_fabricated";
+    // A real archive's root row always has this exact deterministic id (the
+    // server now computes it from `sourceSpaceId` rather than scanning rows
+    // for "the one with a null parentId" — see the matching comment in
+    // import-logic.ts) — fabricate the same id a real export would produce,
+    // not an arbitrary one, or this test would exercise a shape no real
+    // archive can ever have.
+    const fabricatedSourceRootId = rootNodeIdForSpace(sourceSpace);
 
     // Node ids are a single GLOBAL primary key across every space in one DB
     // (not scoped per-space) — a real cross-spaceId restore only ever targets
@@ -127,7 +164,9 @@ describe("dump domain logic — oRPC integration", () => {
       },
     ];
 
-    const { sessionId } = await inSpace(targetSpace, () => client.dump.importBegin());
+    const { sessionId } = await inSpace(targetSpace, () =>
+      client.dump.importBegin({ sourceSpaceId: sourceSpace }),
+    );
 
     // nodes: exercises coerceDateColumns (createdAt/updatedAt as ISO strings on
     // the wire, coerced back to real Date before the drizzle insert), the
@@ -217,7 +256,9 @@ describe("dump domain logic — oRPC integration", () => {
   // ── importCommit integrity checks catch a deliberately-orphaned asset ──
   it("importCommit warns when an imported asset references a never-imported attachmentId", async () => {
     const targetSpace = "space_dump_orphan_asset";
-    const { sessionId } = await inSpace(targetSpace, () => client.dump.importBegin());
+    const { sessionId } = await inSpace(targetSpace, () =>
+      client.dump.importBegin({ sourceSpaceId: targetSpace }),
+    );
 
     // Import a bare `assets` row whose attachmentId was never (and will never
     // be) imported — a deliberately orphaned FK-less reference.
@@ -250,10 +291,14 @@ describe("dump domain logic — oRPC integration", () => {
   it("importTables remaps a principalType:'space' grant's principalId to the target space", async () => {
     const sourceSpace = "space_dump_np_source";
     const targetSpace = "space_dump_np_target";
-    const sourceRootId = "nod_root_np_source_fabricated";
+    // Must be the real deterministic root id a genuine export would produce —
+    // see the matching note on the earlier fabricated-root test above.
+    const sourceRootId = rootNodeIdForSpace(sourceSpace);
     const folderId = "nod_np_folder_child";
 
-    const { sessionId } = await inSpace(targetSpace, () => client.dump.importBegin());
+    const { sessionId } = await inSpace(targetSpace, () =>
+      client.dump.importBegin({ sourceSpaceId: sourceSpace }),
+    );
 
     // A source root + one child folder, exactly as they'd arrive over the wire.
     // The importer drops the source root and remaps the child onto the target's
@@ -372,7 +417,9 @@ describe("dump domain logic — oRPC integration", () => {
 
     it("a non-manager is FORBIDDEN from starting an import", async () => {
       await expect(
-        asRole("space_dump_guard", false, () => client.dump.importBegin()),
+        asRole("space_dump_guard", false, () =>
+          client.dump.importBegin({ sourceSpaceId: "space_dump_guard" }),
+        ),
       ).rejects.toThrow(/owner\/admin|access|forbidden/i);
     });
 

--- a/packages/busabase-core/tests/dump-roundtrip.test.ts
+++ b/packages/busabase-core/tests/dump-roundtrip.test.ts
@@ -214,7 +214,7 @@ describe("dump domain — full demo-seed backup round trip", () => {
     const targetClient = createRouterClient(busabaseRouter);
 
     // ── Import: begin → blobs → tables (FK order) → doc bodies → commit ──────
-    const { sessionId } = await targetClient.dump.importBegin();
+    const { sessionId } = await targetClient.dump.importBegin({ sourceSpaceId: LOCAL_SPACE_ID });
 
     const blobRows = [...sourceBlobs.entries()].map(([storageKey, blob]) => ({
       storageKey,

--- a/packages/busabase-core/tests/inbox-counts.test.ts
+++ b/packages/busabase-core/tests/inbox-counts.test.ts
@@ -2,8 +2,11 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createRouterClient } from "@orpc/server";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { LOCAL_SPACE_ID, runWithBusabaseContext } from "../src/context";
+import { getDb } from "../src/db";
+import { busabaseChangeRequests, busabaseCommits, busabaseOperations } from "../src/db/schema";
+import { filterVisibleChangeRequestRows } from "../src/logic/cr-lifecycle";
 import { busabaseRouter } from "../src/router";
 
 /**
@@ -22,6 +25,9 @@ type Client = ReturnType<typeof createRouterClient<typeof busabaseRouter, Record
 const MIGRATIONS_CWD = path.resolve(__dirname, "../../../apps/busabase");
 const MINE = "local-editor";
 const OTHER = "local-producer";
+const EXTRA_PENDING = 80;
+const ACL_BATCH_BOUNDARY_TOTAL = 5_001;
+const FIXTURE_INSERT_BATCH_SIZE = 1_000;
 
 describe("inbox counts", () => {
   let dataDir = "";
@@ -29,6 +35,54 @@ describe("inbox counts", () => {
   let originalCwd = "";
   let client: Client;
   let baseId = "";
+  let extraPendingIds: string[] = [];
+
+  const insertPendingRows = async (count: number, prefix: string) => {
+    const db = await getDb();
+    const rows = Array.from({ length: count }, (_, index) => {
+      const suffix = `${prefix}-${index}`;
+      return {
+        changeRequestId: `cr-${suffix}`,
+        commitId: `cmt-${suffix}`,
+        operationId: `op-${suffix}`,
+      };
+    });
+    for (let offset = 0; offset < rows.length; offset += FIXTURE_INSERT_BATCH_SIZE) {
+      const batch = rows.slice(offset, offset + FIXTURE_INSERT_BATCH_SIZE);
+      await db.insert(busabaseChangeRequests).values(
+        batch.map(({ changeRequestId }) => ({
+          id: changeRequestId,
+          spaceId: LOCAL_SPACE_ID,
+          baseId,
+          status: "in_review" as const,
+          submittedBy: OTHER,
+        })),
+      );
+      await db.insert(busabaseCommits).values(
+        batch.map(({ commitId, operationId }) => ({
+          id: commitId,
+          spaceId: LOCAL_SPACE_ID,
+          baseId,
+          operationId,
+          payload: {},
+          operation: "record_create" as const,
+          author: OTHER,
+        })),
+      );
+      await db.insert(busabaseOperations).values(
+        batch.map(({ changeRequestId, commitId, operationId }) => ({
+          id: operationId,
+          spaceId: LOCAL_SPACE_ID,
+          changeRequestId,
+          baseId,
+          operation: "record_create" as const,
+          headCommitId: commitId,
+          position: 0,
+        })),
+      );
+    }
+    return rows.map((row) => row.changeRequestId);
+  };
 
   beforeAll(async () => {
     originalCwd = process.cwd();
@@ -81,6 +135,10 @@ describe("inbox counts", () => {
       const id = await propose(`closed-${i}`, OTHER);
       await client.changeRequests.close({ changeRequestId: id } as never);
     }
+
+    // Cross the former 100-row count batch boundary without paying for 80
+    // complete review-first write cycles in this read-path integration test.
+    extraPendingIds = await insertPendingRows(EXTRA_PENDING, "inbox-counts-extra");
   }, 300_000);
 
   afterAll(async () => {
@@ -95,7 +153,7 @@ describe("inbox counts", () => {
   it("counts every status across the whole space, not just one page", async () => {
     const counts = await client.changeRequests.counts({} as never);
     expect(counts).toEqual({
-      review: 10, // 7 + 3 still in_review
+      review: 10 + EXTRA_PENDING, // 7 + 3 seeded through the API, plus the bulk fixture
       changes: 0,
       created: 5, // 3 pending-mine + 2 merged-mine
       approved: 5,
@@ -143,5 +201,107 @@ describe("inbox counts", () => {
       () => client.changeRequests.counts({} as never),
     );
     expect(asMember).toEqual(asManager);
+  });
+
+  it("scans candidates and operation scopes once beyond the old batch boundary", async () => {
+    const db = await getDb();
+    const selectSpy = vi.spyOn(db, "select");
+    try {
+      const counts = await runWithBusabaseContext(
+        {
+          spaceId: LOCAL_SPACE_ID,
+          actorId: MINE,
+          isSpaceManager: false,
+          permissionLevel: "manage",
+        },
+        () => client.changeRequests.counts({} as never),
+      );
+
+      const selectionKeys = selectSpy.mock.calls.map(([selection]) =>
+        Object.keys(selection ?? {})
+          .sort()
+          .join(","),
+      );
+      expect(selectionKeys.filter((keys) => keys === "id,status,submittedBy")).toHaveLength(1);
+      expect(
+        selectionKeys.filter(
+          (keys) => keys === "baseId,changeRequestId,headCommitId,nodeId,operation,position",
+        ),
+      ).toHaveLength(1);
+      expect(counts.review).toBe(10 + EXTRA_PENDING);
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  it("does not read commit scope hints for base-backed operations", async () => {
+    const db = await getDb();
+    const selectSpy = vi.spyOn(db, "select");
+    try {
+      const visibleRows = await runWithBusabaseContext(
+        {
+          spaceId: LOCAL_SPACE_ID,
+          actorId: MINE,
+          isSpaceManager: false,
+          permissionLevel: "manage",
+        },
+        () => filterVisibleChangeRequestRows(extraPendingIds.map((id) => ({ id }))),
+      );
+
+      const selectionKeys = selectSpy.mock.calls.map(([selection]) =>
+        Object.keys(selection ?? {})
+          .sort()
+          .join(","),
+      );
+      expect(
+        selectionKeys.filter(
+          (keys) => keys === "baseId,changeRequestId,headCommitId,nodeId,operation,position",
+        ),
+      ).toHaveLength(1);
+      expect(
+        selectionKeys.filter((keys) => keys === "id,parentNodeId,parentNodeRef,ref"),
+      ).toHaveLength(0);
+      expect(visibleRows).toHaveLength(EXTRA_PENDING);
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  it("caps each operation scope query at 5,000 change requests", async () => {
+    const db = await getDb();
+    const existingRows = await db
+      .select({ id: busabaseChangeRequests.id })
+      .from(busabaseChangeRequests);
+    const overflowRows = ACL_BATCH_BOUNDARY_TOTAL - existingRows.length;
+    expect(overflowRows).toBeGreaterThan(0);
+    await insertPendingRows(overflowRows, "inbox-counts-overflow");
+
+    const selectSpy = vi.spyOn(db, "select");
+    try {
+      const counts = await runWithBusabaseContext(
+        {
+          spaceId: LOCAL_SPACE_ID,
+          actorId: MINE,
+          isSpaceManager: false,
+          permissionLevel: "manage",
+        },
+        () => client.changeRequests.counts({} as never),
+      );
+
+      const selectionKeys = selectSpy.mock.calls.map(([selection]) =>
+        Object.keys(selection ?? {})
+          .sort()
+          .join(","),
+      );
+      expect(selectionKeys.filter((keys) => keys === "id,status,submittedBy")).toHaveLength(1);
+      expect(
+        selectionKeys.filter(
+          (keys) => keys === "baseId,changeRequestId,headCommitId,nodeId,operation,position",
+        ),
+      ).toHaveLength(2);
+      expect(counts.review).toBe(10 + EXTRA_PENDING + overflowRows);
+    } finally {
+      selectSpy.mockRestore();
+    }
   });
 });

--- a/packages/busabase-core/tests/nested-folder-tree.test.ts
+++ b/packages/busabase-core/tests/nested-folder-tree.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Nested demo folders + what the sidebar actually receives for them.
+ *
+ * The demo data set used to be exactly one folder level under the workspace
+ * root, so the sidebar's depth-bounded prefetch (`nodes.list({ parentId: null,
+ * depth: 2 })`) always happened to carry the entire tree and the lazy
+ * "expand this folder" path was never exercised by seeded content. The
+ * `Product Ops` branch (see `demo/scenarios/nested-folders.ts`) is 4 folder
+ * levels deep on purpose; these tests pin the shape a sidebar sees at each
+ * boundary, which is what a "clicked a second-level folder and it rendered
+ * empty" regression shows up as.
+ */
+import { createRouterClient } from "@orpc/server";
+import { describe, expect, it } from "vitest";
+import { buildDemoDataset, englishScenario } from "../src/demo/dataset";
+import {
+  NESTED_ARCHIVE_FOLDER_NODE_ID,
+  NESTED_BRAND_KIT_FOLDER_NODE_ID,
+  NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID,
+  NESTED_LAUNCH_FOLDER_NODE_ID,
+  NESTED_PRODUCT_OPS_FOLDER_NODE_ID,
+  NESTED_RETRO_FOLDER_NODE_ID,
+} from "../src/demo/scenarios/nested-folders";
+import { zhCnScenario } from "../src/demo/scenarios/zh-cn";
+import { seedScenario as applyDemoScenario } from "../src/logic/seed";
+import { busabaseRouter } from "../src/router";
+import { seedScenario } from "./helpers/seed-scenario";
+
+type RawClient = ReturnType<typeof createRouterClient<typeof busabaseRouter, Record<never, never>>>;
+
+interface TreeNode {
+  id: string;
+  type: string;
+  hasChildren?: boolean;
+  children: TreeNode[];
+}
+
+const findNode = (nodes: TreeNode[], id: string): TreeNode | undefined => {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    const nested = findNode(node.children, id);
+    if (nested) return nested;
+  }
+  return undefined;
+};
+
+describe("nested demo folders in the stateless demo dataset", () => {
+  it.each([
+    ["English", englishScenario],
+    ["Simplified Chinese", zhCnScenario],
+  ])("%s nests Product Ops four folder levels deep", (_locale, scenario) => {
+    const { nodes } = buildDemoDataset("1", new Date("2026-08-27T00:00:00Z"), scenario);
+
+    const productOps = findNode(nodes as TreeNode[], NESTED_PRODUCT_OPS_FOLDER_NODE_ID);
+    expect(productOps).toBeDefined();
+    // Subfolders sort ahead of a folder's own leaves, by position.
+    expect(productOps?.children.map((child) => child.id)).toEqual([
+      NESTED_LAUNCH_FOLDER_NODE_ID,
+      NESTED_ARCHIVE_FOLDER_NODE_ID,
+    ]);
+
+    const launch = findNode(nodes as TreeNode[], NESTED_LAUNCH_FOLDER_NODE_ID);
+    expect(launch?.children.map((child) => child.type)).toEqual(["folder", "html"]);
+
+    const brandKit = findNode(nodes as TreeNode[], NESTED_BRAND_KIT_FOLDER_NODE_ID);
+    expect(brandKit?.children.map((child) => child.type)).toEqual(["html"]);
+  });
+});
+
+describe("nested demo folders through the depth-bounded sidebar fetch", () => {
+  it("stops at the prefetch boundary, then hands the rest over on expand", async () => {
+    await seedScenario("nested-folder-tree");
+    const raw: RawClient = createRouterClient(busabaseRouter);
+    await applyDemoScenario(englishScenario);
+
+    // What the sidebar loads up front: root + 2 levels. `Product Ops` is
+    // level 1, `2026 Launch` level 2 — the deepest prefetched level, so its
+    // own children are absent and only `hasChildren` says they exist.
+    const prefetched = (await raw.nodes.list({ parentId: null, depth: 2 })) as TreeNode[];
+    const launch = findNode(prefetched, NESTED_LAUNCH_FOLDER_NODE_ID);
+    expect(launch).toBeDefined();
+    expect(launch?.children).toEqual([]);
+    expect(launch?.hasChildren).toBe(true);
+    // Nothing below level 2 came back — this is precisely the state in which
+    // the sidebar has to ask for more.
+    expect(findNode(prefetched, NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID)).toBeUndefined();
+
+    // The lazy expand a click on `2026 Launch` triggers.
+    const expanded = (await raw.nodes.list({
+      parentId: NESTED_LAUNCH_FOLDER_NODE_ID,
+      depth: 2,
+    })) as TreeNode[];
+    expect(expanded.map((node) => node.id)).toContain(NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID);
+    // Two more levels arrive with it, so `Brand Kit` is already visible…
+    const brandKit = findNode(expanded, NESTED_BRAND_KIT_FOLDER_NODE_ID);
+    expect(brandKit).toBeDefined();
+    // …and it is itself a depth boundary that still declares its own children.
+    expect(brandKit?.children).toEqual([]);
+    expect(brandKit?.hasChildren).toBe(true);
+
+    // The second lazy expand, one level deeper.
+    const deepest = (await raw.nodes.list({
+      parentId: NESTED_BRAND_KIT_FOLDER_NODE_ID,
+      depth: 2,
+    })) as TreeNode[];
+    expect(deepest.map((node) => node.type)).toEqual(["html"]);
+  });
+});
+
+describe("nodes.ancestors — what the sidebar needs on a cold deep load", () => {
+  it("returns the full chain root-first, by id and by slug, and [] at the top", async () => {
+    await seedScenario("nested-folder-ancestors");
+    const raw: RawClient = createRouterClient(busabaseRouter);
+    await applyDemoScenario(englishScenario);
+
+    // The whole point: one call, from the deepest node, naming every folder
+    // that has to be expanded — none of which the sidebar has fetched yet.
+    const deep = await raw.nodes.ancestors({ nodeId: NESTED_BRAND_KIT_FOLDER_NODE_ID });
+    expect(deep.ancestorIds).toEqual([
+      NESTED_PRODUCT_OPS_FOLDER_NODE_ID,
+      NESTED_LAUNCH_FOLDER_NODE_ID,
+      NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID,
+    ]);
+
+    // A slug is what actually appears in the url the sidebar reads, so the
+    // slug path must resolve identically to the id path.
+    const bySlug = await raw.nodes.ancestors({ nodeId: "brand-kit" });
+    expect(bySlug.ancestorIds).toEqual(deep.ancestorIds);
+
+    // A leaf (non-folder) node resolves too — its chain is its folders.
+    const leaf = await raw.nodes.ancestors({ nodeId: "launch-one-pager" });
+    expect(leaf.ancestorIds).toEqual([
+      NESTED_PRODUCT_OPS_FOLDER_NODE_ID,
+      NESTED_LAUNCH_FOLDER_NODE_ID,
+      NESTED_LAUNCH_ASSETS_FOLDER_NODE_ID,
+      NESTED_BRAND_KIT_FOLDER_NODE_ID,
+    ]);
+
+    // A sibling branch does not leak into another's chain.
+    const retro = await raw.nodes.ancestors({ nodeId: NESTED_RETRO_FOLDER_NODE_ID });
+    expect(retro.ancestorIds).toEqual([
+      NESTED_PRODUCT_OPS_FOLDER_NODE_ID,
+      NESTED_ARCHIVE_FOLDER_NODE_ID,
+    ]);
+
+    // A top-level folder sits directly under the workspace root, which the
+    // sidebar strips — so there is nothing for it to expand.
+    const top = await raw.nodes.ancestors({ nodeId: NESTED_PRODUCT_OPS_FOLDER_NODE_ID });
+    expect(top.ancestorIds).toEqual([]);
+  });
+});

--- a/packages/busabase-core/tests/node-content-search.test.ts
+++ b/packages/busabase-core/tests/node-content-search.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Node content search (`search({ sources: ["nodes"] })`) — the human-facing
+ * counterpart to grep's `nodes` source.
+ *
+ * The gap these cover: before this feature a user could not find a Doc by a
+ * phrase in its body, only by its title, while an agent's `grep` found it
+ * immediately. Driven through the real oRPC router (real temp PGLite + real
+ * local storage), same harness as `unified-grep.test.ts`.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createRouterClient } from "@orpc/server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { VALUE_TEXT_INDEX_LIMIT } from "../src/logic/vo";
+import { busabaseRouter } from "../src/router";
+
+type Client = ReturnType<typeof createRouterClient<typeof busabaseRouter, Record<never, never>>>;
+const MIGRATIONS_CWD = path.resolve(__dirname, "../../../apps/busabase");
+
+describe("Node content search", () => {
+  let dataDir = "";
+  let storageDir = "";
+  let originalCwd = "";
+  let client: Client;
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    process.chdir(MIGRATIONS_CWD);
+    dataDir = await mkdtemp(path.join(os.tmpdir(), "busabase-nodesearch-db-"));
+    storageDir = await mkdtemp(path.join(os.tmpdir(), "busabase-nodesearch-storage-"));
+    process.env.PG_DATABASE_URL = `pglite://${dataDir}`;
+    process.env.STORAGE_URL = `local:${storageDir}?base_url=/api/test/storage`;
+    client = createRouterClient(busabaseRouter);
+  }, 300_000);
+
+  afterAll(async () => {
+    delete process.env.PG_DATABASE_URL;
+    delete process.env.STORAGE_URL;
+    if (originalCwd) process.chdir(originalCwd);
+    for (const dir of [dataDir, storageDir]) {
+      if (dir) await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  const seedDoc = async (slug: string, name: string, body: string) => {
+    const doc = await client.docs.create({ autoMerge: true, slug, name, body });
+    if (!("node" in doc)) throw new Error("expected a materialized DocVO");
+    return doc.node.id;
+  };
+
+  const seedRich = async (
+    nodeType: "html" | "whiteboard" | "workflow",
+    slug: string,
+    content: Parameters<Client["nodes"]["updateContent"]>[0]["content"],
+  ) => {
+    const rootId = (await client.nodes.list({}))[0]?.id ?? "";
+    await client.nodes.createChangeRequest({
+      autoMerge: true,
+      operations: [{ kind: "create", parentNodeId: rootId, nodeType, slug, name: slug }],
+    });
+    const flatten = (e: Awaited<ReturnType<Client["nodes"]["list"]>>): typeof e =>
+      e.flatMap((x) => [x, ...flatten(x.children)]);
+    const nodeId = flatten(await client.nodes.list({})).find((n) => n.slug === slug)?.id ?? "";
+    expect(nodeId).not.toBe("");
+    await client.nodes.updateContent({ nodeId, content, autoMerge: true });
+    return nodeId;
+  };
+
+  const searchNodes = (query: string) =>
+    client.search({ query, limit: 20, offset: 0, sources: ["nodes"] });
+
+  it("finds a Doc by a phrase in its BODY, not just its title", async () => {
+    // The exact shape of the original complaint: the phrase is in the body and
+    // deliberately NOT in the title, so a title-only search cannot find it.
+    const nodeId = await seedDoc(
+      "pricing-plan",
+      "Q3 Planning",
+      "# Notes\n\nOur BODYNEEDLE strategy for the launch.\n",
+    );
+
+    const result = await searchNodes("BODYNEEDLE");
+    const hit = result.results.find((r) => r.id === nodeId);
+    expect(hit, "the Doc containing the phrase must be found").toBeDefined();
+    expect(hit?.kind).toBe("node");
+    expect(hit?.title).toBe("Q3 Planning");
+    // A snippet, so a user can tell near-identical docs apart (spec S1).
+    expect(hit?.body).toContain("BODYNEEDLE");
+  });
+
+  it("agrees with grep: the same phrase is found by both surfaces", async () => {
+    const nodeId = await seedDoc("parity-doc", "Parity", "PARITYNEEDLE lives here\n");
+    const [searched, grepped] = await Promise.all([
+      searchNodes("PARITYNEEDLE"),
+      client.grep({ pattern: "PARITYNEEDLE", sources: ["nodes"] }),
+    ]);
+    expect(searched.results.some((r) => r.id === nodeId)).toBe(true);
+    expect(
+      grepped.matches.some((m) => m.source === "nodes" && m.nodeId === nodeId),
+      "search and grep must not disagree about what the workspace contains",
+    ).toBe(true);
+  });
+
+  it("finds html source text", async () => {
+    const nodeId = await seedRich("html", "pricing-page", {
+      kind: "html",
+      document: { version: 1, source: "<html><body><h1>HTMLBODYNEEDLE</h1></body></html>\n" },
+    });
+    const result = await searchNodes("HTMLBODYNEEDLE");
+    expect(result.results.some((r) => r.id === nodeId)).toBe(true);
+  });
+
+  it("finds whiteboard text without matching Excalidraw's JSON keys", async () => {
+    const nodeId = await seedRich("whiteboard", "launch-board", {
+      kind: "whiteboard",
+      document: {
+        version: 1,
+        elements: [
+          {
+            id: "t1",
+            type: "text",
+            isDeleted: false,
+            strokeColor: "#0f172a",
+            originalText: "BOARDBODYNEEDLE plan",
+          },
+        ],
+        appState: {},
+      },
+    });
+
+    expect((await searchNodes("BOARDBODYNEEDLE")).results.some((r) => r.id === nodeId)).toBe(true);
+
+    // The whole reason extraction exists: a structural key that IS present in
+    // the stored object must not be searchable.
+    const noise = await searchNodes("strokeColor");
+    expect(noise.results.some((r) => r.id === nodeId)).toBe(false);
+  });
+
+  it("makes an approved edit searchable immediately — no indexing lag", async () => {
+    const nodeId = await seedDoc("fresh-doc", "Fresh", "before the edit\n");
+    await client.nodes.updateContent({
+      nodeId,
+      autoMerge: true,
+      content: { kind: "doc", body: "FRESHNEEDLE after the edit\n" },
+    });
+    // No sleep, no polling: the projection is written in the merge transaction.
+    const result = await searchNodes("FRESHNEEDLE");
+    expect(result.results.some((r) => r.id === nodeId)).toBe(true);
+  });
+
+  it("stops finding content that was edited away", async () => {
+    const nodeId = await seedDoc("stale-doc", "Stale", "GONENEEDLE is here\n");
+    expect((await searchNodes("GONENEEDLE")).results.some((r) => r.id === nodeId)).toBe(true);
+    await client.nodes.updateContent({
+      nodeId,
+      autoMerge: true,
+      content: { kind: "doc", body: "the phrase is gone now\n" },
+    });
+    expect((await searchNodes("GONENEEDLE")).results.some((r) => r.id === nodeId)).toBe(false);
+  });
+
+  it("does not index an unapproved ChangeRequest's content", async () => {
+    const nodeId = await seedDoc("pending-doc", "Pending", "approved text only\n");
+    const cr = await client.nodes.updateContent({
+      nodeId,
+      autoMerge: false, // review-first: never merged below
+      content: { kind: "doc", body: "PENDINGNEEDLE not approved\n" },
+    });
+    expect(cr.status).toBe("in_review");
+    // Search reflects the APPROVED state of the workspace (spec S5).
+    expect((await searchNodes("PENDINGNEEDLE")).results).toHaveLength(0);
+  });
+
+  it("excludes an archived node's content", async () => {
+    const nodeId = await seedDoc("archived-doc", "Archived", "ARCHIVEDNEEDLE here\n");
+    expect((await searchNodes("ARCHIVEDNEEDLE")).results.some((r) => r.id === nodeId)).toBe(true);
+
+    const cr = await client.nodes.createChangeRequest({
+      operations: [{ kind: "delete", nodeId }],
+      autoMerge: false,
+    });
+    await client.changeRequests.review({ changeRequestIds: [cr.id], verdict: "approved" });
+    await client.changeRequests.merge({ changeRequestIds: [cr.id] });
+
+    expect((await searchNodes("ARCHIVEDNEEDLE")).results.some((r) => r.id === nodeId)).toBe(false);
+  });
+
+  it("reports contentTruncated so an empty result is never misread as absence", async () => {
+    // Past the projection cap by construction.
+    const filler = "x".repeat(VALUE_TEXT_INDEX_LIMIT + 500);
+    const nodeId = await seedDoc("long-doc", "Long", `${filler}\nTAILNEEDLE past the cap\n`);
+
+    const result = await searchNodes("TAILNEEDLE");
+    // The term itself is beyond the cap, so it is genuinely not findable...
+    expect(result.results.some((r) => r.id === nodeId)).toBe(false);
+    // ...but the caller is TOLD coverage was partial rather than being left to
+    // conclude the workspace does not contain it (spec D2b / Principle #1).
+    expect(result.contentTruncated).toBe(true);
+  });
+
+  it("finds Chinese content — which rides entirely on the trigram/ilike branch", async () => {
+    // Postgres has no CJK segmenter: `to_tsvector('simple', …)` turns a whole
+    // Chinese run into ONE oversized lexeme, so the tsvector branch scores zero
+    // here and the ilike branch is what actually works (spec D2a). If someone
+    // ever "optimizes away" that branch or its trigram index, this goes red.
+    const nodeId = await seedDoc("zh-doc", "中文文档", "我们的定价策略与上线计划的评审记录。\n");
+    const result = await searchNodes("定价策略");
+    expect(result.results.some((r) => r.id === nodeId)).toBe(true);
+  });
+
+  // ── Pre-existing content (the upgrade path) ───────────────────────────────
+  // Every node that existed before this feature shipped has no projection row.
+  // Deleting the row simulates exactly that state, because it is the same
+  // state: a content-bearing node whose content is in storage and whose
+  // projection is absent.
+
+  it("indexes a node that predates the feature — deleting its row is the upgrade state", async () => {
+    const nodeId = await seedDoc("legacy-doc", "Legacy", "LEGACYNEEDLE written long ago\n");
+    expect((await searchNodes("LEGACYNEEDLE")).results.some((r) => r.id === nodeId)).toBe(true);
+
+    // Wipe the projection: this node is now indistinguishable from one created
+    // before busabase_node_content_search existed.
+    const { getDb } = await import("../src/db");
+    const { busabaseNodeContentSearch } = await import("../src/db/schema");
+    const { eq } = await import("drizzle-orm");
+    const db = await getDb();
+    await db.delete(busabaseNodeContentSearch).where(eq(busabaseNodeContentSearch.nodeId, nodeId));
+    const [gone] = await db
+      .select()
+      .from(busabaseNodeContentSearch)
+      .where(eq(busabaseNodeContentSearch.nodeId, nodeId));
+    expect(gone, "projection row must really be gone before we test the heal").toBeUndefined();
+
+    // Searching re-indexes it from storage. No migration, no operator step:
+    // the search that would have missed it is the one that repairs it.
+    const healed = await searchNodes("LEGACYNEEDLE");
+    expect(healed.results.some((r) => r.id === nodeId)).toBe(true);
+
+    const [row] = await db
+      .select()
+      .from(busabaseNodeContentSearch)
+      .where(eq(busabaseNodeContentSearch.nodeId, nodeId));
+    expect(row?.contentText).toContain("LEGACYNEEDLE");
+  });
+
+  it("does not return node content when the caller did not ask for that source", async () => {
+    const nodeId = await seedDoc("scoped-doc", "Scoped", "SCOPEDNEEDLE body\n");
+    const recordsOnly = await client.search({
+      query: "SCOPEDNEEDLE",
+      limit: 20,
+      offset: 0,
+      sources: ["records"],
+    });
+    expect(recordsOnly.results.some((r) => r.id === nodeId)).toBe(false);
+  });
+});

--- a/packages/busabase-core/tests/openapi-record-get-routes.test.ts
+++ b/packages/busabase-core/tests/openapi-record-get-routes.test.ts
@@ -144,6 +144,10 @@ describe("Busabase OpenAPI record get route", () => {
     // Embed-link create/list/revoke now belong to this shared contract so
     // Desktop can execute them directly and Cloud can forward the same paths
     // to a remote tunnel (+3 -> 107).
-    expect(operationCount).toBe(107);
+    // `GET /nodes/{nodeId}/ancestors` added (+1 -> 108). Public for the same
+    // reason `nodes.list` is — it returns ids from the tree the caller can
+    // already read, under the same node-visibility ACL — and it is what lets a
+    // depth-bounded sidebar open straight to a deep node on a cold load.
+    expect(operationCount).toBe(108);
   });
 });

--- a/packages/busabase-core/tests/rich-node-content-orpc.test.ts
+++ b/packages/busabase-core/tests/rich-node-content-orpc.test.ts
@@ -5,7 +5,8 @@ import { createRouterClient } from "@orpc/server";
 import type { WhiteboardDocument } from "busabase-contract/domains/rich-node/types";
 import { storage } from "openlib/storage";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { LOCAL_SPACE_ID, runWithBusabaseContext } from "../src/context";
+import { LOCAL_SPACE_ID, runWithAnonymousContext, runWithBusabaseContext } from "../src/context";
+import { disableNodeShare, setNodeShare } from "../src/logic/node-share";
 import { busabaseRouter } from "../src/router";
 
 /**
@@ -107,6 +108,23 @@ describe("nodes.updateContent — whiteboard (real oRPC + PGLite + storage)", ()
     const detail = await raw.nodes.get({ nodeId: whiteboardNodeId, type: "whiteboard" });
     if (detail.type !== "whiteboard") throw new Error("expected a whiteboard detail");
     expect(detail.document.elements).toEqual([]);
+  });
+
+  it("hydrates a publicly shared whiteboard for an anonymous visitor", async () => {
+    await asManager("alice", () =>
+      setNodeShare(whiteboardNodeId, { scope: "public", capability: "read" }),
+    );
+    try {
+      const detail = await runWithAnonymousContext({ spaceId: LOCAL_SPACE_ID }, () =>
+        raw.nodes.get({ nodeId: whiteboardNodeId, type: "whiteboard" }),
+      );
+      expect(detail.type).toBe("whiteboard");
+      if (detail.type !== "whiteboard") throw new Error("expected a whiteboard detail");
+      expect(detail.node.id).toBe(whiteboardNodeId);
+      expect(detail.document.elements).toEqual([]);
+    } finally {
+      await asManager("alice", () => disableNodeShare(whiteboardNodeId));
+    }
   });
 
   it("a changeRequest-level actor's edit stays pending (in_review), canvas unchanged", async () => {

--- a/packages/busabase-core/tests/rich-node-demo-seed.test.ts
+++ b/packages/busabase-core/tests/rich-node-demo-seed.test.ts
@@ -24,7 +24,12 @@ describe.each([
       expectedTypes.includes(node.type as (typeof expectedTypes)[number]),
     );
 
-    expect(richNodes.map((node) => node.type).sort()).toEqual([...expectedTypes].sort());
+    // Deduped: the point is that every rich-node type is represented (and that
+    // no unexpected type sneaks in), not how many nodes of each the demo ships
+    // — several folders now carry an `html` node.
+    expect([...new Set(richNodes.map((node) => node.type))].sort()).toEqual(
+      [...expectedTypes].sort(),
+    );
     expect(
       parseWhiteboardDocument(
         richNodes.find((node) => node.type === "whiteboard")?.metadata.whiteboardDocument,
@@ -47,8 +52,9 @@ describe.each([
       ]),
     );
     expect(
-      parseHtmlDocument(richNodes.find((node) => node.type === "html")?.metadata.htmlDocument)
-        .source,
+      parseHtmlDocument(
+        richNodes.find((node) => node.id === "nod_html_waitlist_form")?.metadata.htmlDocument,
+      ).source,
     ).toContain("<form");
   });
 });

--- a/packages/busabase-core/tests/seed-file-tree-existing-folder.test.ts
+++ b/packages/busabase-core/tests/seed-file-tree-existing-folder.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { LOCAL_SPACE_ID } from "../src/context";
+import { getDb } from "../src/db";
+import { busabaseNodes } from "../src/db/schema";
+import { englishScenario } from "../src/demo/dataset";
+import { ensureReady, seedScenario } from "../src/logic/store";
+
+const MIGRATIONS_CWD = path.resolve(__dirname, "../../../apps/busabase");
+const EXISTING_SKILLS_FOLDER_ID = "nod_existing_skills";
+const OTHER_SPACE_SKILLS_FOLDER_ID = "nod_other_space_skills";
+
+describe("file-tree seed folder adoption", () => {
+  let dataDir = "";
+  let storageDir = "";
+  let originalCwd = "";
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    process.chdir(MIGRATIONS_CWD);
+    dataDir = await mkdtemp(path.join(os.tmpdir(), "busabase-file-tree-seed-db-"));
+    storageDir = await mkdtemp(path.join(os.tmpdir(), "busabase-file-tree-seed-storage-"));
+    process.env.PG_DATABASE_URL = `pglite://${dataDir}`;
+    process.env.STORAGE_URL = `local:${storageDir}?base_url=/api/test/storage`;
+
+    await ensureReady();
+    const db = await getDb();
+    const createdAt = new Date("2026-08-28T00:00:00.000Z");
+    await db.insert(busabaseNodes).values([
+      {
+        id: OTHER_SPACE_SKILLS_FOLDER_ID,
+        spaceId: "other-space",
+        parentId: null,
+        type: "folder",
+        slug: "skills",
+        name: "Other workspace skills",
+        description: "Must not be adopted by the local seed.",
+        position: 1,
+        createdAt,
+        updatedAt: createdAt,
+      },
+      {
+        id: EXISTING_SKILLS_FOLDER_ID,
+        parentId: "nod_root",
+        type: "folder",
+        slug: "skills",
+        name: "Existing Agent Skills",
+        description: "Production folder created before the canonical seed id existed.",
+        position: 1,
+        createdAt,
+        updatedAt: createdAt,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    delete process.env.PG_DATABASE_URL;
+    delete process.env.STORAGE_URL;
+    process.chdir(originalCwd);
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(storageDir, { recursive: true, force: true });
+  });
+
+  it("reuses the active same-space folder and remains idempotent", async () => {
+    await seedScenario(englishScenario);
+    const db = await getDb();
+
+    const localSkillsFolders = await db
+      .select({ id: busabaseNodes.id })
+      .from(busabaseNodes)
+      .where(
+        and(
+          eq(busabaseNodes.spaceId, LOCAL_SPACE_ID),
+          eq(busabaseNodes.type, "folder"),
+          eq(busabaseNodes.slug, "skills"),
+        ),
+      );
+    expect(localSkillsFolders).toEqual([{ id: EXISTING_SKILLS_FOLDER_ID }]);
+
+    const [seededSkill] = await db
+      .select({ parentId: busabaseNodes.parentId })
+      .from(busabaseNodes)
+      .where(eq(busabaseNodes.id, "nod_skill_ai_research_editor"))
+      .limit(1);
+    expect(seededSkill?.parentId).toBe(EXISTING_SKILLS_FOLDER_ID);
+
+    const [otherSpaceFolder] = await db
+      .select({ name: busabaseNodes.name })
+      .from(busabaseNodes)
+      .where(eq(busabaseNodes.id, OTHER_SPACE_SKILLS_FOLDER_ID))
+      .limit(1);
+    expect(otherSpaceFolder?.name).toBe("Other workspace skills");
+
+    const nodeCountBeforeRerun = (await db.select({ id: busabaseNodes.id }).from(busabaseNodes))
+      .length;
+    await seedScenario(englishScenario);
+    const nodeCountAfterRerun = (await db.select({ id: busabaseNodes.id }).from(busabaseNodes))
+      .length;
+    expect(nodeCountAfterRerun).toBe(nodeCountBeforeRerun);
+
+    const [seededSkillAfterRerun] = await db
+      .select({ parentId: busabaseNodes.parentId })
+      .from(busabaseNodes)
+      .where(eq(busabaseNodes.id, "nod_skill_ai_research_editor"))
+      .limit(1);
+    expect(seededSkillAfterRerun?.parentId).toBe(EXISTING_SKILLS_FOLDER_ID);
+  }, 60_000);
+});

--- a/packages/busabase-core/tests/template-screenshot-showcase.test.ts
+++ b/packages/busabase-core/tests/template-screenshot-showcase.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { isScreenshotQuarterTurn } from "../src/domains/templates/components/template-detail-image";
+import {
+  adjustScreenshotZoom,
+  clampScreenshotIndex,
+  clampScreenshotZoom,
+  getScreenshotDownloadName,
+  rotateScreenshotClockwise,
+} from "../src/domains/templates/components/template-screenshot-showcase";
+
+describe("clampScreenshotIndex", () => {
+  it("keeps screenshot navigation inside the available range", () => {
+    expect(clampScreenshotIndex(-1, 2)).toBe(0);
+    expect(clampScreenshotIndex(1, 2)).toBe(1);
+    expect(clampScreenshotIndex(2, 2)).toBe(1);
+    expect(clampScreenshotIndex(0, 0)).toBe(0);
+  });
+});
+
+describe("template screenshot preview tools", () => {
+  it("clamps zoom between 50% and 300%", () => {
+    expect(clampScreenshotZoom(25)).toBe(50);
+    expect(clampScreenshotZoom(125)).toBe(125);
+    expect(clampScreenshotZoom(325)).toBe(300);
+  });
+
+  it("adjusts zoom in 25% steps without crossing its bounds", () => {
+    expect(adjustScreenshotZoom(100, 1)).toBe(125);
+    expect(adjustScreenshotZoom(50, -1)).toBe(50);
+    expect(adjustScreenshotZoom(300, 1)).toBe(300);
+  });
+
+  it("rotates clockwise in 90 degree steps", () => {
+    expect(rotateScreenshotClockwise(0)).toBe(90);
+    expect(rotateScreenshotClockwise(270)).toBe(0);
+  });
+
+  it("swaps fit constraints for quarter turns", () => {
+    expect(isScreenshotQuarterTurn(0)).toBe(false);
+    expect(isScreenshotQuarterTurn(90)).toBe(true);
+    expect(isScreenshotQuarterTurn(180)).toBe(false);
+    expect(isScreenshotQuarterTurn(270)).toBe(true);
+  });
+
+  it("keeps a remote filename and falls back for malformed URLs", () => {
+    expect(getScreenshotDownloadName("https://example.com/gallery/CRM%20Overview.png?v=2", 0)).toBe(
+      "CRM Overview.png",
+    );
+    expect(getScreenshotDownloadName("not a valid URL", 2)).toBe("template-screenshot-3.png");
+  });
+});

--- a/packages/busabase-core/vitest.config.ts
+++ b/packages/busabase-core/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       "src/domains/dashboard/components/**/*.test.tsx",
       "src/domains/embed-links/**/*.test.ts",
       "src/domains/rich-node/utils/**/*.test.ts",
+      "src/domains/templates/components/**/*.test.tsx",
       "src/logic/**/*.test.ts",
     ],
     // DB-heavy oRPC/PGLite integration tests exceed vitest's 5s default on cold

--- a/packages/busabase-package/package.json
+++ b/packages/busabase-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-package",
-  "description": "The `busabase-package@1` format: GitHub source, layout read/write, install planning, and the five-pass apply. Shared by busabase-cli (`install` / `export`) and busabase-core's server-side install domain. Node-only APIs are fine here — it is never browser-bundled.",
-  "version": "0.20.0",
+  "description": "The `busabase-package@1` format: GitHub source, layout read/write, install planning, and the five-pass apply. Shared by busabase-cli (`install` / `export`) and busabase-core's server-side install domain. Node-only APIs are fine here \u2014 it is never browser-bundled.",
+  "version": "0.21.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/packages/busabase-package",
@@ -18,6 +18,10 @@
       "./apply": {
         "types": "./dist/apply.d.ts",
         "default": "./dist/apply.js"
+      },
+      "./audit": {
+        "types": "./dist/audit.d.ts",
+        "default": "./dist/audit.js"
       },
       "./client": {
         "types": "./dist/client.d.ts",
@@ -72,6 +76,10 @@
     "./apply": {
       "types": "./src/apply.ts",
       "default": "./src/apply.ts"
+    },
+    "./audit": {
+      "types": "./src/audit.ts",
+      "default": "./src/audit.ts"
     },
     "./client": {
       "types": "./src/client.ts",

--- a/packages/busabase-package/src/audit.test.ts
+++ b/packages/busabase-package/src/audit.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Each case starts from one valid package and breaks exactly one thing, so every
+ * rule is shown to fire rather than merely shown not to crash.
+ *
+ * The other half matters just as much: `auditPackage` and `auditSkill` must stay
+ * silent on things `validateTemplate` already owns. Duplicating a rule across the two
+ * would mean one of them eventually disagrees with the other.
+ */
+import { describe, expect, it } from "vitest";
+
+import { auditPackage, auditSkill } from "./audit";
+import { type PackageFiles, readPackageTree } from "./layout-read";
+
+const NAME = "fixture-desk";
+
+const SKILL_MD = `---
+name: ${NAME}
+description: "A fixture: does nothing, correctly."
+metadata:
+  busabase:
+    template: true
+    resources:
+      - reviews
+---
+
+# Fixture Desk
+
+Read \`references/taxonomy.md\` before classifying anything.
+`;
+
+const MANIFEST = {
+  format: "busabase-package@1",
+  name: NAME,
+  description: "A fixture.",
+  version: "1.0.0",
+  template: {
+    category: "ops",
+    screenshots: ["assets/screenshots/overview.webp"],
+    agentPrompts: ["Show me what is waiting for review."],
+  },
+};
+
+const BASE = { name: "Reviews", description: "Review items", position: 0, fields: [], views: [] };
+
+const files = (overrides: Record<string, string | null> = {}): PackageFiles => {
+  const base: Record<string, string> = {
+    "SKILL.md": SKILL_MD,
+    "references/taxonomy.md": "# Taxonomy\n",
+    "busabase.json": JSON.stringify(MANIFEST),
+    "assets/screenshots/overview.webp": "not really a webp",
+    "content/_folder.json": JSON.stringify({ name: "Fixture Desk" }),
+    "content/reviews/base.json": JSON.stringify(BASE),
+    "content/reviews/records.ndjson": `${JSON.stringify({ key: "r1", fields: { name: "Hi" } })}\n`,
+  };
+  const map: PackageFiles = new Map();
+  for (const [path, contents] of Object.entries({ ...base, ...overrides })) {
+    if (contents === null) continue;
+    map.set(path, Buffer.from(contents));
+  }
+  return map;
+};
+
+const audit = (
+  overrides: Record<string, string | null> = {},
+  options: { directoryName?: string } = { directoryName: NAME },
+) => {
+  const map = files(overrides);
+  const tree = readPackageTree(map);
+  return [...auditPackage(tree, map, options), ...auditSkill(map, options)];
+};
+
+const rules = (findings: ReturnType<typeof audit>, severity: "error" | "warning" = "error") =>
+  findings.filter((finding) => finding.severity === severity).map((finding) => finding.rule);
+
+describe("a package fit to publish", () => {
+  it("reports no errors", () => {
+    expect(rules(audit())).toEqual([]);
+  });
+
+  it("reports no warnings either, so warnings stay meaningful", () => {
+    expect(rules(audit(), "warning")).toEqual([]);
+  });
+
+  it("skips the identity rule when the directory name was not supplied", () => {
+    expect(rules(audit({}, {}))).toEqual([]);
+  });
+});
+
+describe("identity and the catalog card", () => {
+  it("catches a directory name that drifted from the manifest", () => {
+    expect(rules(audit({}, { directoryName: "renamed" }))).toContain("package/identity");
+  });
+
+  /**
+   * Deliberately an audit rule and not a `validateTemplate` hard condition: promoting
+   * it would stop a template installing over a missing image.
+   */
+  it("catches a declared screenshot that is not in the package", () => {
+    expect(rules(audit({ "assets/screenshots/overview.webp": null }))).toContain(
+      "package/screenshot-missing",
+    );
+  });
+});
+
+describe("what must never be published", () => {
+  it("catches a committed .env", () => {
+    expect(rules(audit({ "content/reviews/.env": "KEY=live" }))).toContain("package/dotenv");
+  });
+
+  it("allows a .env.example", () => {
+    expect(rules(audit({ ".env.example": "KEY=" }))).not.toContain("package/dotenv");
+  });
+
+  it("catches key material", () => {
+    expect(rules(audit({ "server.pem": "-----BEGIN" }))).toContain("package/key-material");
+  });
+
+  it("catches a materialized workspace id", () => {
+    const contents = JSON.stringify({ ...MANIFEST, description: "node nodmf3k29ax7b2q1z9" });
+    expect(rules(audit({ "busabase.json": contents }))).toContain("package/workspace-ids");
+  });
+
+  it("does not mistake an ordinary word for an id", () => {
+    const contents = JSON.stringify({
+      ...MANIFEST,
+      description: "recommendations and comparisons",
+    });
+    expect(rules(audit({ "busabase.json": contents }))).not.toContain("package/workspace-ids");
+  });
+
+  /**
+   * A file that asserts a string is absent necessarily contains it. Scanning those
+   * turns a correctly-guarded package into a failure.
+   */
+  it("does not scan a check script for what it forbids", () => {
+    const check = 'if (/nodmf3k29ax7b2q1z9/.test(source)) throw new Error("id leaked");\n';
+    expect(rules(audit({ "scripts/check.mjs": check }))).not.toContain("package/workspace-ids");
+  });
+
+  it("warns about committed build output", () => {
+    expect(rules(audit({ "content/reviews/dist/bundle.js": "x" }), "warning")).toContain(
+      "package/build-output",
+    );
+  });
+});
+
+describe("the manual an agent acts on", () => {
+  it("catches an unfinished export draft", () => {
+    const skill = SKILL_MD.replace("# Fixture Desk", "# Fixture Desk\n\nTODO: describe the job.");
+    expect(rules(audit({ "SKILL.md": skill }))).toContain("skill/todo");
+  });
+
+  it("catches an empty description, which is a Skill that never gets picked", () => {
+    const skill = SKILL_MD.replace(
+      'description: "A fixture: does nothing, correctly."',
+      'description: ""',
+    );
+    expect(rules(audit({ "SKILL.md": skill }))).toContain("skill/description");
+  });
+
+  it("warns about a reference the package does not ship", () => {
+    expect(rules(audit({ "references/taxonomy.md": null }), "warning")).toContain(
+      "skill/missing-reference",
+    );
+  });
+
+  it("reports nothing for a plain package with no manual", () => {
+    const map = files({ "SKILL.md": null, "references/taxonomy.md": null });
+    expect(auditSkill(map)).toEqual([]);
+  });
+});
+
+/**
+ * The split these two functions exist to preserve. `validateTemplate` classifies —
+ * its verdict changes what install does, so four consumers must agree on it. The
+ * audit advises. A rule living in both eventually means the two disagree.
+ */
+describe("no overlap with validateTemplate", () => {
+  it("leaves a resource the manual invented to validateTemplate", () => {
+    const skill = SKILL_MD.replace("- reviews", "- invoices");
+    const reported = rules(audit({ "SKILL.md": skill }));
+    expect(reported).not.toContain("resources/declared-missing");
+    expect(reported).toEqual([]);
+  });
+
+  it("leaves name agreement between manifest and manual to validateTemplate", () => {
+    const skill = SKILL_MD.replace(`name: ${NAME}`, "name: something-else");
+    // The directory still matches the manifest, so the audit's own identity rule is silent.
+    expect(rules(audit({ "SKILL.md": skill }))).toEqual([]);
+  });
+});

--- a/packages/busabase-package/src/audit.ts
+++ b/packages/busabase-package/src/audit.ts
@@ -1,0 +1,257 @@
+/**
+ * Is this package **fit to publish**?
+ *
+ * Deliberately a different question from {@link validateTemplate}, and the split is
+ * the point rather than an organisational preference:
+ *
+ * - `validateTemplate` **classifies**. Its verdict changes what install *does* — a
+ *   Skill node, ownership stamps and a sample merge, versus a plain package install.
+ *   Four consumers must agree on it or the catalog lies about what an install does,
+ *   so it stays small and stable.
+ * - `auditPackage` / `auditSkill` **advise**. Nothing behaves differently based on
+ *   their verdict; they exist for the author and the reviewer, and are free to grow.
+ *
+ * The practical consequence: a declared screenshot that is not on disk belongs here,
+ * never in `validateTemplate`. Promoting it there would stop a template installing
+ * over a missing image, which is the wrong lever entirely.
+ *
+ * Nothing here re-checks what `validateTemplate` already decides (declared resources,
+ * the sample-row ceiling, name agreement between manifest and manual, an unambiguous
+ * primary AirApp). Run both; they compose.
+ *
+ * Purely static: no install, no network, and none of the package's own code is
+ * executed — safe to run in CI over a pull request from someone you do not know.
+ */
+
+import {
+  PACKAGE_SKILL_ENTRY,
+  PACKAGE_SKILL_SIDECAR_DIRS,
+} from "busabase-contract/domains/package/template";
+import { SkillFrontmatterSchema } from "busabase-contract/domains/skill/frontmatter";
+
+import { parseFrontmatter } from "./frontmatter";
+import type { PackageFiles } from "./layout-read";
+import type { PackageTree } from "./tree";
+
+export type AuditSeverity = "error" | "warning";
+
+export interface AuditFinding {
+  severity: AuditSeverity;
+  /** Stable kebab-case id, so callers can group or allowlist without matching prose. */
+  rule: string;
+  message: string;
+}
+
+export interface AuditOptions {
+  /**
+   * The directory the package was read from. The directory name IS the template's
+   * identity — it must equal `busabase.json`'s `name` and the manual's `name` — so
+   * without it that rule cannot run and is skipped rather than guessed.
+   */
+  directoryName?: string;
+  /** Path prefix the files were read under, matching `readPackageTree`'s `root`. */
+  root?: string;
+}
+
+/**
+ * A materialized workspace id: busabase-core's `id()` is a three-letter prefix, the
+ * creation time in base36, then seven random characters.
+ *
+ * The lookahead requiring a digit is what keeps ordinary words out — `recommendation`
+ * has the right prefix and the wrong shape. A real id always carries its timestamp.
+ */
+const WORKSPACE_ID =
+  /(?<![0-9a-z])(?:nod|bse|viw|rec|crq|ast|com|fom|shr|fvl|opr|cmt|rev|whd|aud)(?=[0-9a-z]{15}(?![0-9a-z]))(?=[0-9a-z]*\d)[0-9a-z]{15}/;
+
+const TEXT_EXTENSIONS =
+  /\.(?:js|mjs|cjs|ts|mts|cts|json|ndjson|md|html|css|ya?ml|txt)$|(?:^|\/)\.env(?:\.|$)/;
+
+/**
+ * Files that exist to *forbid* a string necessarily contain it. An AirApp's own
+ * `scripts/check.mjs` asserts the obsolete API prefix is absent, and a test fixture
+ * spells out the credential it proves gets rejected — scanning those turns a
+ * correctly-guarded package into a failure.
+ */
+const IS_ASSERTION_CODE = /(?:^|\/)(?:scripts\/check\.mjs|tests?\/|[^/]*\.test\.[cm]?[jt]s)$/;
+
+/** Lockfiles carry integrity hashes that are not ours to interpret. */
+const NOT_SOURCE = /(?:^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$/;
+
+const relativePaths = (files: PackageFiles, root = ""): string[] => {
+  const prefix = root ? `${root.replace(/\/+$/, "")}/` : "";
+  const out: string[] = [];
+  for (const key of files.keys()) {
+    if (!prefix || key.startsWith(prefix)) out.push(key.slice(prefix.length));
+  }
+  return out;
+};
+
+const readText = (files: PackageFiles, root: string, relative: string): string | undefined => {
+  const prefix = root ? `${root.replace(/\/+$/, "")}/` : "";
+  return files.get(`${prefix}${relative}`)?.toString("utf8");
+};
+
+/**
+ * Audit the package layer: identity, the assets the catalog promises, and anything
+ * that must never be published.
+ *
+ * `files` is the flat map `readPackageTree` was given, not the tree. That is load-bearing:
+ * `assets/screenshots/` holds no nodes and so never reaches the tree, and "the manifest
+ * promises a screenshot that does not exist" is exactly a file-level question.
+ */
+export const auditPackage = (
+  tree: PackageTree,
+  files: PackageFiles,
+  options: AuditOptions = {},
+): AuditFinding[] => {
+  const findings: AuditFinding[] = [];
+  const error = (rule: string, message: string) =>
+    findings.push({ severity: "error", rule, message });
+  const warn = (rule: string, message: string) =>
+    findings.push({ severity: "warning", rule, message });
+  const root = options.root ?? "";
+  const paths = relativePaths(files, root);
+  const present = new Set(paths);
+
+  // ── One identity ───────────────────────────────────────────────────────────
+  if (options.directoryName !== undefined && options.directoryName !== tree.manifest.name) {
+    error(
+      "package/identity",
+      `Directory is "${options.directoryName}" but busabase.json declares "${tree.manifest.name}". The directory name is the package's identity, not a label beside it.`,
+    );
+  }
+
+  // ── The catalog card is not a promise the repo cannot keep ─────────────────
+  for (const screenshot of tree.manifest.template?.screenshots ?? []) {
+    if (!present.has(screenshot)) {
+      error(
+        "package/screenshot-missing",
+        `busabase.json declares screenshot "${screenshot}", which is not in the package. The Template Center card would render a broken image.`,
+      );
+    }
+  }
+
+  // ── What must never be published ───────────────────────────────────────────
+  for (const relative of paths) {
+    const base = relative.slice(relative.lastIndexOf("/") + 1);
+    if (/^\.env(?!\.example$)(?:\.|$)/.test(base)) {
+      error(
+        "package/dotenv",
+        `${relative} is part of the package. Credentials belong in Vault, never in something people install.`,
+      );
+    }
+    if (/^(?:id_rsa|id_ed25519)$/.test(base) || /\.(?:pem|p12|pfx|keystore)$/.test(base)) {
+      error(
+        "package/key-material",
+        `${relative} looks like key material and must not be published.`,
+      );
+    }
+    if (/(?:^|\/)(?:node_modules|dist|build)\//.test(relative)) {
+      warn(
+        "package/build-output",
+        `${relative} looks like installed or built output. Ship source; the installer builds nothing.`,
+      );
+    }
+  }
+
+  // ── Somebody's live workspace, shipped to everyone ─────────────────────────
+  for (const relative of paths) {
+    if (!TEXT_EXTENSIONS.test(relative)) continue;
+    if (NOT_SOURCE.test(relative) || IS_ASSERTION_CODE.test(relative)) continue;
+    const source = readText(files, root, relative);
+    if (source === undefined) continue;
+    const found = WORKSPACE_ID.exec(source);
+    if (found) {
+      // One report per file: the fix is the same for every id in it.
+      error(
+        "package/workspace-ids",
+        `${relative} contains "${found[0]}", a materialized workspace id. Node, Base and Space ids are whoever last ran setup's runtime state — publishing them ships one person's workspace layout to everyone.`,
+      );
+    }
+  }
+
+  return findings;
+};
+
+/**
+ * Audit the Skill layer: is the manual one an agent can actually act on?
+ *
+ * Runs for any directory carrying a root `SKILL.md` — package or not, template or not.
+ * It reports nothing at all when there is no manual: a package without one is a
+ * perfectly legitimate thing to publish, not a Skill that failed.
+ *
+ * The honest limit: a checker can tell you the frontmatter parses and the files the
+ * manual points at exist. It cannot tell you the manual is *true*. Everything in
+ * `SKILL.md` becomes instructions an agent acts on, and no static rule catches a
+ * confident, wrong sentence about what a table means.
+ */
+export const auditSkill = (files: PackageFiles, options: AuditOptions = {}): AuditFinding[] => {
+  const findings: AuditFinding[] = [];
+  const error = (rule: string, message: string) =>
+    findings.push({ severity: "error", rule, message });
+  const warn = (rule: string, message: string) =>
+    findings.push({ severity: "warning", rule, message });
+  const root = options.root ?? "";
+
+  // Gated on the file, not on a package tree. A Skill needs no `busabase.json` and no
+  // `content/` — most Skills are not packages at all — so requiring a tree here would
+  // leave the commonest kind of Skill with nothing checking it, which is the gap this
+  // function exists to close.
+  const source = readText(files, root, PACKAGE_SKILL_ENTRY);
+  if (source === undefined) return findings;
+
+  let body = "";
+  try {
+    const parsed = parseFrontmatter(source, PACKAGE_SKILL_ENTRY);
+    body = parsed.body;
+    const frontmatter = SkillFrontmatterSchema.safeParse(parsed.data);
+    if (!frontmatter.success) {
+      error(
+        "skill/frontmatter",
+        `${PACKAGE_SKILL_ENTRY} frontmatter is not a valid Skill declaration: ${frontmatter.error.issues
+          .map((issue) => `${issue.path.join(".") || "(root)"} ${issue.message}`)
+          .join("; ")}`,
+      );
+    } else if (frontmatter.data.description.trim() === "") {
+      error(
+        "skill/description",
+        `${PACKAGE_SKILL_ENTRY} has no description. An agent chooses whether to reach for a Skill by reading it, so an empty one is not cosmetic — it is a Skill that never gets picked.`,
+      );
+    }
+  } catch (cause) {
+    error("skill/frontmatter", `${PACKAGE_SKILL_ENTRY}: ${(cause as Error).message}`);
+    return findings;
+  }
+
+  // ── An unfinished export draft ─────────────────────────────────────────────
+  const todos = (body.match(/^.*\bTODO\b.*$/gm) ?? []).length;
+  if (todos > 0) {
+    error(
+      "skill/todo",
+      `${PACKAGE_SKILL_ENTRY} still carries ${todos} TODO line(s). The export draft leaves them on purpose — an agent acts on what this file says, and a blank the author was meant to fill in is worse than nothing once it ships.`,
+    );
+  }
+
+  // ── A reference that does not travel is an instruction nobody can follow ───
+  const present = new Set(relativePaths(files, root));
+  const sidecar = new RegExp(
+    `\\]\\((\\.?/?(?:${PACKAGE_SIDECARS})/[^)\\s]+)\\)|\`((?:${PACKAGE_SIDECARS})/[^\`\\s]+)\``,
+    "g",
+  );
+  const seen = new Set<string>();
+  for (const match of body.matchAll(sidecar)) {
+    const target = (match[1] ?? match[2]).replace(/^\.?\//, "");
+    if (seen.has(target)) continue;
+    seen.add(target);
+    if (!present.has(target)) {
+      warn(
+        "skill/missing-reference",
+        `${PACKAGE_SKILL_ENTRY} points at "${target}", which the package does not ship. An agent told to read it has an instruction it cannot satisfy.`,
+      );
+    }
+  }
+
+  return findings;
+};
+
+const PACKAGE_SIDECARS = PACKAGE_SKILL_SIDECAR_DIRS.join("|");

--- a/packages/busabase-package/src/collect-dangling-relations.test.ts
+++ b/packages/busabase-package/src/collect-dangling-relations.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `assertSelfContained` claims a dangling relation value — one pointing at a
+ * record that isn't in the package (commonly: archived, so excluded from
+ * `records.ndjson` even though its Base IS in the package) — "was dropped".
+ * Regression coverage for the bug where it only counted and warned, never
+ * actually removing the key from `record.fields`, so the archive still shipped
+ * exactly the reference the warning said was gone. `install` then failed with
+ * "Nothing was installed" on a package `export` had just called self-contained.
+ */
+import { PACKAGE_FORMAT, type PackageManifest } from "busabase-contract/domains/package/types";
+import { describe, expect, it } from "vitest";
+import { assertSelfContained } from "./collect";
+import type { PackageBaseNode, PackageTree } from "./tree";
+
+const manifest = (): PackageManifest => ({
+  format: PACKAGE_FORMAT,
+  name: "test",
+  description: "",
+  tags: [],
+});
+
+const relationField = (slug: string, targetBaseSlug: string) => ({
+  slug,
+  name: slug,
+  type: "relation" as const,
+  required: false,
+  position: 0,
+  options: { targetBaseSlug },
+});
+
+const baseNode = (slug: string, node: Partial<PackageBaseNode>): PackageBaseNode => ({
+  slug,
+  name: slug,
+  description: "",
+  position: 0,
+  type: "base",
+  base: { name: slug, description: "", fields: [], views: [] },
+  records: [],
+  ...node,
+});
+
+describe("assertSelfContained — dangling same-package relations", () => {
+  it("actually removes a relation value pointing at a record excluded from the package (e.g. archived)", () => {
+    const artifacts = baseNode("artifacts", {
+      base: {
+        name: "artifacts",
+        description: "",
+        fields: [relationField("project", "video-projects")],
+        views: [],
+      },
+      records: [
+        {
+          key: "rec-artifact-1",
+          fields: { project: ["rec-project-archived", "rec-project-live"] },
+        },
+      ],
+    });
+    const videoProjects = baseNode("video-projects", {
+      records: [{ key: "rec-project-live", fields: {} }],
+      // "rec-project-archived" deliberately absent — the archived-record case.
+    });
+    const tree: PackageTree = { manifest: manifest(), nodes: [artifacts, videoProjects] };
+
+    const warnings: string[] = [];
+    assertSelfContained(tree, {
+      manifest: manifest(),
+      warn: (m) => warnings.push(m),
+      baseUrl: "http://localhost",
+    });
+
+    // The dangling key is gone; the still-valid one survives.
+    expect(artifacts.records[0].fields.project).toEqual(["rec-project-live"]);
+    expect(warnings).toEqual([
+      'Base "artifacts" has 1 relation value(s) pointing at records outside the exported subtree — they were dropped.',
+    ]);
+  });
+
+  it("drops every value and leaves an empty array when none of them resolve", () => {
+    const artifacts = baseNode("artifacts", {
+      base: {
+        name: "artifacts",
+        description: "",
+        fields: [relationField("project", "video-projects")],
+        views: [],
+      },
+      records: [{ key: "rec-artifact-1", fields: { project: ["rec-gone-1", "rec-gone-2"] } }],
+    });
+    const videoProjects = baseNode("video-projects", { records: [] });
+    const tree: PackageTree = { manifest: manifest(), nodes: [artifacts, videoProjects] };
+
+    assertSelfContained(tree, {
+      manifest: manifest(),
+      warn: () => {},
+      baseUrl: "http://localhost",
+    });
+
+    expect(artifacts.records[0].fields.project).toEqual([]);
+  });
+
+  it("leaves a fully-resolved relation untouched and warns nothing", () => {
+    const artifacts = baseNode("artifacts", {
+      base: {
+        name: "artifacts",
+        description: "",
+        fields: [relationField("project", "video-projects")],
+        views: [],
+      },
+      records: [{ key: "rec-artifact-1", fields: { project: ["rec-project-live"] } }],
+    });
+    const videoProjects = baseNode("video-projects", {
+      records: [{ key: "rec-project-live", fields: {} }],
+    });
+    const tree: PackageTree = { manifest: manifest(), nodes: [artifacts, videoProjects] };
+
+    const warnings: string[] = [];
+    assertSelfContained(tree, {
+      manifest: manifest(),
+      warn: (m) => warnings.push(m),
+      baseUrl: "http://localhost",
+    });
+
+    expect(artifacts.records[0].fields.project).toEqual(["rec-project-live"]);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/busabase-package/src/collect-root-node.test.ts
+++ b/packages/busabase-package/src/collect-root-node.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `export <slug>` accepts any node, not just a folder. A folder's content lives
+ * in `children`, but a Doc/Base/Drive/… node IS the content — it has no
+ * `children` at all. Regression coverage for the bug where exporting such a
+ * node directly silently walked zero nodes and produced an empty manifest.
+ */
+
+import { PACKAGE_FORMAT, type PackageManifest } from "busabase-contract/domains/package/types";
+import { describe, expect, it } from "vitest";
+import type { PackageClient } from "./client";
+import { collectPackageTree, type SourceNode } from "./collect";
+import { renderPackageTree } from "./layout-write";
+
+const manifest = (): PackageManifest => ({
+  format: PACKAGE_FORMAT,
+  name: "handbook",
+  description: "",
+  tags: [],
+});
+
+const stubClient = (docBody: string): PackageClient =>
+  ({
+    nodes: {
+      get: async ({ type }: { nodeId: string; type: string }) =>
+        type === "doc" ? { type: "doc", body: docBody } : undefined,
+    },
+  }) as unknown as PackageClient;
+
+const docRoot: SourceNode = {
+  id: "nod-handbook",
+  slug: "handbook",
+  name: "Handbook",
+  type: "doc",
+  description: "Team handbook",
+  position: 0,
+};
+
+describe("collectPackageTree — non-folder root", () => {
+  it("collects a bare Doc node exported directly, instead of walking its (nonexistent) children", async () => {
+    const tree = await collectPackageTree(stubClient("# Handbook\n"), docRoot, {
+      manifest: manifest(),
+      warn: () => {},
+      baseUrl: "http://localhost",
+    });
+    expect(tree.nodes).toHaveLength(1);
+    expect(tree.nodes[0]).toMatchObject({ slug: "handbook", type: "doc", body: "# Handbook\n" });
+  });
+
+  it("renders the doc's content, not just a bare manifest", async () => {
+    const tree = await collectPackageTree(stubClient("# Handbook\n"), docRoot, {
+      manifest: manifest(),
+      warn: () => {},
+      baseUrl: "http://localhost",
+    });
+    const files = renderPackageTree(tree);
+    expect([...files.keys()]).toContain("content/handbook.md");
+  });
+});

--- a/packages/busabase-package/src/collect.ts
+++ b/packages/busabase-package/src/collect.ts
@@ -82,7 +82,12 @@ export const collectPackageTree = async (
   root: SourceNode,
   options: CollectOptions,
 ): Promise<PackageTree> => {
-  const children = root.children ?? [];
+  // A folder's own content lives in `children`. Any other node type (a bare
+  // Base, Doc, Drive, …) has no `children` at all — it IS the content — so
+  // treating `root.children ?? []` as the source list here would silently
+  // walk zero nodes and export nothing but an empty manifest. Fall back to
+  // `[root]` so exporting a non-folder node directly still collects it.
+  const children = root.type === "folder" ? (root.children ?? []) : [root];
   const { skillSource, rest } = partitionTemplateSkill(children);
   const nodes = await collectNodes(client, rest, options);
   const tree: PackageTree = {
@@ -638,7 +643,7 @@ const downloadBytes = async (
  * So the rule the format actually enforces is: never ship a reference that would
  * resolve to the WRONG thing; do warn about one that resolves to nothing.
  */
-const assertSelfContained = (tree: PackageTree, options: CollectOptions): void => {
+export const assertSelfContained = (tree: PackageTree, options: CollectOptions): void => {
   const carriedAssetIds = new Set((tree.assets ?? []).map((asset) => asset.assetId));
   for (const node of walkNodes(tree.nodes)) {
     if (node.type !== "doc") continue;
@@ -671,9 +676,14 @@ const assertSelfContained = (tree: PackageTree, options: CollectOptions): void =
         if (field.type !== "relation") continue;
         const value = record.fields[field.slug];
         const keys = Array.isArray(value) ? value : typeof value === "string" ? [value] : [];
-        for (const key of keys) {
-          if (typeof key === "string" && !packagedRecordKeys.has(key)) dangling++;
-        }
+        if (keys.length === 0) continue;
+        const kept = keys.filter((key) => typeof key !== "string" || packagedRecordKeys.has(key));
+        dangling += keys.length - kept.length;
+        // The warning below claims these are dropped — actually drop them, or a
+        // package that says "self-contained" still ships a reference `apply`'s
+        // pass 5 cannot resolve, and `install` fails outright on a record that
+        // export already told the user was cleaned up.
+        if (kept.length !== keys.length) record.fields[field.slug] = kept;
       }
     }
     if (dangling > 0) {

--- a/packages/busabase-package/src/tree.test.ts
+++ b/packages/busabase-package/src/tree.test.ts
@@ -1,0 +1,32 @@
+/**
+ * `assertSafeFilePath` guards file-tree paths against shapes that break a git
+ * checkout on Windows/macOS. Regression coverage for the bug where it also
+ * rejected a LEADING dot — the ordinary hidden-file convention (`.gitignore`,
+ * `.env`, `.eslintrc`) that every real AirApp source tree uses, and which
+ * checks out identically on every OS. Found live: `busabase-cli export`
+ * refused every AirApp that happened to carry a `.gitignore`.
+ */
+import { describe, expect, it } from "vitest";
+import { assertSafeFilePath } from "./tree";
+
+describe("assertSafeFilePath", () => {
+  it("accepts a leading-dot filename (the hidden-file convention)", () => {
+    expect(() => assertSafeFilePath(".gitignore", "airapp")).not.toThrow();
+    expect(() => assertSafeFilePath("app/.env.example", "airapp")).not.toThrow();
+    expect(() => assertSafeFilePath(".github/workflows/ci.yml", "airapp")).not.toThrow();
+  });
+
+  it("still rejects a TRAILING dot or space — silently stripped by Windows on checkout", () => {
+    expect(() => assertSafeFilePath("notes.", "airapp")).toThrow(/ends with a dot or space/);
+    expect(() => assertSafeFilePath("notes ", "airapp")).toThrow(/ends with a dot or space/);
+    expect(() => assertSafeFilePath("app/config. ", "airapp")).toThrow(/ends with a dot or space/);
+  });
+
+  it("still rejects Windows/macOS-illegal characters", () => {
+    expect(() => assertSafeFilePath("app/con:fig.js", "airapp")).toThrow(/illegal in a file name/);
+  });
+
+  it("still rejects an empty path segment", () => {
+    expect(() => assertSafeFilePath("app//config.js", "airapp")).toThrow(/empty path segment/);
+  });
+});

--- a/packages/busabase-package/src/tree.ts
+++ b/packages/busabase-package/src/tree.ts
@@ -172,9 +172,15 @@ export const assertSafeFilePath = (filePath: string, context: string): void => {
         `Invalid file path "${filePath}" (${context}): the segment "${segment}" contains a character that is illegal in a file name on Windows or macOS (/ \\ : * ? " < > |). Rename the file.`,
       );
     }
-    if (/^[. ]|[. ]$/.test(segment)) {
+    // Windows silently strips a TRAILING dot or space when a file is created,
+    // so an archived "foo." would come back as "foo" on checkout there — a
+    // real cross-OS hazard. A LEADING dot has no such problem: it is the
+    // ordinary hidden-file convention (.gitignore, .env, .eslintrc, …) and
+    // checks out identically everywhere, so it must not be rejected here —
+    // real AirApp source trees are full of them.
+    if (/[. ]$/.test(segment)) {
       throw new Error(
-        `Invalid file path "${filePath}" (${context}): the segment "${segment}" starts or ends with a dot or space, which does not survive a checkout on every OS. Rename the file.`,
+        `Invalid file path "${filePath}" (${context}): the segment "${segment}" ends with a dot or space, which does not survive a checkout on every OS. Rename the file.`,
       );
     }
   }

--- a/packages/kui/package.json
+++ b/packages/kui/package.json
@@ -137,7 +137,7 @@
     "embla-carousel-react": "^8.6.0",
     "frimousse": "^0.3.0",
     "input-otp": "^1.5.0",
-    "lucide-react": "^1.33.0",
+    "lucide-react": "^1.34.0",
     "media-chrome": "^4.19.2",
     "motion": "^13.1.1",
     "nanoid": "^6.0.1",

--- a/packages/openlib/package.json
+++ b/packages/openlib/package.json
@@ -121,7 +121,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "lucide-react": ">=0.556.0",
+    "lucide-react": "^1.34.0",
     "next": ">=14.0.0",
     "next-themes": ">=0.4.0",
     "react": "^19.2.4",

--- a/packages/openlib/ui/dashboard/NavMain.tsx
+++ b/packages/openlib/ui/dashboard/NavMain.tsx
@@ -45,6 +45,7 @@ import {
   memo,
   type ReactNode,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -144,6 +145,41 @@ const getNavItemKey = (item: NavKeyItem, index: number, prefix = "item") =>
 const isExternalUrl = (url: string) => url.startsWith("http://") || url.startsWith("https://");
 
 /**
+ * Renders nothing; asks the consumer to load `item`'s children exactly once
+ * per mount. Rendered only inside an OPEN folder that declares `hasChildren`
+ * but has no loaded `items` yet, so mounting IS the "this folder is showing
+ * and has nothing to show" signal.
+ *
+ * Why this and not the `Collapsible`'s own `onOpenChange`: a folder also opens
+ * with no toggle event at all. `isOpen` is true whenever the folder — or any
+ * descendant — is the active route, so merely NAVIGATING to a folder expands
+ * it. Radix only fires `onOpenChange` for interactions with the trigger, so
+ * that route-driven open never reached `onExpand`, and any folder past the
+ * host's eager prefetch depth (whose children only ever arrive lazily) stayed
+ * permanently, silently empty in the sidebar while its own detail page listed
+ * the children just fine. Reacting to the rendered `isOpen` state instead of
+ * to one of the events that can produce it covers every route into it.
+ */
+function NavLazyExpandTrigger({
+  item,
+  onExpand,
+}: {
+  item: NavItem;
+  onExpand: (item: NavItem) => void;
+}) {
+  // Read through a ref so `item` — a fresh object on every parent render —
+  // stays out of the dependency list. One ask per mount is exactly right: the
+  // folder row this renders inside is keyed by the node's id, so a different
+  // folder is a different mount.
+  const itemRef = useRef(item);
+  itemRef.current = item;
+  useEffect(() => {
+    onExpand(itemRef.current);
+  }, [onExpand]);
+  return null;
+}
+
+/**
  * The ONE button footprint for every hover-revealed row control, at every depth.
  *
  * `size-5` + a `size-4` icon deliberately matches kui's own `SidebarMenuAction`
@@ -216,14 +252,39 @@ interface NavMainProps {
    */
   isDropAllowed?: (draggedId: string, targetId: string, position: NavDropPosition) => boolean;
   /**
-   * Called when a folder row (`item.hasChildren` or `item.items`) transitions
-   * to open while it has no loaded `items` yet (`item.hasChildren: true` but
-   * `items` empty/undefined) — the signal for a consumer that lazy-loads a
-   * folder's children on first expand to kick off that fetch. Never called
-   * for a folder that already has `items` loaded, or on every open/close —
-   * only the "needs its children" transition.
+   * Called for a folder row that is rendered OPEN while it has no loaded
+   * `items` yet (`item.hasChildren: true`, `items` empty/undefined) — the
+   * signal for a consumer that lazy-loads a folder's children to kick off
+   * that fetch. Never called for a folder that already has `items` loaded.
+   *
+   * Deliberately tied to the rendered open STATE, not to a toggle event: a
+   * folder also opens by simply being (or containing) the active route, with
+   * no `onOpenChange` ever firing. Expect it once per such row per mount, so
+   * it must be idempotent — re-opening a folder whose children are already
+   * cached will call it again.
    */
   onExpand?: (item: NavItem) => void;
+  /**
+   * Ids of the folders on the path to the currently-active row — its ancestor
+   * chain, supplied by the consumer (which is the only side that can resolve
+   * it; see below). Any row whose `id` is in here is treated as being on the
+   * active path: it renders open, and if its children are not loaded yet the
+   * usual `onExpand` fetch fires for it.
+   *
+   * Needed because "am I an ancestor of the active row?" is otherwise answered
+   * by walking `items` — which only sees children ALREADY LOADED. For a tree
+   * that is lazily expanded, landing directly on a deep url (a refresh, a
+   * bookmark, a shared link) means none of the ancestors have been fetched, so
+   * that walk finds nothing, nothing expands, and nothing can ever expand:
+   * without an expansion there is no fetch, and without a fetch there is
+   * nothing to expand. This breaks the deadlock — each expanded ancestor loads
+   * the next level, which contains the next ancestor, and so on down to the
+   * active row.
+   *
+   * Omit for a consumer that loads its whole tree eagerly; the `items` walk
+   * already covers that case.
+   */
+  activeAncestorIds?: ReadonlySet<string>;
 }
 
 function NavMainComponent({
@@ -235,6 +296,7 @@ function NavMainComponent({
   onNodeDrop,
   isDropAllowed,
   onExpand,
+  activeAncestorIds,
 }: NavMainProps) {
   const [location, setLocation] = useLocation();
   const currentSearch = useSearch();
@@ -244,9 +306,165 @@ function NavMainComponent({
   const isPathActive = (url?: string) =>
     !!url && (location === url || (url !== "/" && location.startsWith(`${url}/`)));
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
-  // Per-folder manual expand/collapse override (by nav-item key). A folder on the
-  // active route is always expanded; this only adds extra opens for other folders.
-  const [openOverrides, setOpenOverrides] = useState<Record<string, boolean>>({});
+  // Per-folder manual expand/collapse override, by nav-item key.
+  //
+  // A COLLAPSE carries the location it was made at and expires the moment
+  // location changes to anything else — see the pruning effect below, which
+  // is what actually enforces "anything else". Comparing the override's `at`
+  // against the CURRENT location on every render instead (no effect, no
+  // pruning) was tried first and breaks the instant you navigate away and
+  // back to the exact same path: collapse Brand Kit while on
+  // `/folder/brand-kit`, go Home, click back down through 2026 Launch ->
+  // Launch Assets -> Brand Kit — location is `/folder/brand-kit` again, so a
+  // plain string comparison cannot tell "never left" from "left and
+  // returned", and the stale collapse reappears hiding the very row you just
+  // navigated to.
+  //
+  // Existing at all is what makes the chevron work on the folder you are
+  // currently inside: that folder is pinned open by `isActiveTree`, so
+  // Radix's `onOpenChange(!open)` — `open` always `true` — sends `false` on
+  // every click, and nothing would move without an override to override it.
+  //
+  // An EXPAND has neither hazard, so it simply persists as you browse.
+  const [openOverrides, setOpenOverrides] = useState<Record<string, { open: boolean; at: string }>>(
+    {},
+  );
+  // Enforces "expires on navigation" for a collapse: fires on every location
+  // change and drops any override whose `at` is not THIS location, before the
+  // next render computes `isOpen`. An expand is untouched — it has no reason
+  // to expire.
+  useEffect(() => {
+    setOpenOverrides((prev) => {
+      let changed = false;
+      const next: typeof prev = {};
+      for (const [key, override] of Object.entries(prev)) {
+        if (override.open || override.at === location) {
+          next[key] = override;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location]);
+
+  // Scrolls the row whose OWN url exactly matches the current location into
+  // view. Exists because a depth-bounded, lazily-expanded tree can land the
+  // just-navigated-to row anywhere: past the visible fold entirely, or
+  // sitting behind a host's fixed sidebar footer (both look, to a user, like
+  // the row never loaded — it did, it's just off-screen).
+  //
+  // Reacts to actual DOM mutations inside the tree (by a `data-nav-url`
+  // attribute set on every row below), rather than a fixed-length poll or a
+  // mount-triggered ref — both were tried first, and both guess at a timing
+  // budget that real async loading doesn't respect:
+  //
+  // - A mount-triggered ref only fires for a row that GENUINELY mounts fresh.
+  //   That covers a cold deep-link (refresh, bookmark, shared link), whose row
+  //   only exists once `NavLazyExpandTrigger`'s ancestor-chain fetch resolves
+  //   — but not clicking DOWN through an already-expanded tree (Product Ops
+  //   -> 2026 Launch -> ... -> Brand Kit), which navigates onto a row that was
+  //   ALREADY in the DOM before the click (you have to see a row to click it,
+  //   so nothing mounts). No mount, so the ref never fires.
+  // - A fixed settle-then-check poll (wait N x 100ms, hope nothing moves
+  //   again after) covers that case, but Brand Kit's own further children
+  //   loading in — a SEPARATE lazy fetch, on a real network, with no fixed
+  //   upper bound — can keep shifting the row's position well past whatever
+  //   budget seemed "generous enough" in testing, silently reintroducing the
+  //   exact bug this is fixing.
+  //
+  // A MutationObserver has no such budget to guess: every time the tree's DOM
+  // actually changes, it re-runs the same visibility check, however many
+  // times that takes, however long the underlying fetches take. It stops
+  // after `CORRECTION_WINDOW_MS` of no further mutations (or that much time
+  // has elapsed since navigation) so it doesn't fight a user who has since
+  // scrolled elsewhere on their own.
+  const navContainerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const CORRECTION_WINDOW_MS = 4000;
+    const deadline = Date.now() + CORRECTION_WINDOW_MS;
+    let debounceId: ReturnType<typeof setTimeout> | undefined;
+    let stopId: ReturnType<typeof setTimeout>;
+
+    const evaluate = () => {
+      const headerEl = navContainerRef.current?.querySelector<HTMLElement>(
+        `[data-nav-url="${CSS.escape(location)}"]`,
+      );
+      if (!headerEl) return;
+      // The `<li>` wrapping this row. For a leaf, `data-nav-url` already
+      // lives on the `<li>` itself, so this is a no-op. For a FOLDER,
+      // `data-nav-url` lives on its inner header `<div>` — the `<li>` also
+      // wraps its `CollapsibleContent`, i.e. every currently-visible child —
+      // and that's deliberately what gets checked and scrolled here, not just
+      // the header. A folder whose OWN header is already on-screen but whose
+      // children still land behind the footer is the exact scenario this fix
+      // exists for: the whole point of navigating into a folder is to see
+      // what's in it, so "the header made it, its contents didn't" is not
+      // success.
+      const el = headerEl.closest<HTMLElement>("li") ?? headerEl;
+      // Gate on ACTUAL occlusion, not merely "call scrollIntoView and let the
+      // browser decide" (`block: "nearest"` is a no-op when already visible,
+      // but landed a couple of pixels short of the true fold in this
+      // sidebar's doubly-nested scroll containers — a host's own wrapper
+      // around this tree, inside kui's own `SidebarContent`, each scrolling
+      // independently). A plain viewport-bounds check alone isn't enough
+      // either: a row sitting exactly in a fixed footer's band still reports
+      // a rect fully inside the window (the footer PAINTS OVER it, it isn't
+      // clipped out of the layout). So also check the footer's own band
+      // directly, if this host renders one (kui's `Sidebar` primitive, which
+      // this component is built to run inside) — `elementFromPoint` alone
+      // only samples ONE pixel, meaningless for a tall folder-plus-children
+      // box, where the header can be clear while a child two rows down is
+      // still covered.
+      const rect = el.getBoundingClientRect();
+      const footerRect = document.querySelector('[data-sidebar="footer"]')?.getBoundingClientRect();
+      const overlapsFooter =
+        !!footerRect && rect.bottom > footerRect.top && rect.top < footerRect.bottom;
+      const paintedAtHeaderCenter = document.elementFromPoint(
+        rect.left + rect.width / 2,
+        rect.top + headerEl.getBoundingClientRect().height / 2,
+      );
+      const alreadyVisible =
+        rect.top >= 0 &&
+        rect.bottom <= window.innerHeight &&
+        !overlapsFooter &&
+        !!paintedAtHeaderCenter &&
+        headerEl.contains(paintedAtHeaderCenter);
+      if (alreadyVisible) return;
+      // `block: "start"`, not `"center"`: a folder's children render BELOW
+      // its header, never above, so pinning the header near the top of the
+      // scrollport leaves the maximum possible room for them, where centering
+      // would waste half that room above the header where there is nothing to
+      // show. `"start"` clears the nested-container rounding shortfall
+      // `"nearest"` suffered from just as reliably — the fix for that was
+      // "give it real margin", and `"start"` gives just as much as `"center"`
+      // did.
+      el.scrollIntoView({ block: "start" });
+    };
+
+    const observer = new MutationObserver(() => {
+      if (Date.now() > deadline) {
+        observer.disconnect();
+        return;
+      }
+      // Coalesce a burst of mutations (a folder's children arriving is
+      // several DOM insertions, not one) into a single re-check per burst.
+      clearTimeout(debounceId);
+      debounceId = setTimeout(evaluate, 50);
+    });
+    if (navContainerRef.current) {
+      observer.observe(navContainerRef.current, { childList: true, subtree: true });
+    }
+    evaluate(); // the "nothing more is going to change" case: no mutations, check once up front.
+    stopId = setTimeout(() => observer.disconnect(), CORRECTION_WINDOW_MS);
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(debounceId);
+      clearTimeout(stopId);
+    };
+  }, [location]);
 
   const dragEnabled = Boolean(onNodeDrop);
   // Titles of every draggable row, for the `DragOverlay` chip that follows the
@@ -610,8 +828,17 @@ function NavMainComponent({
     const isActiveTree =
       Boolean(item.isActive) ||
       isPathActive(item.url) ||
+      // Consumer-supplied ancestor chain FIRST-CLASS alongside the `items`
+      // walk below, not as a fallback to it: the walk cannot see unloaded
+      // children, which is exactly the cold-load case this covers.
+      (!!item.id && (activeAncestorIds?.has(item.id) ?? false)) ||
       (item.items?.some((subItem) => isDescendantActive(subItem)) ?? false);
-    const isOpen = isActiveTree || (openOverrides[itemKey] ?? false);
+    // Whatever survived the pruning effect (see `openOverrides`) is by
+    // definition still valid: an expand, or a collapse whose location has not
+    // changed since. Its absence — never set, or since pruned — falls back to
+    // the route-derived default.
+    const override = openOverrides[itemKey];
+    const isOpen = override !== undefined ? override.open : isActiveTree;
 
     // If item declares sub-items, render as a folder-style row, even when the
     // current folder is empty. `hasChildren` alone (no `items` loaded yet —
@@ -633,20 +860,18 @@ function NavMainComponent({
           key={itemKey}
           asChild
           open={isOpen}
+          // Records the user's explicit intent only. The lazy-children fetch
+          // is NOT kicked off from here — see `NavLazyExpandTrigger` below for
+          // why it keys off the rendered open state instead of this event.
           onOpenChange={(open) => {
-            setOpenOverrides((prev) => ({ ...prev, [itemKey]: open }));
-            // Fire the lazy-load signal only on the actual "needs children"
-            // transition — a folder that already has `items` loaded (or is
-            // being closed) never triggers a refetch.
-            if (open && item.hasChildren && !item.items?.length) {
-              onExpand?.(item);
-            }
+            setOpenOverrides((prev) => ({ ...prev, [itemKey]: { open, at: location } }));
           }}
           className="group/collapsible"
         >
           <ItemWrapper>
             <div
               ref={dragProps?.setNodeRef}
+              data-nav-url={item.url || undefined}
               style={dragProps?.style}
               // The sortable ref binds to just this header row, NOT the outer
               // list item — that <li> also wraps the expanded
@@ -764,6 +989,13 @@ function NavMainComponent({
                     ),
                   );
                 })()}
+                {/* Asks the consumer for this folder's children the first
+                    time it is rendered open with none loaded — however it got
+                    opened (chevron, folder-name navigation, or an active
+                    descendant route). Renders nothing itself. */}
+                {isOpen && item.hasChildren && folderItems.length === 0 && onExpand && (
+                  <NavLazyExpandTrigger item={item} onExpand={onExpand} />
+                )}
                 {/* Lazy-load placeholder: shown only while a `hasChildren`
                     folder's children are being fetched (never alongside
                     already-loaded `items`, which render above instead). Plain
@@ -805,6 +1037,7 @@ function NavMainComponent({
         <SidebarMenuItem
           key={itemKey}
           ref={dragProps?.setNodeRef}
+          data-nav-url={item.url || undefined}
           style={dragProps?.style}
           className={`group/nav-row ${dropIndicatorClass(item.id)}`}
         >
@@ -879,6 +1112,7 @@ function NavMainComponent({
       <SidebarMenuSubItem
         key={itemKey}
         ref={dragProps?.setNodeRef}
+        data-nav-url={item.url || undefined}
         style={dragProps?.style}
         className={`group/nav-row relative ${dropIndicatorClass(item.id)}`}
       >
@@ -929,7 +1163,10 @@ function NavMainComponent({
   const hasDynamicGroup = items.some((group) => group.isDynamic);
 
   const content = (
-    <div className={hasDynamicGroup ? "flex flex-col flex-1 min-h-0 gap-1" : "contents"}>
+    <div
+      ref={navContainerRef}
+      className={hasDynamicGroup ? "flex flex-col flex-1 min-h-0 gap-1" : "contents"}
+    >
       {items.map((group, groupIndex) => {
         const HeaderActionIcon = group.headerAction;
         const GroupIcon = group.icon;

--- a/packages/openlib/ui/dashboard/SettingsDialogShell.test.tsx
+++ b/packages/openlib/ui/dashboard/SettingsDialogShell.test.tsx
@@ -1,0 +1,350 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Circle } from "lucide-react";
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsDialogShell } from "./SettingsDialogShell";
+
+afterEach(cleanup);
+
+vi.mock("kui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogClose: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  DialogContent: ({
+    children,
+    showCloseButton: _showCloseButton,
+    ...props
+  }: HTMLAttributes<HTMLDivElement> & { showCloseButton?: boolean }) => (
+    <div {...props}>{children}</div>
+  ),
+  DialogTitle: ({ children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
+    <h2 {...props}>{children}</h2>
+  ),
+  DialogDescription: ({ children, ...props }: HTMLAttributes<HTMLParagraphElement>) => (
+    <p {...props}>{children}</p>
+  ),
+  DialogTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("kui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = [];
+
+  private callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ResizeObserverMock.instances.push(this);
+  }
+
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+const renderShell = () =>
+  render(
+    <SettingsDialogShell
+      open
+      onOpenChange={vi.fn()}
+      title="Settings"
+      closeLabel="Close"
+      sections={[
+        {
+          key: "account",
+          title: "Account Settings",
+          icon: Circle,
+          tabs: [{ id: "environment", label: "Environment Variables", icon: Circle }],
+        },
+      ]}
+      activeTab="environment"
+      onTabChange={vi.fn()}
+      accordion
+      activeSectionKey="account"
+      onSectionChange={vi.fn()}
+    >
+      <div>Settings content</div>
+    </SettingsDialogShell>,
+  );
+
+const setElementWidth = (element: HTMLElement, clientWidth: number, scrollWidth: number) => {
+  Object.defineProperties(element, {
+    clientWidth: { configurable: true, value: clientWidth },
+    scrollWidth: { configurable: true, value: scrollWidth },
+  });
+};
+
+const notifyResize = () => {
+  act(() => {
+    for (const observer of ResizeObserverMock.instances) observer.trigger();
+  });
+};
+
+describe("SettingsDialogShell sidebar overflow", () => {
+  beforeEach(() => {
+    ResizeObserverMock.instances = [];
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  it("shows a tooltip on focus and hover only when the rendered label is truncated", async () => {
+    const { container } = renderShell();
+    const label = container.querySelector<HTMLElement>(
+      '[data-settings-sidebar-label="Account Settings"]',
+    );
+    const button = label?.closest("button");
+
+    expect(label).not.toBeNull();
+    expect(button).not.toBeNull();
+
+    setElementWidth(label as HTMLElement, 160, 160);
+    notifyResize();
+    fireEvent.focus(button as HTMLButtonElement);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    fireEvent.blur(button as HTMLButtonElement);
+
+    setElementWidth(label as HTMLElement, 100, 160);
+    notifyResize();
+    fireEvent.focus(button as HTMLButtonElement);
+
+    expect((await screen.findByRole("tooltip")).textContent).toContain("Account Settings");
+
+    fireEvent.blur(button as HTMLButtonElement);
+    await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
+
+    fireEvent.pointerMove(button as HTMLButtonElement, { pointerType: "mouse" });
+    expect((await screen.findByRole("tooltip")).textContent).toContain("Account Settings");
+
+    fireEvent.pointerLeave(button as HTMLButtonElement);
+  });
+
+  it("uses responsive width, tighter nested padding, and no horizontal scrolling", () => {
+    const { container } = renderShell();
+    // Mobile and desktop each render their own copy of the section list
+    // (CSS-only responsive switch), so scope to the desktop sidebar instance.
+    const desktopSidebar = container.querySelector('[data-settings-viewport="desktop"]');
+    const label = desktopSidebar?.querySelector<HTMLElement>(
+      '[data-settings-sidebar-label="Environment Variables"]',
+    );
+    const button = label?.closest("button");
+    const scrollRegion = label?.closest(".overflow-y-auto");
+    const sidebar = scrollRegion?.parentElement;
+
+    expect(label?.className).toContain("truncate");
+    expect(label?.className).toContain("min-w-0");
+    expect(button?.className).toContain("px-2");
+    expect(scrollRegion?.className).toContain("overflow-x-hidden");
+    expect(sidebar?.className).toContain("w-52");
+    expect(sidebar?.className).toContain("lg:w-56");
+  });
+});
+
+describe("SettingsDialogShell content overflow", () => {
+  it("constrains the main content pane without clipping wide tab content", () => {
+    renderShell();
+    const content = screen.getByText("Settings content");
+    const contentPadding = content.parentElement;
+    const scrollRegion = contentPadding?.parentElement;
+    const contentColumn = scrollRegion?.parentElement;
+
+    expect(contentPadding?.className).toContain("min-w-0");
+    expect(scrollRegion?.className).toContain("min-w-0");
+    expect(scrollRegion?.className).toContain("overflow-x-hidden");
+    expect(scrollRegion?.className).toContain("overflow-y-auto");
+    expect(contentColumn?.className).toContain("min-w-0");
+  });
+});
+
+describe("SettingsDialogShell rendering contracts", () => {
+  it("uses section-scoped keys when different sections share a tab id", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <SettingsDialogShell
+        open
+        onOpenChange={vi.fn()}
+        title="Settings"
+        closeLabel="Close"
+        sections={[
+          {
+            key: "space",
+            title: "Space",
+            tabs: [{ id: "channels", label: "Space channels", icon: Circle }],
+          },
+          {
+            key: "agent",
+            title: "Agent",
+            tabs: [{ id: "channels", label: "Agent channels", icon: Circle }],
+          },
+        ]}
+        activeTab="channels"
+        onTabChange={vi.fn()}
+      >
+        <div>Settings content</div>
+      </SettingsDialogShell>,
+    );
+
+    expect(consoleError.mock.calls.flat().join(" ")).not.toContain("same key");
+    consoleError.mockRestore();
+  });
+
+  it("provides a hidden description for the dialog content", () => {
+    renderShell();
+
+    const description = screen.getAllByText("Settings").find((element) => element.tagName === "P");
+    expect(description?.className).toContain("sr-only");
+  });
+});
+
+describe("SettingsDialogShell mobile drill-down", () => {
+  const sections = [
+    {
+      key: "account",
+      title: "Account Settings",
+      icon: Circle,
+      tabs: [{ id: "environment", label: "Environment Variables", icon: Circle }],
+    },
+  ];
+
+  const findMobileList = (container: HTMLElement) =>
+    container.querySelector('[data-settings-viewport="mobile"]');
+
+  const findMobileTabButton = (container: HTMLElement) =>
+    findMobileList(container)
+      ?.querySelector<HTMLElement>('[data-settings-sidebar-label="Environment Variables"]')
+      ?.closest("button");
+
+  // "hidden" the Tailwind utility class, not the substring in "sm:hidden".
+  const hasHiddenClass = (element: Element | null | undefined) =>
+    (element?.className.split(/\s+/) ?? []).includes("hidden");
+
+  it("shows the tab content and a back button after picking a tab, and returns to the list on back", () => {
+    const onTabChange = vi.fn();
+    const { container } = render(
+      <SettingsDialogShell
+        open
+        onOpenChange={vi.fn()}
+        title="Settings"
+        closeLabel="Close"
+        sections={sections}
+        activeTab="environment"
+        onTabChange={onTabChange}
+        accordion
+        activeSectionKey="account"
+        onSectionChange={vi.fn()}
+      >
+        <div>Settings content</div>
+      </SettingsDialogShell>,
+    );
+
+    // Starts on the list — the mobile section list is visible, no back bar yet.
+    expect(hasHiddenClass(findMobileList(container))).toBe(false);
+    expect(screen.queryByRole("button", { name: /Back/ })).toBeNull();
+
+    fireEvent.click(findMobileTabButton(container) as HTMLElement);
+
+    expect(onTabChange).toHaveBeenCalledWith("environment", "account");
+    // Drilled into detail: list hides, a back bar with the tab label appears.
+    expect(hasHiddenClass(findMobileList(container))).toBe(true);
+    const backButton = screen.getByRole("button", { name: /Back/ });
+    expect(screen.getAllByText("Environment Variables").length).toBeGreaterThan(0);
+
+    fireEvent.click(backButton);
+
+    // Back out: list reappears, back bar is gone.
+    expect(hasHiddenClass(findMobileList(container))).toBe(false);
+    expect(screen.queryByRole("button", { name: /Back/ })).toBeNull();
+  });
+
+  it("resets to the list view whenever the dialog re-opens", () => {
+    const baseProps = {
+      onOpenChange: vi.fn(),
+      title: "Settings",
+      closeLabel: "Close",
+      sections,
+      activeTab: "environment" as const,
+      onTabChange: vi.fn(),
+      accordion: true as const,
+      activeSectionKey: "account",
+      onSectionChange: vi.fn(),
+    };
+
+    const { container, rerender } = render(
+      <SettingsDialogShell open {...baseProps}>
+        <div>Settings content</div>
+      </SettingsDialogShell>,
+    );
+
+    fireEvent.click(findMobileTabButton(container) as HTMLElement);
+    expect(hasHiddenClass(findMobileList(container))).toBe(true);
+
+    // Close, then re-open — should land back on the list, not the last detail.
+    rerender(
+      <SettingsDialogShell open={false} {...baseProps}>
+        <div>Settings content</div>
+      </SettingsDialogShell>,
+    );
+    rerender(
+      <SettingsDialogShell open {...baseProps}>
+        <div>Settings content</div>
+      </SettingsDialogShell>,
+    );
+
+    expect(hasHiddenClass(findMobileList(container))).toBe(false);
+  });
+
+  it("drills down the same way in flat (non-accordion) mode, e.g. the account/space-only SettingsModal", () => {
+    const onTabChange = vi.fn();
+    const { container } = render(
+      <SettingsDialogShell
+        open
+        onOpenChange={vi.fn()}
+        title="Settings"
+        closeLabel="Close"
+        sections={[
+          {
+            key: "account",
+            title: "Account Settings",
+            tabs: [{ id: "profile", label: "Profile", icon: Circle }],
+          },
+          {
+            key: "space",
+            title: "Space Settings",
+            tabs: [{ id: "billing", label: "Billing", icon: Circle }],
+          },
+        ]}
+        activeTab="profile"
+        onTabChange={onTabChange}
+      >
+        <div>Settings content</div>
+      </SettingsDialogShell>,
+    );
+
+    expect(hasHiddenClass(findMobileList(container))).toBe(false);
+
+    const mobileBillingButton = findMobileList(container)
+      ?.querySelector<HTMLElement>('[data-settings-sidebar-label="Billing"]')
+      ?.closest("button");
+    fireEvent.click(mobileBillingButton as HTMLElement);
+
+    expect(onTabChange).toHaveBeenCalledWith("billing", "space");
+    expect(hasHiddenClass(findMobileList(container))).toBe(true);
+    expect(screen.getByRole("button", { name: /Back/ })).toBeTruthy();
+  });
+});

--- a/packages/openlib/ui/dashboard/SettingsDialogShell.tsx
+++ b/packages/openlib/ui/dashboard/SettingsDialogShell.tsx
@@ -1,0 +1,561 @@
+"use client";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { Button } from "kui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "kui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "kui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "kui/tooltip";
+import { cn } from "kui/utils";
+import type { LucideIcon } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, X } from "lucide-react";
+import type React from "react";
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface SettingsShellTab<T extends string = string> {
+  id: T;
+  label: string;
+  icon: LucideIcon;
+}
+
+export interface SettingsShellSection<T extends string = string> {
+  /** Stable key for accordion expand/collapse. Falls back to `title` when omitted. */
+  key?: string;
+  title: string;
+  /** Icon shown on the accordion section header. */
+  icon?: LucideIcon;
+  /**
+   * Optional node rendered inside the expanded section, above its tabs
+   * (accordion mode). e.g. the Agent picker for the Agent settings section.
+   */
+  headerNode?: React.ReactNode;
+  tabs: SettingsShellTab<T>[];
+}
+
+export interface SettingsDialogShellProps<T extends string = string> {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Accessible title (visually hidden) */
+  title: string;
+  /** Localized label for the close button (visible to screen readers only). */
+  closeLabel: string;
+  /**
+   * Localized label for the mobile drill-down's back button. Only rendered
+   * below the `sm` breakpoint, where picking a tab replaces the section list
+   * with that tab's content. Defaults to "Back" so callers that never render
+   * at mobile width don't have to supply it.
+   */
+  backLabel?: string;
+  /** Optional trigger element rendered inside the Dialog */
+  trigger?: React.ReactNode;
+  /** Fixed height on desktop in px. Defaults to 640. */
+  desktopHeight?: number;
+  /**
+   * Tab groups shown in the sidebar.
+   * Pass a single-element array for a flat (ungrouped) sidebar.
+   */
+  sections: SettingsShellSection<T>[];
+  activeTab: T;
+  /**
+   * Called when the user picks a tab. `sectionKey` identifies which
+   * `SettingsShellSection` the clicked tab belongs to — required because tab
+   * `id`s are only unique WITHIN a section (e.g. two sections may each have a
+   * "general" tab), so the id alone can't disambiguate which section the
+   * click came from once sections are flattened into one row (mobile) or
+   * dropdown (breadcrumb tab-jump).
+   */
+  onTabChange: (tab: T, sectionKey: string) => void;
+  /**
+   * Accordion mode: section headers become clickable; only the expanded
+   * section (`activeSectionKey`) shows its tabs. Requires `activeSectionKey`
+   * and `onSectionChange`.
+   */
+  accordion?: boolean;
+  /** Key of the currently expanded section (accordion mode). */
+  activeSectionKey?: string;
+  /** Called when the user clicks a collapsed section header (accordion mode). */
+  onSectionChange?: (key: string) => void;
+  /**
+   * Optional middle crumb inserted between the section title and the tab label
+   * in the breadcrumb. Pass a string for plain text, or a node (e.g. an agent
+   * picker dropdown) for an interactive crumb.
+   */
+  breadcrumbMiddle?: React.ReactNode;
+  /**
+   * Tabs whose content area should be full-bleed (no padding, no scroll).
+   * e.g. ["skills"]
+   */
+  fullBleedTabs?: T[];
+  /**
+   * Optional CSS class applied to the shell's scrollable regions (mobile tab
+   * row, desktop sidebar, main content pane) for a host-supplied custom
+   * scrollbar look (e.g. a hover-visible thin scrollbar utility). Defaults to
+   * "" (browser default scrollbar) since this package carries no shared CSS.
+   */
+  scrollbarClassName?: string;
+  /** Optional desktop-only actions pinned to the bottom of the sidebar. */
+  sidebarFooter?: React.ReactNode;
+  /** Optional content rendered above the section list in the sidebar (desktop only). */
+  sidebarHeader?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+interface SettingsDialogActionsContextValue {
+  setActions: (actions: React.ReactNode) => void;
+  closeDialog: () => void;
+}
+
+const SettingsDialogActionsContext = createContext<SettingsDialogActionsContextValue | null>(null);
+
+export function useSettingsDialogActions() {
+  const context = useContext(SettingsDialogActionsContext);
+  return context;
+}
+
+interface OverflowTooltipNavItemProps {
+  label: string;
+  children: (labelNode: React.ReactNode) => React.ReactElement;
+}
+
+const OverflowTooltipNavItem = ({ label, children }: OverflowTooltipNavItemProps) => {
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    const labelElement = labelRef.current;
+    if (!labelElement) return;
+
+    const updateOverflow = () => {
+      if (labelElement.textContent !== label) return;
+      setIsOverflowing(labelElement.scrollWidth > labelElement.clientWidth);
+    };
+
+    updateOverflow();
+    if (typeof ResizeObserver === "undefined") return;
+
+    const resizeObserver = new ResizeObserver(updateOverflow);
+    resizeObserver.observe(labelElement);
+
+    return () => resizeObserver.disconnect();
+  }, [label]);
+
+  const labelNode = (
+    <span
+      ref={labelRef}
+      className="min-w-0 flex-1 truncate text-left"
+      data-settings-sidebar-label={label}
+    >
+      {label}
+    </span>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children(labelNode)}</TooltipTrigger>
+      {isOverflowing && (
+        <TooltipPrimitive.Portal>
+          <TooltipContent
+            side="right"
+            align="center"
+            sideOffset={8}
+            className="z-[9999] max-w-72 whitespace-normal"
+          >
+            <span className="break-words text-xs">{label}</span>
+          </TooltipContent>
+        </TooltipPrimitive.Portal>
+      )}
+    </Tooltip>
+  );
+};
+
+// ── Shell ──────────────────────────────────────────────────────────────
+
+export function SettingsDialogShell<T extends string = string>({
+  open,
+  onOpenChange,
+  title,
+  closeLabel,
+  backLabel = "Back",
+  trigger,
+  desktopHeight = 640,
+  sections,
+  activeTab,
+  onTabChange,
+  accordion = false,
+  activeSectionKey,
+  onSectionChange,
+  breadcrumbMiddle,
+  fullBleedTabs = [],
+  scrollbarClassName = "",
+  sidebarFooter,
+  sidebarHeader,
+  children,
+}: SettingsDialogShellProps<T>) {
+  const isFullBleed = fullBleedTabs.includes(activeTab);
+  const allTabs = sections.flatMap((s) => s.tabs);
+  const [actions, setActions] = useState<React.ReactNode>(null);
+  // Mobile-only: whether the user has drilled into a tab's content (vs. still
+  // browsing the section/tab list). Irrelevant on sm: and up, where sidebar +
+  // content always show side by side.
+  const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
+
+  useEffect(() => {
+    if (open) setMobileDetailOpen(false);
+  }, [open]);
+
+  const sectionKeyOf = (s: SettingsShellSection<T>) => s.key ?? s.title;
+  // Resolve which section owns the current view for the breadcrumb.
+  const activeSection = accordion
+    ? sections.find((s) => sectionKeyOf(s) === activeSectionKey)
+    : (sections.find((s) => s.tabs.some((t) => t.id === activeTab)) ?? sections[0]);
+  // Resolve the tab label from the ACTIVE section's tabs — tab ids can collide
+  // across sections (space + agent both have "general"), so searching all tabs
+  // would pick the wrong label.
+  const activeSectionTabs = activeSection?.tabs ?? [];
+  const activeTabLabel =
+    activeSectionTabs.find((t) => t.id === activeTab)?.label ??
+    allTabs.find((t) => t.id === activeTab)?.label;
+  const otherSections = accordion
+    ? sections.filter((s) => sectionKeyOf(s) !== activeSectionKey)
+    : [];
+
+  const breadcrumb =
+    activeSection && activeTabLabel ? (
+      <nav
+        aria-label="breadcrumb"
+        className="flex items-center gap-0.5 text-xs text-muted-foreground"
+      >
+        {/* Section crumb — dropdown to jump to another top-level section */}
+        {accordion && onSectionChange && otherSections.length > 0 ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 transition-colors hover:bg-accent/50 hover:text-foreground focus:outline-none"
+              >
+                {activeSection.title}
+                <ChevronDown className="h-3 w-3 opacity-50" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              {otherSections.map((s) => {
+                const k = sectionKeyOf(s);
+                const Icon = s.icon;
+                return (
+                  <DropdownMenuItem key={k} onClick={() => onSectionChange(k)} className="gap-2">
+                    {Icon && <Icon className="h-4 w-4" />}
+                    {s.title}
+                  </DropdownMenuItem>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <span className="px-1.5 py-0.5">{activeSection.title}</span>
+        )}
+
+        {breadcrumbMiddle && (
+          <>
+            <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/40" />
+            {typeof breadcrumbMiddle === "string" ? (
+              <span className="px-1.5 py-0.5 truncate">{breadcrumbMiddle}</span>
+            ) : (
+              breadcrumbMiddle
+            )}
+          </>
+        )}
+
+        <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/40" />
+
+        {/* Tab crumb — dropdown to jump to another tab in the current section */}
+        {activeSectionTabs.length > 1 ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 font-medium text-foreground transition-colors hover:bg-accent/50 focus:outline-none"
+              >
+                {activeTabLabel}
+                <ChevronDown className="h-3 w-3 opacity-50" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
+              {activeSectionTabs.map((tab) => (
+                <DropdownMenuItem
+                  key={tab.id}
+                  onClick={() => activeSection && onTabChange(tab.id, sectionKeyOf(activeSection))}
+                  className={cn("gap-2", tab.id === activeTab && "bg-accent")}
+                >
+                  <tab.icon className="h-4 w-4" />
+                  {tab.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <span className="px-1.5 py-0.5 font-medium text-foreground">{activeTabLabel}</span>
+        )}
+      </nav>
+    ) : null;
+  const actionsContextValue = useMemo(
+    () => ({ setActions, closeDialog: () => onOpenChange(false) }),
+    [onOpenChange],
+  );
+
+  // Shared section/tab nav list — used for the desktop sidebar as-is, and
+  // reused full-width as the mobile "browse" screen (onTabSelected drills
+  // into the "detail" screen there; desktop passes nothing, unaffected).
+  const renderSectionList = (onTabSelected?: () => void) => (
+    <>
+      {sections.map((section, i) => {
+        const key = sectionKeyOf(section);
+        const expanded = accordion ? key === activeSectionKey : true;
+        const SectionIcon = section.icon;
+        return (
+          <div
+            key={key}
+            className={cn(
+              accordion && expanded && "mb-1",
+              !accordion && i < sections.length - 1 && "mb-4",
+            )}
+          >
+            {accordion ? (
+              // ── Level 1: section header ──
+              // Group-title styling (not a plain nav row) so the parent/
+              // child hierarchy reads clearly against the level-2 tabs.
+              <OverflowTooltipNavItem label={section.title}>
+                {(labelNode) => (
+                  <button
+                    type="button"
+                    onClick={() => !expanded && onSectionChange?.(key)}
+                    className={cn(
+                      "flex h-9 w-full items-center gap-2 rounded-md px-2 text-sm transition-colors",
+                      expanded
+                        ? "cursor-default font-semibold text-foreground"
+                        : "font-medium text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+                    )}
+                  >
+                    {SectionIcon && (
+                      <SectionIcon
+                        className={cn(
+                          "h-4 w-4 shrink-0",
+                          expanded ? "text-foreground" : "text-muted-foreground",
+                        )}
+                      />
+                    )}
+                    {labelNode}
+                    {expanded ? (
+                      <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
+                    ) : (
+                      <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
+                    )}
+                  </button>
+                )}
+              </OverflowTooltipNavItem>
+            ) : (
+              <h3 className="text-xs font-normal text-muted-foreground/60 uppercase tracking-wider px-2 mb-2">
+                {section.title}
+              </h3>
+            )}
+            {expanded && accordion && section.headerNode && (
+              <div className="mt-1.5 mb-1 px-1">{section.headerNode}</div>
+            )}
+            {expanded &&
+              (accordion ? (
+                // ── Level 2: tabs grouped under a vertical guide rail ──
+                <div className="mt-1 ml-[15px] flex flex-col gap-0.5 border-l border-border/60 pl-2">
+                  {section.tabs.map((tab) => (
+                    <OverflowTooltipNavItem key={tab.id} label={tab.label}>
+                      {(labelNode) => (
+                        <Button
+                          variant="ghost"
+                          className={cn(
+                            "h-8 w-full justify-start gap-2 px-2 text-[13px] font-normal",
+                            activeTab === tab.id
+                              ? "bg-accent text-accent-foreground hover:bg-accent"
+                              : "text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+                          )}
+                          onClick={() => {
+                            onTabChange(tab.id, key);
+                            onTabSelected?.();
+                          }}
+                        >
+                          <tab.icon className="h-4 w-4 shrink-0" />
+                          {labelNode}
+                        </Button>
+                      )}
+                    </OverflowTooltipNavItem>
+                  ))}
+                </div>
+              ) : (
+                section.tabs.map((tab) => (
+                  <OverflowTooltipNavItem key={tab.id} label={tab.label}>
+                    {(labelNode) => (
+                      <Button
+                        variant="ghost"
+                        className={cn(
+                          "h-9 w-full justify-start gap-2 font-normal",
+                          activeTab === tab.id
+                            ? "bg-accent text-accent-foreground hover:bg-accent"
+                            : "text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+                        )}
+                        onClick={() => {
+                          onTabChange(tab.id, key);
+                          onTabSelected?.();
+                        }}
+                      >
+                        <tab.icon className="h-4 w-4 shrink-0" />
+                        {labelNode}
+                      </Button>
+                    )}
+                  </OverflowTooltipNavItem>
+                ))
+              ))}
+          </div>
+        );
+      })}
+    </>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
+      <DialogContent
+        showCloseButton={false}
+        className="w-[min(96vw,1020px)] sm:max-w-[1020px] flex flex-col p-0 gap-0 overflow-hidden rounded-2xl h-[80vh] sm:h-auto"
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogDescription className="sr-only">{title}</DialogDescription>
+
+        <div className="absolute right-3 top-3 z-20 flex items-center gap-1">
+          {actions}
+          <DialogClose className="inline-flex size-8 items-center justify-center rounded-md text-foreground/70 ring-offset-background transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+            <X className="size-4" />
+            <span className="sr-only">{closeLabel}</span>
+          </DialogClose>
+        </div>
+
+        <SettingsDialogActionsContext.Provider value={actionsContextValue}>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden sm:flex-row">
+            {/* Mobile: full-page section/tab list ("browse"), replaced by the
+                content pane ("detail") once a tab is picked — see mobileDetailOpen. */}
+            <div
+              data-settings-viewport="mobile"
+              className={cn(
+                "sm:hidden min-h-0 flex-col overflow-x-hidden overflow-y-auto px-3 pb-3 pt-14",
+                scrollbarClassName,
+                mobileDetailOpen ? "hidden" : "flex flex-1",
+              )}
+            >
+              <TooltipProvider delayDuration={300}>
+                {sidebarHeader && <div className="mb-3">{sidebarHeader}</div>}
+                {renderSectionList(() => setMobileDetailOpen(true))}
+              </TooltipProvider>
+              {sidebarFooter && (
+                <div className="mt-3 shrink-0 border-t pt-3 space-y-1">{sidebarFooter}</div>
+              )}
+            </div>
+
+            {/* Mobile: back bar shown only while browsing a tab's content. */}
+            {mobileDetailOpen && (
+              <div className="sm:hidden flex shrink-0 items-center gap-2 border-b py-2 pl-3 pr-12">
+                <button
+                  type="button"
+                  onClick={() => setMobileDetailOpen(false)}
+                  className="flex h-8 items-center gap-1 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground"
+                >
+                  <ChevronLeft className="h-4 w-4 shrink-0" />
+                  {backLabel}
+                </button>
+                {activeTabLabel && (
+                  <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                    {activeTabLabel}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Desktop: vertical sidebar */}
+            <div
+              data-settings-viewport="desktop"
+              className="hidden w-52 shrink-0 flex-col overflow-hidden border-r bg-muted/20 p-3 sm:flex lg:w-56"
+              style={{ height: `${desktopHeight}px` }}
+            >
+              <TooltipProvider delayDuration={300}>
+                <div
+                  className={cn(
+                    "min-h-0 flex-1 space-y-1 overflow-x-hidden overflow-y-auto",
+                    scrollbarClassName,
+                  )}
+                >
+                  {sidebarHeader && <div className="mb-3">{sidebarHeader}</div>}
+                  {renderSectionList()}
+                </div>
+              </TooltipProvider>
+              {sidebarFooter && (
+                <div className="mt-3 shrink-0 border-t pt-3 space-y-1">{sidebarFooter}</div>
+              )}
+            </div>
+
+            {/* Content
+             *  max-height (not height) is used here so overflow-y-auto activates
+             *  regardless of the flex container's own height. Using `height` alone
+             *  was insufficient because align-items:stretch on the row flex parent
+             *  overrides a child's height when the parent is unconstrained (sm:h-auto
+             *  on DialogContent), causing tall tabs like Security to expand the dialog
+             *  instead of scrolling within it.
+             */}
+            <div
+              className={cn(
+                "min-h-0 min-w-0 flex-1 flex-col sm:flex",
+                mobileDetailOpen ? "flex" : "hidden",
+              )}
+              style={{ maxHeight: `${desktopHeight}px` }}
+            >
+              {isFullBleed ? (
+                <>
+                  {/* Full-bleed pages own their scroll/layout, so the breadcrumb
+                      sits in a fixed header row above them. Hidden on mobile —
+                      the back bar above already shows the current tab. */}
+                  {breadcrumb && (
+                    <div className="hidden shrink-0 px-4 pt-4 pb-2 sm:block sm:px-5">
+                      {breadcrumb}
+                    </div>
+                  )}
+                  <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+                </>
+              ) : (
+                <div
+                  className={cn(
+                    "min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto",
+                    scrollbarClassName,
+                  )}
+                >
+                  <div className="min-w-0 p-4 sm:px-5 sm:py-5">
+                    {/* Breadcrumb eyebrow, sits directly above the page title.
+                        Hidden on mobile — the back bar above already shows it. */}
+                    {breadcrumb && <div className="mb-4 hidden sm:block">{breadcrumb}</div>}
+                    {children}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </SettingsDialogActionsContext.Provider>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/openlib/ui/dashboard/index.ts
+++ b/packages/openlib/ui/dashboard/index.ts
@@ -5,6 +5,7 @@ export * from "./demo-client";
 export * from "./hooks";
 export * from "./NavMain";
 export * from "./NavUser";
+export * from "./SettingsDialogShell";
 export * from "./SidebarTaskList";
 export * from "./SPABreadcrumb";
 export * from "./SPALink";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,19 +94,19 @@ importers:
         version: 0.31.9
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0)
       fumadocs-core:
         specifier: 16.14.5
-        version: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-ui:
         specifier: 16.14.5
-        version: 16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
+        version: 16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
       kui:
         specifier: workspace:*
         version: link:../../packages/kui
       lucide-react:
-        specifier: ^0.556.0
-        version: 0.556.0(react@19.2.7)
+        specifier: ^1.34.0
+        version: 1.34.0(react@19.2.7)
       next:
         specifier: 16.3.3
         version: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
@@ -232,8 +232,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/kui
       lucide-react:
-        specifier: ^0.556.0
-        version: 0.556.0(react@19.2.7)
+        specifier: ^1.34.0
+        version: 1.34.0(react@19.2.7)
       next:
         specifier: 16.3.3
         version: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
@@ -273,10 +273,10 @@ importers:
         version: 0.4.1
       '@expo/metro-runtime':
         specifier: 56.0.18
-        version: 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       '@expo/vector-icons':
         specifier: ^15.0.3
-        version: 15.0.3(expo-font@56.0.7)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 15.0.3(expo-font@56.0.7)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       '@orpc/client':
         specifier: ^1.14.6
         version: 1.14.6(@opentelemetry/api@1.9.0)
@@ -288,10 +288,10 @@ importers:
         version: 1.14.6(@opentelemetry/api@1.9.0)(@orpc/client@1.14.6(@opentelemetry/api@1.9.0))(@tanstack/query-core@5.101.0)
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
-        version: 2.2.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+        version: 2.2.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       '@react-native-cookies/cookies':
         specifier: ^6.2.1
-        version: 6.2.1(patch_hash=b09ca6391bd8bbbebd3636254f0b90ca48724fd2b23dad03ab598522f3ad0127)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+        version: 6.2.1(patch_hash=b09ca6391bd8bbbebd3636254f0b90ca48724fd2b23dad03ab598522f3ad0127)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       '@tanstack/react-query':
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.3)
@@ -309,13 +309,13 @@ importers:
         version: 3.0.0
       expo:
         specifier: ~56.0.11
-        version: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+        version: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       expo-background-task:
         specifier: ~56.0.18
-        version: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+        version: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       expo-constants:
         specifier: ~56.0.18
-        version: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+        version: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       expo-crypto:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.11)
@@ -324,7 +324,7 @@ importers:
         version: 56.0.4(expo@56.0.11)
       expo-font:
         specifier: ~56.0.7
-        version: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       expo-haptics:
         specifier: ~56.0.3
         version: 56.0.3(expo@56.0.11)
@@ -333,13 +333,13 @@ importers:
         version: 56.0.18(expo@56.0.11)
       expo-linking:
         specifier: ~56.0.14
-        version: 56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       expo-notifications:
         specifier: ~56.0.17
-        version: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2)
+        version: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2)
       expo-router:
         specifier: ~56.2.10
-        version: 56.2.10(818b2ffe1dbaecba4b09c16c3b6faa0f)
+        version: 56.2.10(d649f0a2225fc9b41a201b5c7781e831)
       expo-secure-store:
         specifier: ^56.0.4
         version: 56.0.4(expo@56.0.11)
@@ -348,19 +348,19 @@ importers:
         version: 56.0.10(expo@56.0.11)(typescript@7.0.2)
       expo-status-bar:
         specifier: ~56.0.4
-        version: 56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       expo-system-ui:
         specifier: ~56.0.5
-        version: 56.0.5(expo@56.0.11)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+        version: 56.0.5(expo@56.0.11)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       expo-task-manager:
         specifier: ~56.0.18
-        version: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+        version: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       expo-web-browser:
         specifier: ~56.0.5
-        version: 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+        version: 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       lucide-react-native:
         specifier: ^0.556.0
-        version: 0.556.0(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 0.556.0(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       openlib:
         specifier: workspace:*
         version: link:../../packages/openlib
@@ -372,28 +372,28 @@ importers:
         version: 19.2.3(react@19.2.3)
       react-native:
         specifier: 0.85.3
-        version: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+        version: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       react-native-gesture-handler:
         specifier: ~2.31.2
-        version: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       react-native-reanimated:
         specifier: ~4.3.1
-        version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       react-native-safe-area-context:
         specifier: 5.7.0
-        version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       react-native-screens:
         specifier: ~4.25.2
-        version: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       react-native-svg:
         specifier: 15.15.4
-        version: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       react-native-web:
         specifier: ~0.21.2
         version: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-native-webview:
         specifier: 13.16.1
-        version: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+        version: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -491,8 +491,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       lucide-react:
-        specifier: ^0.556.0
-        version: 0.556.0(react@19.2.7)
+        specifier: ^1.34.0
+        version: 1.34.0(react@19.2.7)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -535,7 +535,7 @@ importers:
         version: link:../../apps/busabase-sdk
       fumadocs-core:
         specifier: 16.14.5
-        version: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.33.0(react@19.2.7))(next@16.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
@@ -587,13 +587,13 @@ importers:
         version: link:../../apps/busabase-sdk
       fumadocs-core:
         specifier: 16.14.5
-        version: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-ui:
         specifier: 16.14.5
-        version: 16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
+        version: 16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
       lucide-react:
-        specifier: ^0.556.0
-        version: 0.556.0(react@19.2.7)
+        specifier: ^1.34.0
+        version: 1.34.0(react@19.2.7)
       next:
         specifier: 16.3.3
         version: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
@@ -704,6 +704,9 @@ importers:
       '@orpc/zod':
         specifier: ^1.14.6
         version: 1.14.6(@opentelemetry/api@1.9.0)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.0))(@orpc/server@1.14.6(@opentelemetry/api@1.9.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.23
+        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@scelar/nodepod':
         specifier: ^1.9.20
         version: 1.9.20(patch_hash=7fc761dfebd713e7059856683b37a78cc4483a4e6a7243df1fc190a894af01a6)(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(vite@7.1.9(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(stylus@0.64.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -724,7 +727,7 @@ importers:
         version: link:../busabase-package
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0)
       elkjs:
         specifier: ^0.9.3
         version: 0.9.3
@@ -738,8 +741,8 @@ importers:
         specifier: workspace:*
         version: link:../kui
       lucide-react:
-        specifier: ^0.556.0
-        version: 0.556.0(react@19.2.7)
+        specifier: ^1.34.0
+        version: 1.34.0(react@19.2.7)
       micromark:
         specifier: ^4.0.2
         version: 4.0.2
@@ -971,8 +974,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react:
-        specifier: ^1.33.0
-        version: 1.33.0(react@19.2.7)
+        specifier: ^1.34.0
+        version: 1.34.0(react@19.2.7)
       media-chrome:
         specifier: ^4.19.2
         version: 4.19.2(react@19.2.7)
@@ -1063,7 +1066,7 @@ importers:
         version: 1.14.6(@opentelemetry/api@1.9.0)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0)
       openlib:
         specifier: workspace:*
         version: link:../openlib
@@ -1117,19 +1120,19 @@ importers:
         version: 1.11.10
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0)
       fumadocs-core:
         specifier: 16.14.5
-        version: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.7.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-ui:
         specifier: 16.14.5
-        version: 16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.7.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
+        version: 16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
       kui:
         specifier: workspace:*
         version: link:../kui
       lucide-react:
-        specifier: '>=0.556.0'
-        version: 1.7.0(react@19.2.7)
+        specifier: ^1.34.0
+        version: 1.34.0(react@19.2.7)
       mime-types:
         specifier: ^2.1.35
         version: 2.1.35
@@ -9000,18 +9003,8 @@ packages:
       react-native: '*'
       react-native-svg: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
 
-  lucide-react@0.556.0:
-    resolution: {integrity: sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  lucide-react@1.33.0:
-    resolution: {integrity: sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  lucide-react@1.7.0:
-    resolution: {integrity: sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==}
+  lucide-react@1.34.0:
+    resolution: {integrity: sha512-vnjGJNI7Htk5+oWW8gXGuaLgwgAb0T6/iZbBrp9JCfRFwdNWZ0YTm3eyxjOLgwN6r8iyAf3UA70zNmBRBNv7yg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -13563,7 +13556,7 @@ snapshots:
 
   '@expo-google-fonts/material-symbols@0.4.38': {}
 
-  '@expo/cli@56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@expo/cli@56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@7.0.2)
@@ -13573,7 +13566,7 @@ snapshots:
       '@expo/image-utils': 0.10.1(typescript@7.0.2)
       '@expo/inline-modules': 0.0.11(typescript@7.0.2)
       '@expo/json-file': 10.2.0
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@expo/metro-config': 56.0.14(bufferutil@4.1.0)(expo@56.0.11)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@expo/metro-file-map': 56.0.3
@@ -13598,7 +13591,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.6
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       expo-server: 56.0.5
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -13624,8 +13617,8 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.10(818b2ffe1dbaecba4b09c16c3b6faa0f)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      expo-router: 56.2.10(d649f0a2225fc9b41a201b5c7781e831)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@expo/dom-webview'
       - '@expo/metro-runtime'
@@ -13639,7 +13632,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@expo/cli@56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@7.0.2)(utf-8-validate@5.0.10)':
+  '@expo/cli@56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@7.0.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@7.0.2)
@@ -13649,7 +13642,7 @@ snapshots:
       '@expo/image-utils': 0.10.1(typescript@7.0.2)
       '@expo/inline-modules': 0.0.11(typescript@7.0.2)
       '@expo/json-file': 10.2.0
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@expo/metro-config': 56.0.14(bufferutil@4.1.0)(expo@56.0.11)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@expo/metro-file-map': 56.0.3
@@ -13674,7 +13667,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.6
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
       expo-server: 56.0.5
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -13700,8 +13693,8 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.10(9fb076151369289459144445e7f942e1)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      expo-router: 56.2.10(5c753956ae8fdd3d9e6c0e3a9432f11c)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@expo/dom-webview'
       - '@expo/metro-runtime'
@@ -13716,7 +13709,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@expo/cli@56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@7.0.2)(utf-8-validate@6.0.6)':
+  '@expo/cli@56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@7.0.2)(utf-8-validate@6.0.6)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 56.0.9(typescript@7.0.2)
@@ -13726,7 +13719,7 @@ snapshots:
       '@expo/image-utils': 0.10.1(typescript@7.0.2)
       '@expo/inline-modules': 0.0.11(typescript@7.0.2)
       '@expo/json-file': 10.2.0
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@expo/metro-config': 56.0.14(bufferutil@4.1.0)(expo@56.0.11)(typescript@7.0.2)(utf-8-validate@6.0.6)
       '@expo/metro-file-map': 56.0.3
@@ -13751,7 +13744,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.6
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
       expo-server: 56.0.5
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -13777,8 +13770,8 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.10(312ab9e79a718a669fd195b74a01f937)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      expo-router: 56.2.10(710c68676a07b8bd0f5f48d22de70f6d)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/dom-webview'
       - '@expo/metro-runtime'
@@ -13841,47 +13834,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
+  '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
+  '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
+  '@expo/devtools@56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
     dependencies:
       chalk: 4.1.2
     optionalDependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  '@expo/dom-webview@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
+  '@expo/dom-webview@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  '@expo/dom-webview@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
+  '@expo/dom-webview@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
     dependencies:
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  '@expo/dom-webview@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
+  '@expo/dom-webview@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
     dependencies:
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
   '@expo/env@2.3.0':
@@ -13943,32 +13936,32 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/log-box@56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
+  '@expo/log-box@56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
     dependencies:
-      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       anser: 1.4.10
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       stacktrace-parser: 0.1.11
 
-  '@expo/log-box@56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
+  '@expo/log-box@56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
     dependencies:
-      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       anser: 1.4.10
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
       stacktrace-parser: 0.1.11
     optional: true
 
-  '@expo/log-box@56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
+  '@expo/log-box@56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
     dependencies:
-      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       anser: 1.4.10
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
     optional: true
 
@@ -13998,7 +13991,7 @@ snapshots:
       postcss: 8.5.22
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -14031,7 +14024,7 @@ snapshots:
       postcss: 8.5.22
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -14050,41 +14043,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/metro-runtime@56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
+  '@expo/metro-runtime@56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
     dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       anser: 1.4.10
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       pretty-format: 29.7.0
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
       react-dom: 19.2.3(react@19.2.3)
 
-  '@expo/metro-runtime@56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
+  '@expo/metro-runtime@56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
     dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       anser: 1.4.10
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
       pretty-format: 29.7.0
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
     optional: true
 
-  '@expo/metro-runtime@56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
+  '@expo/metro-runtime@56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
     dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       anser: 1.4.10
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
       pretty-format: 29.7.0
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
     optionalDependencies:
@@ -14097,7 +14090,7 @@ snapshots:
       metro-babel-transformer: 0.84.4
       metro-cache: 0.84.4
       metro-cache-key: 0.84.4
-      metro-config: 0.84.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.84.4
       metro-file-map: 0.84.4
       metro-minify-terser: 0.84.4
@@ -14182,14 +14175,14 @@ snapshots:
   '@expo/router-server@56.0.14(@expo/metro-runtime@56.0.18)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo-server@56.0.5)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       debug: 4.4.3
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       expo-server: 56.0.5
       react: 19.2.3
     optionalDependencies:
-      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      expo-router: 56.2.10(818b2ffe1dbaecba4b09c16c3b6faa0f)
+      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo-router: 56.2.10(d649f0a2225fc9b41a201b5c7781e831)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -14197,14 +14190,14 @@ snapshots:
   '@expo/router-server@56.0.14(@expo/metro-runtime@56.0.18)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo-server@56.0.5)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       debug: 4.4.3
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       expo-server: 56.0.5
       react: 19.2.7
     optionalDependencies:
-      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      expo-router: 56.2.10(312ab9e79a718a669fd195b74a01f937)
+      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo-router: 56.2.10(710c68676a07b8bd0f5f48d22de70f6d)
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - supports-color
@@ -14220,61 +14213,61 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/ui@56.0.17(8c92481c2e3b9062df13c425840fe0cf)':
+  '@expo/ui@56.0.17(18834e0097d83bb8b200bd94b45a4253)':
     dependencies:
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
-      react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
-      sf-symbols-typescript: 2.2.0
-      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    optionalDependencies:
-      '@babel/core': 7.29.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-    optional: true
-
-  '@expo/ui@56.0.17(a930e5fda1bb8bc4fbba570c41afb0a3)':
-    dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       sf-symbols-typescript: 2.2.0
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
       '@babel/core': 7.29.7
       react-dom: 19.2.3(react@19.2.3)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
 
-  '@expo/ui@56.0.17(fec994d4eb8bd1e7b6a8f388fbfa13e9)':
+  '@expo/ui@56.0.17(e87fa6cbd852c7f69dc13000ffe8cd2a)':
     dependencies:
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
       sf-symbols-typescript: 2.2.0
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
       '@babel/core': 7.29.7
       react-dom: 19.2.7(react@19.2.7)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
     optional: true
 
-  '@expo/vector-icons@15.0.3(expo-font@56.0.7)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
+  '@expo/ui@56.0.17(f109ef4284c26127ccbc49f8cd863955)':
     dependencies:
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
+      react: 19.2.7
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      sf-symbols-typescript: 2.2.0
+      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@babel/core': 7.29.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    optional: true
+
+  '@expo/vector-icons@15.0.3(expo-font@56.0.7)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
+    dependencies:
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
   '@expo/ws-tunnel@2.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
@@ -16823,10 +16816,10 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
-  '@react-native-async-storage/async-storage@2.2.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))':
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
   '@react-native-community/cli-clean@20.1.3':
     dependencies:
@@ -17013,26 +17006,26 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@react-native-cookies/cookies@6.2.1(patch_hash=b09ca6391bd8bbbebd3636254f0b90ca48724fd2b23dad03ab598522f3ad0127)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))':
+  '@react-native-cookies/cookies@6.2.1(patch_hash=b09ca6391bd8bbbebd3636254f0b90ca48724fd2b23dad03ab598522f3ad0127)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))':
     dependencies:
       invariant: 2.2.4
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
+  '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
+  '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
     dependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
+  '@react-native-masked-view/masked-view@0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
     dependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
   '@react-native/assets-registry@0.85.3': {}
@@ -17093,24 +17086,24 @@ snapshots:
       tinyglobby: 0.2.17
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+  '@react-native/community-cli-plugin@0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@react-native/dev-middleware': 0.85.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.84.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.84.4
       semver: 7.8.5
     optionalDependencies:
       '@react-native-community/cli': 20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@react-native/community-cli-plugin@0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+  '@react-native/community-cli-plugin@0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@react-native/dev-middleware': 0.85.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       debug: 4.4.3
@@ -17121,7 +17114,7 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       '@react-native-community/cli': 20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6)
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -17190,7 +17183,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/metro-config@0.85.3(@babel/core@7.29.7)':
+  '@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@react-native/js-polyfills': 0.85.3
+      '@react-native/metro-babel-transformer': 0.85.3(@babel/core@7.29.7)
+      metro-config: 0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-runtime: 0.84.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@react-native/js-polyfills': 0.85.3
       '@react-native/metro-babel-transformer': 0.85.3(@babel/core@7.29.7)
@@ -17198,37 +17203,40 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+    optional: true
 
   '@react-native/normalize-colors@0.74.89': {}
 
   '@react-native/normalize-colors@0.85.3': {}
 
-  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
+  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
+  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optionalDependencies:
       '@types/react': 19.2.17
     optional: true
 
-  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
+  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@types/react': 19.2.17
     optional: true
@@ -18960,7 +18968,7 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -19805,14 +19813,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260617.1
       '@electric-sql/pglite': 0.3.15
       '@opentelemetry/api': 1.9.0
       '@prisma/client': 6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2)
       '@types/pg': 8.16.0
-      expo-sqlite: 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      expo-sqlite: 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       kysely: 0.29.3
       mysql2: 3.17.1
       pg: 8.18.0
@@ -19820,14 +19828,14 @@ snapshots:
       prisma: 6.16.3(magicast@0.3.5)(typescript@7.0.2)
       sql.js: 1.14.0
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260617.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.16.0)(expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(kysely@0.29.3)(mysql2@3.17.1)(pg@8.18.0)(postgres@3.4.8)(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(sql.js@1.14.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260617.1
       '@electric-sql/pglite': 0.3.15
       '@opentelemetry/api': 1.9.0
       '@prisma/client': 6.16.3(prisma@6.16.3(magicast@0.3.5)(typescript@7.0.2))(typescript@7.0.2)
       '@types/pg': 8.16.0
-      expo-sqlite: 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo-sqlite: 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       kysely: 0.29.3
       mysql2: 3.17.1
       pg: 8.18.0
@@ -20148,195 +20156,195 @@ snapshots:
 
   expo-application@56.0.3(expo@56.0.11):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
 
-  expo-asset@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2):
+  expo-asset@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2):
     dependencies:
       '@expo/image-utils': 0.10.1(typescript@7.0.2)
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-asset@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@7.0.2):
+  expo-asset@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@7.0.2):
     dependencies:
       '@expo/image-utils': 0.10.1(typescript@7.0.2)
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
       - typescript
     optional: true
 
-  expo-asset@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@7.0.2):
+  expo-asset@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@7.0.2):
     dependencies:
       '@expo/image-utils': 0.10.1(typescript@7.0.2)
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
     optional: true
 
-  expo-background-task@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
+  expo-background-task@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      expo-task-manager: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      expo-task-manager: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
     transitivePeerDependencies:
       - react-native
 
-  expo-constants@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
+  expo-constants@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
     dependencies:
       '@expo/env': 2.3.0
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)):
+  expo-constants@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)):
     dependencies:
       '@expo/env': 2.3.0
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  expo-constants@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)):
+  expo-constants@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)):
     dependencies:
       '@expo/env': 2.3.0
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
   expo-crypto@56.0.4(expo@56.0.11):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
 
   expo-document-picker@56.0.4(expo@56.0.11):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
 
-  expo-file-system@56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
+  expo-file-system@56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  expo-file-system@56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)):
+  expo-file-system@56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)):
     dependencies:
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  expo-file-system@56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)):
+  expo-file-system@56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  expo-font@56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  expo-font@56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       fontfaceobserver: 2.3.0
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  expo-font@56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  expo-font@56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
       fontfaceobserver: 2.3.0
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  expo-font@56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  expo-font@56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
       fontfaceobserver: 2.3.0
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  expo-glass-effect@56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  expo-glass-effect@56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  expo-glass-effect@56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  expo-glass-effect@56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  expo-glass-effect@56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  expo-glass-effect@56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
   expo-haptics@56.0.3(expo@56.0.11):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
 
   expo-image-loader@56.0.3(expo@56.0.11):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
 
   expo-image-picker@56.0.18(expo@56.0.11):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       expo-image-loader: 56.0.3(expo@56.0.11)
 
   expo-keep-awake@56.0.3(expo@56.0.11)(react@19.2.3):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       react: 19.2.3
 
   expo-keep-awake@56.0.3(expo@56.0.11)(react@19.2.7):
     dependencies:
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
       react: 19.2.7
     optional: true
 
-  expo-linking@56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  expo-linking@56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - expo
       - supports-color
 
-  expo-linking@56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  expo-linking@56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
       invariant: 2.2.4
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - expo
       - supports-color
     optional: true
 
-  expo-linking@56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  expo-linking@56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
       invariant: 2.2.4
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - expo
       - supports-color
@@ -20352,87 +20360,87 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  expo-modules-core@56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       '@expo/expo-modules-macros-plugin': 0.2.2
-      expo-modules-jsi: 56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo-modules-jsi: 56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
     optionalDependencies:
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
 
-  expo-modules-core@56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  expo-modules-core@56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       '@expo/expo-modules-macros-plugin': 0.2.2
-      expo-modules-jsi: 56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
+      expo-modules-jsi: 56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
       invariant: 2.2.4
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optionalDependencies:
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
     optional: true
 
-  expo-modules-core@56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  expo-modules-core@56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       '@expo/expo-modules-macros-plugin': 0.2.2
-      expo-modules-jsi: 56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
+      expo-modules-jsi: 56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
       invariant: 2.2.4
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optionalDependencies:
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
     optional: true
 
-  expo-modules-jsi@56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
+  expo-modules-jsi@56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
     dependencies:
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  expo-modules-jsi@56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)):
+  expo-modules-jsi@56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)):
     dependencies:
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  expo-modules-jsi@56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)):
+  expo-modules-jsi@56.0.9(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)):
     dependencies:
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  expo-notifications@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2):
+  expo-notifications@56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2):
     dependencies:
       '@expo/image-utils': 0.10.1(typescript@7.0.2)
       abort-controller: 3.0.0
       badgin: 1.2.3
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       expo-application: 56.0.3(expo@56.0.11)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-router@56.2.10(312ab9e79a718a669fd195b74a01f937):
+  expo-router@56.2.10(5c753956ae8fdd3d9e6c0e3a9432f11c):
     dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       '@expo/schema-utils': 56.0.1
-      '@expo/ui': 56.0.17(8c92481c2e3b9062df13c425840fe0cf)
+      '@expo/ui': 56.0.17(e87fa6cbd852c7f69dc13000ffe8cd2a)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       client-only: 0.0.1
       color: 4.2.3
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
-      expo-glass-effect: 56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      expo-linking: 56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
+      expo-glass-effect: 56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      expo-linking: 56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       expo-server: 56.0.5
-      expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.18
@@ -20440,10 +20448,10 @@ snapshots:
       react: 19.2.7
       react-fast-compare: 3.2.2
       react-is: 19.2.4
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
-      react-native-drawer-layout: 4.2.5(a03d6160d4eeabdf5eb52bb321542cde)
-      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      react-native-screens: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native-drawer-layout: 4.2.5(30312299dd1bcae0d53dc3d388c912ac)
+      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native-screens: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
@@ -20451,8 +20459,8 @@ snapshots:
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -20464,27 +20472,79 @@ snapshots:
       - supports-color
     optional: true
 
-  expo-router@56.2.10(818b2ffe1dbaecba4b09c16c3b6faa0f):
+  expo-router@56.2.10(710c68676a07b8bd0f5f48d22de70f6d):
     dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       '@expo/schema-utils': 56.0.1
-      '@expo/ui': 56.0.17(a930e5fda1bb8bc4fbba570c41afb0a3)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.3)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/ui': 56.0.17(f109ef4284c26127ccbc49f8cd863955)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       client-only: 0.0.1
       color: 4.2.3
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
-      expo-glass-effect: 56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      expo-linking: 56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
+      expo-glass-effect: 56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo-linking: 56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       expo-server: 56.0.5
-      expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.18
+      query-string: 7.1.3
+      react: 19.2.7
+      react-fast-compare: 3.2.2
+      react-is: 19.2.4
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native-drawer-layout: 4.2.5(d20ecf2cabd6b22c18fa665ea61442d3)
+      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-screens: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      standard-navigation: 0.0.5
+      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@testing-library/dom'
+      - '@types/react'
+      - '@types/react-dom'
+      - expo-font
+      - react-native-worklets
+      - supports-color
+    optional: true
+
+  expo-router@56.2.10(d649f0a2225fc9b41a201b5c7781e831):
+    dependencies:
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/schema-utils': 56.0.1
+      '@expo/ui': 56.0.17(18834e0097d83bb8b200bd94b45a4253)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.3)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      client-only: 0.0.1
+      color: 4.2.3
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo-glass-effect: 56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo-linking: 56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo-server: 56.0.5
+      expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.18
@@ -20492,10 +20552,10 @@ snapshots:
       react: 19.2.3
       react-fast-compare: 3.2.2
       react-is: 19.2.4
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
-      react-native-drawer-layout: 4.2.5(c21937c4c768b0375b6e6d163a5523e8)
-      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      react-native-screens: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native-drawer-layout: 4.2.5(5ffcefc10edc2556e86b152b970f690e)
+      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native-screens: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
@@ -20503,8 +20563,8 @@ snapshots:
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
       react-dom: 19.2.3(react@19.2.3)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
@@ -20515,61 +20575,9 @@ snapshots:
       - react-native-worklets
       - supports-color
 
-  expo-router@56.2.10(9fb076151369289459144445e7f942e1):
-    dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      '@expo/schema-utils': 56.0.1
-      '@expo/ui': 56.0.17(fec994d4eb8bd1e7b6a8f388fbfa13e9)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      client-only: 0.0.1
-      color: 4.2.3
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
-      expo-glass-effect: 56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      expo-linking: 56.0.14(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      expo-server: 56.0.5
-      expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      fast-deep-equal: 3.1.3
-      invariant: 2.2.4
-      nanoid: 3.3.18
-      query-string: 7.1.3
-      react: 19.2.7
-      react-fast-compare: 3.2.2
-      react-is: 19.2.4
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
-      react-native-drawer-layout: 4.2.5(6fdb658cf346ce3213e9f901b826b582)
-      react-native-safe-area-context: 5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      react-native-screens: 4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      server-only: 0.0.1
-      sf-symbols-typescript: 2.2.0
-      shallowequal: 1.1.0
-      standard-navigation: 0.0.5
-      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    optionalDependencies:
-      react-dom: 19.2.7(react@19.2.7)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@testing-library/dom'
-      - '@types/react'
-      - '@types/react-dom'
-      - expo-font
-      - react-native-worklets
-      - supports-color
-    optional: true
-
   expo-secure-store@56.0.4(expo@56.0.11):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
 
   expo-server@56.0.5: {}
 
@@ -20577,160 +20585,117 @@ snapshots:
     dependencies:
       '@expo/config-plugins': 56.0.8(typescript@7.0.2)
       '@expo/image-utils': 0.10.1(typescript@7.0.2)
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       await-lock: 2.2.2
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  expo-sqlite@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       await-lock: 2.2.2
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  expo-status-bar@56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  expo-status-bar@56.0.4(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  expo-symbols@56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  expo-symbols@56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.38
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       sf-symbols-typescript: 2.2.0
 
-  expo-symbols@56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  expo-symbols@56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.38
-      expo: 56.0.11(510b5295c67ef74d5df70674af36acc5)
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      expo: 56.0.11(2220459dd498514c5c25669c78d4e756)
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
       sf-symbols-typescript: 2.2.0
     optional: true
 
-  expo-symbols@56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  expo-symbols@56.0.6(expo-font@56.0.7)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.38
-      expo: 56.0.11(99dfdeca537466a9a0ecec7c663e6c19)
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo: 56.0.11(ae800e4096e42abead98d2665db84d2c)
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
       sf-symbols-typescript: 2.2.0
     optional: true
 
-  expo-system-ui@56.0.5(expo@56.0.11)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
+  expo-system-ui@56.0.5(expo@56.0.11)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
     dependencies:
       '@react-native/normalize-colors': 0.85.3
       debug: 4.4.3
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
     optionalDependencies:
       react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
 
-  expo-task-manager@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
+  expo-task-manager@56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       unimodules-app-loader: 56.0.1
 
-  expo-web-browser@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
+  expo-web-browser@56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)):
     dependencies:
-      expo: 56.0.11(2074b482cf56fdbaded539438e5e0e1c)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      expo: 56.0.11(b4c531be2a77cba62842ed5b18e4334a)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  expo@56.0.11(2074b482cf56fdbaded539438e5e0e1c):
+  expo@56.0.11(2220459dd498514c5c25669c78d4e756):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@expo/cli': 56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@expo/config': 56.0.9(typescript@7.0.2)
       '@expo/config-plugins': 56.0.8(typescript@7.0.2)
-      '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       '@expo/fingerprint': 0.19.4
       '@expo/local-build-cache-provider': 56.0.8(typescript@7.0.2)
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@expo/metro-config': 56.0.14(bufferutil@4.1.0)(expo@56.0.11)(typescript@7.0.2)(utf-8-validate@5.0.10)
       '@ungap/structured-clone': 1.3.0
       babel-preset-expo: 56.0.15(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@56.0.11)(react-refresh@0.14.2)
-      expo-asset: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
-      expo-file-system: 56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      expo-keep-awake: 56.0.3(expo@56.0.11)(react@19.2.3)
-      expo-modules-autolinking: 56.0.15(typescript@7.0.2)
-      expo-modules-core: 56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      pretty-format: 29.7.0
-      react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
-      react-refresh: 0.14.2
-      whatwg-url-minimum: 0.1.2
-    optionalDependencies:
-      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      react-dom: 19.2.3(react@19.2.3)
-      react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react-native-webview: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - expo-router
-      - expo-widgets
-      - react-native-worklets
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  expo@56.0.11(510b5295c67ef74d5df70674af36acc5):
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@expo/cli': 56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@expo/config': 56.0.9(typescript@7.0.2)
-      '@expo/config-plugins': 56.0.8(typescript@7.0.2)
-      '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      '@expo/fingerprint': 0.19.4
-      '@expo/local-build-cache-provider': 56.0.8(typescript@7.0.2)
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      '@expo/metro-config': 56.0.14(bufferutil@4.1.0)(expo@56.0.11)(typescript@7.0.2)(utf-8-validate@5.0.10)
-      '@ungap/structured-clone': 1.3.0
-      babel-preset-expo: 56.0.15(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@56.0.11)(react-refresh@0.14.2)
-      expo-asset: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@7.0.2)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
-      expo-file-system: 56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      expo-asset: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)(typescript@7.0.2)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
+      expo-file-system: 56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       expo-keep-awake: 56.0.3(expo@56.0.11)(react@19.2.7)
       expo-modules-autolinking: 56.0.15(typescript@7.0.2)
-      expo-modules-core: 56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      expo-modules-core: 56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       pretty-format: 29.7.0
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.2
     optionalDependencies:
-      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
       react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-native-webview: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native-webview: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -20743,38 +20708,38 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  expo@56.0.11(99dfdeca537466a9a0ecec7c663e6c19):
+  expo@56.0.11(ae800e4096e42abead98d2665db84d2c):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@7.0.2)(utf-8-validate@6.0.6)
+      '@expo/cli': 56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@7.0.2)(utf-8-validate@6.0.6)
       '@expo/config': 56.0.9(typescript@7.0.2)
       '@expo/config-plugins': 56.0.8(typescript@7.0.2)
-      '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       '@expo/fingerprint': 0.19.4
       '@expo/local-build-cache-provider': 56.0.8(typescript@7.0.2)
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@expo/metro-config': 56.0.14(bufferutil@4.1.0)(expo@56.0.11)(typescript@7.0.2)(utf-8-validate@6.0.6)
       '@ungap/structured-clone': 1.3.0
       babel-preset-expo: 56.0.15(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@56.0.11)(react-refresh@0.14.2)
-      expo-asset: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@7.0.2)
-      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
-      expo-file-system: 56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
-      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo-asset: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)(typescript@7.0.2)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
+      expo-file-system: 56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       expo-keep-awake: 56.0.3(expo@56.0.11)(react@19.2.7)
       expo-modules-autolinking: 56.0.15(typescript@7.0.2)
-      expo-modules-core: 56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      expo-modules-core: 56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       pretty-format: 29.7.0
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
       react-refresh: 0.14.2
       whatwg-url-minimum: 0.1.2
     optionalDependencies:
-      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
       react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-native-webview: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-webview: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -20786,6 +20751,49 @@ snapshots:
       - typescript
       - utf-8-validate
     optional: true
+
+  expo@56.0.11(b4c531be2a77cba62842ed5b18e4334a):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@expo/cli': 56.1.15(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.18)(bufferutil@4.1.0)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.10)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@expo/config': 56.0.9(typescript@7.0.2)
+      '@expo/config-plugins': 56.0.8(typescript@7.0.2)
+      '@expo/devtools': 56.0.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/fingerprint': 0.19.4
+      '@expo/local-build-cache-provider': 56.0.8(typescript@7.0.2)
+      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.5)(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/metro': 56.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@expo/metro-config': 56.0.14(bufferutil@4.1.0)(expo@56.0.11)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      '@ungap/structured-clone': 1.3.0
+      babel-preset-expo: 56.0.15(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@56.0.11)(react-refresh@0.14.2)
+      expo-asset: 56.0.17(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@7.0.2)
+      expo-constants: 56.0.18(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo-file-system: 56.0.8(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))
+      expo-font: 56.0.7(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      expo-keep-awake: 56.0.3(expo@56.0.11)(react@19.2.3)
+      expo-modules-autolinking: 56.0.15(typescript@7.0.2)
+      expo-modules-core: 56.0.16(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      pretty-format: 29.7.0
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-refresh: 0.14.2
+      whatwg-url-minimum: 0.1.2
+    optionalDependencies:
+      '@expo/dom-webview': 56.0.5(expo@56.0.11)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@expo/metro-runtime': 56.0.18(@expo/log-box@56.0.13)(expo@56.0.11)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-dom: 19.2.3(react@19.2.3)
+      react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-native-webview: 13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - expo-router
+      - expo-widgets
+      - react-native-worklets
+      - react-server-dom-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
 
   exponential-backoff@3.1.3: {}
 
@@ -21014,7 +21022,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@fumari/image-size': 0.1.0
       estree-util-value-to-estree: 3.5.0
@@ -21041,7 +21049,7 @@ snapshots:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
-      lucide-react: 0.556.0(react@19.2.7)
+      lucide-react: 1.34.0(react@19.2.7)
       next: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -21049,112 +21057,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
-    dependencies:
-      '@fumari/image-size': 0.1.0
-      estree-util-value-to-estree: 3.5.0
-      github-slugger: 2.0.0
-      hast-util-to-estree: 3.1.3
-      hast-util-to-jsx-runtime: 2.3.6
-      mdast-util-mdx: 3.0.0
-      mdast-util-to-markdown: 2.1.2
-      npm-to-yarn: 3.2.0
-      remark: 15.0.1
-      remark-gfm: 4.0.1
-      remark-rehype: 11.1.2
-      scroll-into-view-if-needed: 3.1.0
-      shiki: 4.4.3
-      tinyglobby: 0.2.17
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-      yaml: 2.9.0
-      zbsearch: 4.0.0
-    optionalDependencies:
-      '@mdx-js/mdx': 3.1.1
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.5
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.17
-      lucide-react: 0.556.0(react@19.2.7)
-      next: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.33.0(react@19.2.7))(next@16.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
-    dependencies:
-      '@fumari/image-size': 0.1.0
-      estree-util-value-to-estree: 3.5.0
-      github-slugger: 2.0.0
-      hast-util-to-estree: 3.1.3
-      hast-util-to-jsx-runtime: 2.3.6
-      mdast-util-mdx: 3.0.0
-      mdast-util-to-markdown: 2.1.2
-      npm-to-yarn: 3.2.0
-      remark: 15.0.1
-      remark-gfm: 4.0.1
-      remark-rehype: 11.1.2
-      scroll-into-view-if-needed: 3.1.0
-      shiki: 4.4.3
-      tinyglobby: 0.2.17
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-      yaml: 2.9.0
-      zbsearch: 4.0.0
-    optionalDependencies:
-      '@mdx-js/mdx': 3.1.1
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.5
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.17
-      lucide-react: 1.33.0(react@19.2.7)
-      next: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.7.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
-    dependencies:
-      '@fumari/image-size': 0.1.0
-      estree-util-value-to-estree: 3.5.0
-      github-slugger: 2.0.0
-      hast-util-to-estree: 3.1.3
-      hast-util-to-jsx-runtime: 2.3.6
-      mdast-util-mdx: 3.0.0
-      mdast-util-to-markdown: 2.1.2
-      npm-to-yarn: 3.2.0
-      remark: 15.0.1
-      remark-gfm: 4.0.1
-      remark-rehype: 11.1.2
-      scroll-into-view-if-needed: 3.1.0
-      shiki: 4.4.3
-      tinyglobby: 0.2.17
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-      yaml: 2.9.0
-      zbsearch: 4.0.0
-    optionalDependencies:
-      '@mdx-js/mdx': 3.1.1
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.5
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.17
-      lucide-react: 1.7.0(react@19.2.7)
-      next: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  fumadocs-ui@16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3):
+  fumadocs-ui@16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fumadocs/tailwind': 0.1.1(tailwindcss@4.3.3)
@@ -21170,78 +21073,8 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
       cnfast: 0.1.0
-      fumadocs-core: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
-      lucide-react: 1.33.0(react@19.2.7)
-      motion: 13.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-      rehype-raw: 7.0.0
-      scroll-into-view-if-needed: 3.1.0
-      shiki: 4.4.3
-      unist-util-visit: 5.1.0
-    optionalDependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 19.2.17
-      next: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
-    transitivePeerDependencies:
-      - '@types/react-dom'
-      - tailwindcss
-
-  fumadocs-ui@16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3):
-    dependencies:
-      '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@fumadocs/tailwind': 0.1.1(tailwindcss@4.3.3)
-      '@radix-ui/react-accordion': 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-navigation-menu': 1.2.22(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-popover': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-scroll-area': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      class-variance-authority: 0.7.1
-      cnfast: 0.1.0
-      fumadocs-core: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.556.0(react@19.2.7))(next@16.3.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
-      lucide-react: 1.33.0(react@19.2.7)
-      motion: 13.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-      rehype-raw: 7.0.0
-      scroll-into-view-if-needed: 3.1.0
-      shiki: 4.4.3
-      unist-util-visit: 5.1.0
-    optionalDependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 19.2.17
-      next: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)
-    transitivePeerDependencies:
-      - '@types/react-dom'
-      - tailwindcss
-
-  fumadocs-ui@16.14.5(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.7.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3):
-    dependencies:
-      '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@fumadocs/tailwind': 0.1.1(tailwindcss@4.3.3)
-      '@radix-ui/react-accordion': 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-navigation-menu': 1.2.22(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-popover': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-scroll-area': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      class-variance-authority: 0.7.1
-      cnfast: 0.1.0
-      fumadocs-core: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.7.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
-      lucide-react: 1.33.0(react@19.2.7)
+      fumadocs-core: 16.14.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.34.0(react@19.2.7))(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      lucide-react: 1.34.0(react@19.2.7)
       motion: 13.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -22152,21 +21985,13 @@ snapshots:
   lru.min@1.1.4:
     optional: true
 
-  lucide-react-native@0.556.0(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  lucide-react-native@0.556.0(react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
-      react-native-svg: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native-svg: 15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
 
-  lucide-react@0.556.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-
-  lucide-react@1.33.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-
-  lucide-react@1.7.0(react@19.2.7):
+  lucide-react@1.34.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 
@@ -22488,6 +22313,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-config@0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-cache: 0.84.4
+      metro-core: 0.84.4
+      metro-runtime: 0.84.4
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-config@0.84.4(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -22502,6 +22342,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro-core@0.84.4:
     dependencies:
@@ -22612,6 +22453,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro@0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
@@ -22638,7 +22480,7 @@ snapshots:
       metro-babel-transformer: 0.84.4
       metro-cache: 0.84.4
       metro-cache-key: 0.84.4
-      metro-config: 0.84.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.84.4
       metro-file-map: 0.84.4
       metro-resolver: 0.84.4
@@ -22704,6 +22546,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -23916,153 +23759,153 @@ snapshots:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
-  react-native-drawer-layout@4.2.5(6fdb658cf346ce3213e9f901b826b582):
+  react-native-drawer-layout@4.2.5(30312299dd1bcae0d53dc3d388c912ac):
     dependencies:
       color: 4.2.3
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       use-latest-callback: 0.2.6(react@19.2.7)
     optional: true
 
-  react-native-drawer-layout@4.2.5(a03d6160d4eeabdf5eb52bb321542cde):
-    dependencies:
-      color: 4.2.3
-      react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      use-latest-callback: 0.2.6(react@19.2.7)
-    optional: true
-
-  react-native-drawer-layout@4.2.5(c21937c4c768b0375b6e6d163a5523e8):
+  react-native-drawer-layout@4.2.5(5ffcefc10edc2556e86b152b970f690e):
     dependencies:
       color: 4.2.3
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
-      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
 
-  react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  react-native-drawer-layout@4.2.5(d20ecf2cabd6b22c18fa665ea61442d3):
+    dependencies:
+      color: 4.2.3
+      react: 19.2.7
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native-gesture-handler: 2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-reanimated: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      use-latest-callback: 0.2.6(react@19.2.7)
+    optional: true
+
+  react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       '@types/react-test-renderer': 19.1.0
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       '@types/react-test-renderer': 19.1.0
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       '@types/react-test-renderer': 19.1.0
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  react-native-is-edge-to-edge@1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       semver: 7.8.4
 
-  react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
-      semver: 7.8.4
-    optional: true
-
-  react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
-      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       semver: 7.8.4
     optional: true
 
-  react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      react-native-worklets: 0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      semver: 7.8.4
+    optional: true
+
+  react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  react-native-safe-area-context@5.7.0(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  react-native-screens@4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  react-native-screens@4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-freeze: 1.0.4(react@19.2.3)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       warn-once: 0.1.1
 
-  react-native-screens@4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  react-native-screens@4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-freeze: 1.0.4(react@19.2.7)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
       warn-once: 0.1.1
     optional: true
 
-  react-native-screens@4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  react-native-screens@4.25.2(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-freeze: 1.0.4(react@19.2.7)
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
       warn-once: 0.1.1
     optional: true
 
-  react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  react-native-svg@15.15.4(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       warn-once: 0.1.1
 
   react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
@@ -24096,30 +23939,30 @@ snapshots:
       - encoding
     optional: true
 
-  react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
 
-  react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
     optional: true
 
-  react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
     optional: true
 
-  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
+  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
@@ -24131,15 +23974,15 @@ snapshots:
       '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       convert-source-map: 2.0.0
       react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
-  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
+  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
@@ -24151,16 +23994,16 @@ snapshots:
       '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       convert-source-map: 2.0.0
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10)
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
+  react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
@@ -24172,24 +24015,24 @@ snapshots:
       '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       convert-source-map: 2.0.0
       react: 19.2.7
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10):
+  react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10):
     dependencies:
       '@react-native/assets-registry': 0.85.3
       '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
-      '@react-native/community-cli-plugin': 0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@react-native/community-cli-plugin': 0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@react-native/gradle-plugin': 0.85.3
       '@react-native/js-polyfills': 0.85.3
       '@react-native/normalize-colors': 0.85.3
-      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
+      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -24226,15 +24069,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10):
+  react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10):
     dependencies:
       '@react-native/assets-registry': 0.85.3
       '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
-      '@react-native/community-cli-plugin': 0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@react-native/community-cli-plugin': 0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@react-native/gradle-plugin': 0.85.3
       '@react-native/js-polyfills': 0.85.3
       '@react-native/normalize-colors': 0.85.3
-      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
+      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@5.0.10))(react@19.2.7)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -24272,15 +24115,15 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6):
+  react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6):
     dependencies:
       '@react-native/assets-registry': 0.85.3
       '@react-native/codegen': 0.85.3(@babel/core@7.29.7)
-      '@react-native/community-cli-plugin': 0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@react-native/community-cli-plugin': 0.85.3(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@react-native/gradle-plugin': 0.85.3
       '@react-native/js-polyfills': 0.85.3
       '@react-native/normalize-colors': 0.85.3
-      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
+      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.17)(react-native@0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.1.3(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@6.0.6))(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6))(react@19.2.7)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -25952,6 +25795,7 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
+    optional: true
 
   ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:


### PR DESCRIPTION
Busabase v0.21.0.

- feat(core): agent install shortcuts, template gallery previews, ACL scan cuts
- feat(server): search node content by text, not just by name
- feat(cli)!: busabase-cli check, and read lines from any node type
- chore(desktop): desktop and mobile apps updates
- chore(cms): CMS adapter and example updates
- feat(packages): auditPackage and auditSkill in busabase-package
- chore(release): v0.21.0

Merging this publishes to npm and builds the Docker image, so let CI finish
first.