### PR TITLE
ci(publish-npm): follow the busabase-cms → busabase-cms-sdk rename

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,5 +1,5 @@
-# Publishes busabase-package + busabase-cli + busabase-sdk + busabase-cms + busabase to npm with
-# provenance, from the public repo, on GitHub's official ubuntu-latest runner.
+# Publishes busabase-package + busabase-cli + busabase-sdk + busabase-cms-sdk + busabase to npm
+# with provenance, from the public repo, on GitHub's official ubuntu-latest runner.
 # It also publishes short-name alias packages busa-cli + busa-sdk from the same
 # built artifacts.
 # busabase depends on busabase-cli via workspace:*, so both publish with
@@ -60,7 +60,7 @@ jobs:
       # busabase-desktop and busabase-mobile (Expo/RN); installing those here would
       # pull React Native and run their native postinstall scripts for no reason on
       # an npm publish.
-      - run: pnpm install --frozen-lockfile --filter "busabase..." --filter "busabase-package..." --filter "busabase-cli..." --filter "busabase-sdk..." --filter "busabase-cms..."
+      - run: pnpm install --frozen-lockfile --filter "busabase..." --filter "busabase-package..." --filter "busabase-cli..." --filter "busabase-sdk..." --filter "busabase-cms-sdk..."
 
       - name: Get versions
         id: v
@@ -68,7 +68,7 @@ jobs:
           echo "package=$(node -p "require('./packages/busabase-package/package.json').version")" >> "$GITHUB_OUTPUT"
           echo "cli=$(node -p "require('./apps/busabase-cli/package.json').version")" >> "$GITHUB_OUTPUT"
           echo "sdk=$(node -p "require('./apps/busabase-sdk/package.json').version")" >> "$GITHUB_OUTPUT"
-          echo "cms=$(node -p "require('./packages/busabase-cms/package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "cms_sdk=$(node -p "require('./packages/busabase-cms-sdk/package.json').version")" >> "$GITHUB_OUTPUT"
           echo "app=$(node -p "require('./apps/busabase/package.json').version")" >> "$GITHUB_OUTPUT"
 
       # busabase-sdk MUST build before busabase-cli: the CLI keeps busabase-sdk external
@@ -82,8 +82,8 @@ jobs:
           test -f dist/index.js
           test -f dist/index.d.ts
 
-      - name: Build and test busabase-cms
-        working-directory: packages/busabase-cms
+      - name: Build and test busabase-cms-sdk
+        working-directory: packages/busabase-cms-sdk
         run: |
           pnpm typecheck
           pnpm test
@@ -121,7 +121,7 @@ jobs:
           npm view busabase-package@${{ steps.v.outputs.package }} version >/dev/null 2>&1 && echo "package=true" >> "$GITHUB_OUTPUT" || echo "package=false" >> "$GITHUB_OUTPUT"
           npm view busabase-cli@${{ steps.v.outputs.cli }} version >/dev/null 2>&1 && echo "cli=true" >> "$GITHUB_OUTPUT" || echo "cli=false" >> "$GITHUB_OUTPUT"
           npm view busabase-sdk@${{ steps.v.outputs.sdk }} version >/dev/null 2>&1 && echo "sdk=true" >> "$GITHUB_OUTPUT" || echo "sdk=false" >> "$GITHUB_OUTPUT"
-          npm view busabase-cms@${{ steps.v.outputs.cms }} version >/dev/null 2>&1 && echo "cms=true" >> "$GITHUB_OUTPUT" || echo "cms=false" >> "$GITHUB_OUTPUT"
+          npm view busabase-cms-sdk@${{ steps.v.outputs.cms_sdk }} version >/dev/null 2>&1 && echo "cms_sdk=true" >> "$GITHUB_OUTPUT" || echo "cms_sdk=false" >> "$GITHUB_OUTPUT"
           npm view busabase@${{ steps.v.outputs.app }} version >/dev/null 2>&1 && echo "app=true" >> "$GITHUB_OUTPUT" || echo "app=false" >> "$GITHUB_OUTPUT"
           npm view busa-cli@${{ steps.v.outputs.cli }} version >/dev/null 2>&1 && echo "busa_cli=true" >> "$GITHUB_OUTPUT" || echo "busa_cli=false" >> "$GITHUB_OUTPUT"
           npm view busa-sdk@${{ steps.v.outputs.sdk }} version >/dev/null 2>&1 && echo "busa_sdk=true" >> "$GITHUB_OUTPUT" || echo "busa_sdk=false" >> "$GITHUB_OUTPUT"
@@ -143,9 +143,9 @@ jobs:
         working-directory: apps/busabase-cli
         run: pnpm publish --access public --no-git-checks
 
-      - name: Publish busabase-cms
-        if: steps.pub.outputs.cms != 'true'
-        working-directory: packages/busabase-cms
+      - name: Publish busabase-cms-sdk
+        if: steps.pub.outputs.cms_sdk != 'true'
+        working-directory: packages/busabase-cms-sdk
         run: pnpm publish --access public --no-git-checks
 
       - name: Publish busabase
@@ -248,7 +248,7 @@ jobs:
             echo "- busabase-package@${{ steps.v.outputs.package }} — already published: ${{ steps.pub.outputs.package }}"
             echo "- busabase-cli@${{ steps.v.outputs.cli }} — already published: ${{ steps.pub.outputs.cli }}"
             echo "- busabase-sdk@${{ steps.v.outputs.sdk }} — already published: ${{ steps.pub.outputs.sdk }}"
-            echo "- busabase-cms@${{ steps.v.outputs.cms }} — already published: ${{ steps.pub.outputs.cms }}"
+            echo "- busabase-cms-sdk@${{ steps.v.outputs.cms_sdk }} — already published: ${{ steps.pub.outputs.cms_sdk }}"
             echo "- busabase@${{ steps.v.outputs.app }} — already published: ${{ steps.pub.outputs.app }}"
             echo "- busa-cli@${{ steps.v.outputs.cli }} — already published: ${{ steps.pub.outputs.busa_cli }}"
             echo "- busa-sdk@${{ steps.v.outputs.sdk }} — already published: ${{ steps.pub.outputs.busa_sdk }}"


### PR DESCRIPTION
## Why

`packages/busabase-cms` is being renamed to `packages/busabase-cms-sdk` (directory and npm package name together) — [kapps#7007](https://github.com/vikadata/kapps/pull/7007). The name described what the SDK is *about*, not what it *is*: a typed client library you install into your own app, not a CMS. Both READMEs already had to open with a disclaimer saying so.

This workflow hardcodes the old path and package name in six places. Left as-is, the very next publish run after the rename syncs into this repo fails immediately:

```
Get versions
  Error: Cannot find module './packages/busabase-cms/package.json'
```

## What changes

Every reference — the install filter, version lookup, build/test working-directory, published-version check, the publish step, and the summary line — moves to `packages/busabase-cms-sdk` / `busabase-cms-sdk`. Renamed the internal output key `cms` → `cms_sdk` for consistency with `busa_cli`/`busa_sdk`.

## ⚠️ Sequencing — opened as draft on purpose

This repo's `packages/busabase-cms` directory has **not been renamed yet** — that lands via the next sync from the kapps monorepo, after kapps#7007 merges. If this PR merges *before* that sync, the next unrelated push matching this workflow's `paths:` filter fails CI on `main` for everyone, at a path that no longer matches anything.

**Merge this together with, or immediately after, the sync PR that renames `packages/busabase-cms` here** — not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
