### PR TITLE
fix(ci): give the CMS example the base URL under the name it reads

### DIFF
--- a/.github/workflows/vercel-cms-example.yml
+++ b/.github/workflows/vercel-cms-example.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           set -euo pipefail
           cms_runtime_env=(
-            --env "BUSABASE_BASE_URL=${BUSABASE_BASE_URL}"
+            --env "BUSABASE_CMS_BASE_URL=${BUSABASE_BASE_URL}"
             --env "BUSABASE_CMS_FOLDER_ID=${BUSABASE_CMS_FOLDER_ID}"
             --env "BUSABASE_CMS_DEFAULT_LOCALE=${BUSABASE_CMS_DEFAULT_LOCALE}"
             --env "BUSABASE_CMS_LOCALES=${BUSABASE_CMS_LOCALES}"


### PR DESCRIPTION
## Summary

The production deployment has been rendering the **"Connect a Busabase space"
empty state on every content route**, even though the demo workspace has
published posts and the folder id resolves correctly.

The deploy injects five runtime variables. Four use the `BUSABASE_CMS_*`
prefix — but the base URL goes in as `BUSABASE_BASE_URL`, while the app reads
`process.env.BUSABASE_CMS_BASE_URL`.

That name is half of the app's own gate:

```ts
const isConfigured = Boolean(
  process.env.BUSABASE_CMS_BASE_URL && process.env.BUSABASE_CMS_FOLDER_ID,
);
```

So `isConfigured` has always been `false` in production. The SDK's fallback to
unprefixed `BUSABASE_*` never gets a chance, because the gate is evaluated
before the SDK is constructed.

The comment directly above that gate already called this shot:

> a CMS app reading half its config under one prefix and half under another is
> how you lose an afternoon.

One-line change: inject the value as `BUSABASE_CMS_BASE_URL`, so all five
runtime variables share the prefix the app documents and reads.

## Validation

Same production build both ways, differing **only** in the variable name, run
against the real demo workspace:

| injected as | `/blog` result |
|---|---|
| `BUSABASE_CMS_BASE_URL` (this PR) | **9 posts listed** |
| `BUSABASE_BASE_URL` (today) | **0 posts**, `"Connect a Busabase space"` |

The failing case reproduces exactly what the deployed site serves right now.

Independently confirmed the data was never the problem — querying the demo
workspace straight through the SDK returns the same 9 published posts:

```
published posts (en): 9
  - audit-trails-are-a-growth-feature | Audit trails are a growth feature
  - multimodal-review-is-the-next-frontier | Multimodal review is the next frontier
  - vector-search-alone-won-t-save-your-rag | Vector search alone won't save your RAG
  ...
```

## Note

Unrelated to the recent package rename — this dates back to the commit that
first configured the example for the public demo, so the deployed site has
been empty since then. Found while verifying the rename had reached the
deployment.
