### PR TITLE
fix(ci): configure the CMS example at build time, not just at runtime

### DIFF
--- a/.github/workflows/vercel-cms-example.yml
+++ b/.github/workflows/vercel-cms-example.yml
@@ -43,7 +43,7 @@ concurrency:
 env:
   NODE_VERSION: 24.18.0
   DEPLOY_ENVIRONMENT: ${{ (github.event_name == 'push' || inputs.environment == 'production') && 'production' || 'preview' }}
-  BUSABASE_BASE_URL: https://demo.busabase.com
+  BUSABASE_CMS_BASE_URL: https://demo.busabase.com
   BUSABASE_CMS_FOLDER_SLUG: cms
   BUSABASE_CMS_DEFAULT_LOCALE: en
   BUSABASE_CMS_LOCALES: en,zh-CN
@@ -100,7 +100,7 @@ jobs:
         run: |
           set -euo pipefail
           cms_folder_id=$(
-            curl --fail --silent --show-error "${BUSABASE_BASE_URL}/api/v1/nodes" |
+            curl --fail --silent --show-error "${BUSABASE_CMS_BASE_URL}/api/v1/nodes" |
               jq --raw-output --arg slug "$BUSABASE_CMS_FOLDER_SLUG" \
                 '[.. | objects | select(.type == "folder" and .slug == $slug) | .id][0] // empty'
           )
@@ -120,7 +120,25 @@ jobs:
 
       - name: Pull Vercel environment
         if: steps.vercel_config.outputs.ready == 'true'
-        run: vercel pull --yes --environment="$DEPLOY_ENVIRONMENT" --token="$VERCEL_TOKEN"
+        shell: bash
+        run: |
+          set -euo pipefail
+          vercel pull --yes --environment="$DEPLOY_ENVIRONMENT" --token="$VERCEL_TOKEN"
+          # `vercel build` prerenders the statically-generated content routes
+          # (/categories and /tags), so the CMS config has to be present at
+          # BUILD time — passing it only to `vercel deploy` is too late, those
+          # pages are already baked. Their 5m revalidate does not rescue them
+          # either: the deployment serves the prerendered empty state.
+          # `vercel build` reads .vercel/.env.<target>.local, which `vercel pull`
+          # just wrote, so append the CMS config there.
+          env_file=".vercel/.env.${DEPLOY_ENVIRONMENT}.local"
+          {
+            echo "BUSABASE_CMS_BASE_URL=${BUSABASE_CMS_BASE_URL}"
+            echo "BUSABASE_CMS_FOLDER_ID=${BUSABASE_CMS_FOLDER_ID}"
+            echo "BUSABASE_CMS_DEFAULT_LOCALE=${BUSABASE_CMS_DEFAULT_LOCALE}"
+            echo "BUSABASE_CMS_LOCALES=${BUSABASE_CMS_LOCALES}"
+            echo "NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL}"
+          } >> "$env_file"
 
       - name: Build Vercel project
         if: steps.vercel_config.outputs.ready == 'true'
@@ -140,7 +158,7 @@ jobs:
         run: |
           set -euo pipefail
           cms_runtime_env=(
-            --env "BUSABASE_CMS_BASE_URL=${BUSABASE_BASE_URL}"
+            --env "BUSABASE_CMS_BASE_URL=${BUSABASE_CMS_BASE_URL}"
             --env "BUSABASE_CMS_FOLDER_ID=${BUSABASE_CMS_FOLDER_ID}"
             --env "BUSABASE_CMS_DEFAULT_LOCALE=${BUSABASE_CMS_DEFAULT_LOCALE}"
             --env "BUSABASE_CMS_LOCALES=${BUSABASE_CMS_LOCALES}"
@@ -164,6 +182,6 @@ jobs:
             echo
             echo "- Environment: **${DEPLOY_ENVIRONMENT}**"
             echo "- URL: [${DEPLOYMENT_URL}](${DEPLOYMENT_URL})"
-            echo "- CMS endpoint: [${BUSABASE_BASE_URL}](${BUSABASE_BASE_URL})"
+            echo "- CMS endpoint: [${BUSABASE_CMS_BASE_URL}](${BUSABASE_CMS_BASE_URL})"
             echo "- CMS folder: \`${BUSABASE_CMS_FOLDER_ID}\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Follow-up to #48. That fixed the base URL's name, and `/blog` came back — the
live site now lists all 9 posts. But `/categories` and `/tags` are still
empty, and the cause is different.

Those two routes are **statically prerendered** (the build output marks them
static with a 5m revalidate), so they are rendered by `vercel build`. The CMS
config was only handed to `vercel deploy` — too late. Those pages were already
baked as the "no content" state, and because the deploy is `--prebuilt`, that
prerender is what gets served. The 5m revalidate does not rescue them: the
live site has been up for well over an hour and still serves zero.

That is exactly the split we see in production:

| route | rendering | live result |
|---|---|---|
| `/blog` | server-rendered on demand | ✅ 9 posts |
| `/pages` | server-rendered on demand | ✅ 14 pages |
| `/categories` | **static prerender** | ❌ 0 |
| `/tags` | **static prerender** | ❌ 0 |

## Changes

- Rename the workflow-level `BUSABASE_BASE_URL` to `BUSABASE_CMS_BASE_URL`,
  so every reference uses the one name the app reads and the build process
  inherits it too.
- After `vercel pull`, append the CMS config to `.vercel/.env.<target>.local`
  — the file `vercel build` reads — so the prerender is configured the same
  way the runtime is.

Step order already supports this: **Resolve demo CMS folder** (which exports
`BUSABASE_CMS_FOLDER_ID`) runs before **Pull Vercel environment**.

## Validation

Same code, same runtime config, against the real demo workspace. The only
variable is whether the **build** had the CMS config:

| build config | `/categories` | `/tags` | `/blog` |
|---|---|---|---|
| absent | **0** | **0** | 9 |
| present | **2** | **3** | 9 |

The "absent" row reproduces production exactly, including `/blog` still
working — which is what makes this a build-time problem rather than a repeat
of #48.

The counts match what the workspace actually holds; querying the SDK directly
reports 4 categories and 6 tags across locales, which is 2 and 3 in `en`.

YAML re-parsed after the edit; the job still has its 11 steps in the same
order.
