### PR TITLE
ci: build container images before release merges

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -175,6 +175,25 @@ jobs:
           path: apps/busabase/playwright-report/
           retention-days: 14
 
+  # Build the final runtime image before a release PR can merge. The publishing
+  # workflow still owns registry login and multi-arch pushes on main; this job
+  # is credential-free and proves the Dockerfile against the exact PR tree.
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./apps/busabase/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=busabase-pr
+          cache-to: type=gha,mode=max,scope=busabase-pr
+
   benchmark:
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## 问题

发布 PR 的必需检查没有构建 Docker 镜像，因此 Dockerfile 可以在 PR 全绿并合并、npm 已开始发布后才第一次失败。

## 根因

现有 ci-ok 覆盖 lint、typecheck、测试、覆盖率和 e2e，但真正的容器构建只在 main push 后运行。

## 修复

在可复用检查套件中加入无凭据、非推送的完整 linux/amd64 Docker 构建。注册表登录和多架构推送仍只由 main 的发布工作流负责。

## 验证

- 方法：YAML 解析、git diff --check，以及本 PR 上的真实 GitHub Actions Docker 构建
- 结果：本地结构检查通过；等待 PR CI 构建最终镜像
- 信心值：High — 使用与发布相同的 Dockerfile 和 Buildx action，只关闭推送
- 已知风险/未覆盖：PR 只构建 amd64；main 仍负责最终 amd64+arm64 多架构发布
- 截图：无 UI 变更，也未进行浏览器验证。

## Files Affected

- .github/workflows/ci-checks.yml — 将 Docker 构建纳入发布前必需检查。