### PR TITLE
revert: remove the pull-request Docker build gate

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -175,25 +175,6 @@ jobs:
           path: apps/busabase/playwright-report/
           retention-days: 14
 
-  # Build the final runtime image before a release PR can merge. The publishing
-  # workflow still owns registry login and multi-arch pushes on main; this job
-  # is credential-free and proves the Dockerfile against the exact PR tree.
-  docker:
-    name: Docker build
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./apps/busabase/Dockerfile
-          platforms: linux/amd64
-          push: false
-          cache-from: type=gha,scope=busabase-pr
-          cache-to: type=gha,mode=max,scope=busabase-pr
-
   benchmark:
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## 修复

按维护决定撤销 #54，不再在必需的 pull-request 检查中构建完整 Docker 镜像。

该 revert 将 .github/workflows/ci-checks.yml 精确恢复到 #54 合并前的内容；main 上原有的 Docker 发布工作流保持不变。

## 验证

- git diff 对比 #54 的父提交：ci-checks.yml 无差异
- git diff --check：通过
- 截图：无 UI 变更。