### PR TITLE
Release v0.51.0

### DIFF
--- a/apps/busabase-cli/package.json
+++ b/apps/busabase-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-cli",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Command-line client for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server`.",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-cli",

--- a/apps/busabase-cli/src/package/commands.ts
+++ b/apps/busabase-cli/src/package/commands.ts
@@ -32,6 +32,7 @@ import {
 import { deriveSkillDraft, validateTemplate } from "busabase-package/template";
 import { suggestSlug } from "busabase-package/tree";
 import type { BusabaseClient } from "busabase-sdk";
+import { iStringParse } from "openlib/i18n/i-string";
 
 /** Progress is diagnostics, not data — it must never pollute `--output json` on stdout. */
 const reportProgress = (message: string): void => {
@@ -238,7 +239,11 @@ const renderPackageChoices = (
       .filter(Boolean)
       .join(" · ");
     lines.push(`  ${candidate.name}  (${shape})`);
-    if (candidate.description) lines.push(`    ${candidate.description}`);
+    // A terminal has no locale context of its own — flatten to "en" before the
+    // falsiness check, since an empty-per-locale iString object is still a
+    // truthy object.
+    const description = iStringParse(candidate.description, "en");
+    if (description) lines.push(`    ${description}`);
     for (const error of candidate.templateErrors) {
       lines.push(`    not a template: ${error}`);
     }
@@ -328,7 +333,9 @@ export const runExport = async (
       tree.rootSkill = {
         slug: manifest.name,
         name: manifest.name,
-        description: manifest.description,
+        // The synthetic root skill mirrors SKILL.md frontmatter, which stays
+        // single-locale by design — flatten rather than widen this shape.
+        description: iStringParse(manifest.description, "en"),
         files: [{ path: PACKAGE_SKILL_ENTRY, bytes: Buffer.from(deriveSkillDraft(tree), "utf8") }],
       };
     }

--- a/apps/busabase-desktop/package.json
+++ b/apps/busabase-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@busabase/desktop",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.51.0",
   "type": "module",
   "scripts": {
     "dev": "next dev --port 3064",

--- a/apps/busabase-desktop/src-tauri/Cargo.lock
+++ b/apps/busabase-desktop/src-tauri/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "busabase_desktop"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "semver",
  "serde",

--- a/apps/busabase-desktop/src-tauri/Cargo.toml
+++ b/apps/busabase-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busabase_desktop"
-version = "0.50.0"
+version = "0.51.0"
 description = "Busabase Desktop - private local-first Busabase knowledge base shell"
 authors = ["Busabase Team"]
 edition = "2021"

--- a/apps/busabase-desktop/src-tauri/tauri.conf.json
+++ b/apps/busabase-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Busabase Desktop",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "identifier": "com.busabase.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/busabase-mobile/app.json
+++ b/apps/busabase-mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Busabase",
     "slug": "busabase-mobile",
     "scheme": "busabase",
-    "version": "0.50.0",
+    "version": "0.51.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/busabase-mobile/package.json
+++ b/apps/busabase-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-mobile",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "main": "expo-router/entry",
   "private": true,
   "scripts": {

--- a/apps/busabase-mobile/src/domains/workspace/utils/node-agent-prompts.test.ts
+++ b/apps/busabase-mobile/src/domains/workspace/utils/node-agent-prompts.test.ts
@@ -21,13 +21,41 @@ describe("buildNodeAgentPrompts", () => {
   });
 
   it("uses the shared approval and reply guidance for each mobile locale", () => {
+    // Selected by key, not by position. This asserted on `scenarios[0]` and passed
+    // only because the first entry happened to be a mutating one — so promoting a
+    // read-only scenario to the top of the shared list turned it red without any
+    // mutating prompt having actually lost its approval line.
+    const mutating = (result: ReturnType<typeof buildNodeAgentPrompts>) => {
+      const prompt = result.scenarios.find((entry) => entry.key === "base-bulk-import");
+      if (!prompt)
+        throw new Error("expected the shared Base scenarios to include base-bulk-import");
+      return prompt;
+    };
+
     const english = buildNodeAgentPrompts(context, "en");
-    expect(english.scenarios[0].body).toContain("never merge it without my approval");
-    expect(english.scenarios[0].body).toContain("Reply to me in English");
+    expect(mutating(english).body).toContain("never merge it without my approval");
+    expect(mutating(english).body).toContain("Reply to me in English");
 
     const chinese = buildNodeAgentPrompts(context, "zh-CN");
-    expect(chinese.scenarios[0].body).toContain("未经我批准绝不要合并");
-    expect(chinese.scenarios[0].body).toContain("请用简体中文回复我");
+    expect(mutating(chinese).body).toContain("未经我批准绝不要合并");
+    expect(mutating(chinese).body).toContain("请用简体中文回复我");
+  });
+
+  it("carries the reply guidance but NOT the approval line on read-only scenarios", () => {
+    // The mobile app renders the same bodies, so "read-only" has to read as
+    // read-only here too — an approval line on a prompt that writes nothing is
+    // the kind of wrong that only shows up in a transcript.
+    for (const [locale, reply, approval] of [
+      ["en", "Reply to me in English", "never merge it without my approval"],
+      ["zh-CN", "请用简体中文回复我", "未经我批准绝不要合并"],
+    ] as const) {
+      const readOnly = buildNodeAgentPrompts(context, locale).scenarios.find(
+        (entry) => entry.key === "base-find",
+      );
+      if (!readOnly) throw new Error("expected the shared Base scenarios to include base-find");
+      expect(readOnly.body).toContain(reply);
+      expect(readOnly.body).not.toContain(approval);
+    }
   });
 
   it("leaves no unresolved tokens in shared prompts", () => {

--- a/apps/busabase-sdk/package.json
+++ b/apps/busabase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-sdk",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Typed TypeScript/JavaScript SDK for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server` (or Busabase Cloud).",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-sdk",

--- a/apps/busabase/package.json
+++ b/apps/busabase/package.json
@@ -18,7 +18,7 @@
     "pglite",
     "cli"
   ],
-  "version": "0.50.0",
+  "version": "0.51.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase",

--- a/apps/busabase/public/assets/readme/coverage.svg
+++ b/apps/busabase/public/assets/readme/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="107" height="20" role="img" aria-label="coverage: 76.1%">
-  <title>coverage: 76.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="107" height="20" role="img" aria-label="coverage: 75.9%">
+  <title>coverage: 75.9%</title>
   <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
   <clipPath id="r"><rect width="107" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
@@ -10,7 +10,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="310" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="520">coverage</text>
     <text x="310" y="140" transform="scale(.1)" fill="#fff" textLength="520">coverage</text>
-    <text aria-hidden="true" x="845" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">76.1%</text>
-    <text x="845" y="140" transform="scale(.1)" fill="#fff" textLength="330">76.1%</text>
+    <text aria-hidden="true" x="845" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">75.9%</text>
+    <text x="845" y="140" transform="scale(.1)" fill="#fff" textLength="330">75.9%</text>
   </g>
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-repo",
   "private": true,
-  "version": "0.50.0",
+  "version": "0.51.0",
   "packageManager": "pnpm@10.15.1",
   "workspaces": [
     "apps/*",

--- a/packages/busabase-cms-sdk/src/integration/index.ts
+++ b/packages/busabase-cms-sdk/src/integration/index.ts
@@ -27,10 +27,12 @@ export {
   type CmsPageHelpers,
   type CmsPageHelpersIntegration,
   type CmsPageHelpersOptions,
+  type CmsPageIdentity,
   type CmsPageMetadataOptions,
   type CmsPageReads,
   createCmsPageHelpers,
   createCmsPageReads,
+  type ResolvedCmsPage,
 } from "./pages";
 export {
   type BlogCardContent,

--- a/packages/busabase-cms-sdk/src/integration/pages.ts
+++ b/packages/busabase-cms-sdk/src/integration/pages.ts
@@ -55,6 +55,12 @@ export const createCmsPageReads = (
 
 // ── Page detail resolution + metadata ──────────────────────────────────────────
 
+/**
+ * The locale every other locale falls back to when it has no translation of a Page.
+ * Mirrors the Post resolver in ./posts.ts — see `resolvePostPageWithDependencies`.
+ */
+const FALLBACK_LOCALE = "en";
+
 /** The argument object an app's own `generatePageMetadata` helper accepts. */
 export interface CmsPageMetadataOptions {
   title: string;
@@ -64,18 +70,38 @@ export interface CmsPageMetadataOptions {
   type: "website" | "article";
 }
 
+/**
+ * All the locale resolver actually reads off a Page: its canonical path and its locale. Kept
+ * deliberately narrower than `PageVO` so an app whose own Page VO omits SDK fields it does not
+ * store (Buda drops `hero`/`features`/`faqs`) still flows through these helpers with its own
+ * type intact, instead of being silently widened back to `PageVO`.
+ */
+export type CmsPageIdentity = Pick<PageVO, "path" | "locale">;
+
+/**
+ * A Page resolved for one request, carrying the locale that actually supplied the content.
+ * `isLocaleFallback` is what a route reads to decide whether to render a "not translated yet,
+ * showing English" notice. Structurally mirrors `ResolvedCmsPostPage` on the Post side.
+ */
+export interface ResolvedCmsPage<TPage extends CmsPageIdentity = PageVO> {
+  page: TPage;
+  requestedLocale: string;
+  contentLocale: string;
+  isLocaleFallback: boolean;
+}
+
 /** The slice of a `CmsIntegration` the Page helpers depend on. */
-export interface CmsPageHelpersIntegration {
+export interface CmsPageHelpersIntegration<TPage extends CmsPageIdentity = PageVO> {
   buildCmsPath: (locale: string, path: string | readonly string[]) => string | null;
   parseCmsPath: (path: string) => CmsCanonicalPath | null;
   isCmsContentForLocale: (item: { locale: string; path: string }, locale: string) => boolean;
-  getBusabaseLandingPageByPathOrFallback: (path: string) => Promise<PageVO | null>;
+  getBusabaseLandingPageByPathOrFallback: (path: string) => Promise<TPage | null>;
   /** Status-aware variant, for callers that turn a missing page into a 404. */
-  readBusabaseLandingPageByPath: (path: string) => Promise<CmsRead<PageVO | null>>;
+  readBusabaseLandingPageByPath: (path: string) => Promise<CmsRead<TPage | null>>;
 }
 
-export interface CmsPageHelpersOptions<TMetadata> {
-  integration: CmsPageHelpersIntegration;
+export interface CmsPageHelpersOptions<TMetadata, TPage extends CmsPageIdentity = PageVO> {
+  integration: CmsPageHelpersIntegration<TPage>;
   /**
    * The app's own metadata helper. Injected and typed structurally so the SDK does not depend
    * on any app's site config.
@@ -83,8 +109,26 @@ export interface CmsPageHelpersOptions<TMetadata> {
   generatePageMetadata: (options: CmsPageMetadataOptions) => TMetadata;
 }
 
-export interface CmsPageHelpers<TMetadata> {
-  getCmsPageForRequest: (lang: string, path: string | readonly string[]) => Promise<PageVO | null>;
+export interface CmsPageHelpers<TMetadata, TPage extends CmsPageIdentity = PageVO> {
+  /**
+   * STRICT per-locale lookup: no English fallback, `null` when this exact locale has no Page.
+   * Callers that run their own cross-locale cascade (Buda's use-case resolver cascades CMS →
+   * bundled ICP → editorial before falling back) must use this — handing them the fallback
+   * variant makes every locale look translated, which silently suppresses the "showing English"
+   * notice and mislabels the content locale.
+   */
+  getCmsPageForLocale: (locale: string, path: string | readonly string[]) => Promise<TPage | null>;
+  /**
+   * The resolved Page only. Falls back to English when the requested locale has no translation,
+   * so an untranslated Page renders in English instead of 404ing — the same rule the Post
+   * resolver applies. Use `resolveCmsPageForRequest` when the route needs to know it fell back.
+   */
+  getCmsPageForRequest: (lang: string, path: string | readonly string[]) => Promise<TPage | null>;
+  /** Same resolution as `getCmsPageForRequest`, plus which locale supplied the content. */
+  resolveCmsPageForRequest: (
+    lang: string,
+    path: string | readonly string[],
+  ) => Promise<ResolvedCmsPage<TPage> | null>;
   /**
    * Status-aware variant. A CMS Page has no local-MDX equivalent, so a catch-all
    * route cannot otherwise tell "no page at this path" (a correct, cacheable
@@ -94,14 +138,19 @@ export interface CmsPageHelpers<TMetadata> {
   readCmsPageForRequest: (
     lang: string,
     path: string | readonly string[],
-  ) => Promise<CmsRead<PageVO | null>>;
+  ) => Promise<CmsRead<TPage | null>>;
+  /** Status-aware variant of `resolveCmsPageForRequest`. */
+  readResolvedCmsPageForRequest: (
+    lang: string,
+    path: string | readonly string[],
+  ) => Promise<CmsRead<ResolvedCmsPage<TPage> | null>>;
   generateCmsPageMetadata: (page: PageVO, lang: string) => TMetadata | Record<string, never>;
 }
 
-export const createCmsPageHelpers = <TMetadata>({
+export const createCmsPageHelpers = <TMetadata, TPage extends CmsPageIdentity = PageVO>({
   integration,
   generatePageMetadata,
-}: CmsPageHelpersOptions<TMetadata>): CmsPageHelpers<TMetadata> => {
+}: CmsPageHelpersOptions<TMetadata, TPage>): CmsPageHelpers<TMetadata, TPage> => {
   const {
     buildCmsPath,
     getBusabaseLandingPageByPathOrFallback,
@@ -110,29 +159,89 @@ export const createCmsPageHelpers = <TMetadata>({
     readBusabaseLandingPageByPath,
   } = integration;
 
-  const getCmsPageForRequest = async (
-    lang: string,
+  const getForLocale = async (
+    locale: string,
     path: string | readonly string[],
-  ): Promise<PageVO | null> => {
-    const canonicalPath = buildCmsPath(lang, path);
+  ): Promise<TPage | null> => {
+    const canonicalPath = buildCmsPath(locale, path);
     if (!canonicalPath) return null;
 
     const page = await getBusabaseLandingPageByPathOrFallback(canonicalPath);
-    return page && isCmsContentForLocale(page, lang) ? page : null;
+    return page && isCmsContentForLocale(page, locale) ? page : null;
   };
 
-  const readCmsPageForRequest = async (
-    lang: string,
+  const readForLocale = async (
+    locale: string,
     path: string | readonly string[],
-  ): Promise<CmsRead<PageVO | null>> => {
-    const canonicalPath = buildCmsPath(lang, path);
+  ): Promise<CmsRead<TPage | null>> => {
+    const canonicalPath = buildCmsPath(locale, path);
     // A path this app cannot even form is genuinely "no such page" — no read needed.
     if (!canonicalPath) return { status: "ok", data: null };
 
     const read = await readBusabaseLandingPageByPath(canonicalPath);
     if (read.status !== "ok") return read;
     const page = read.data;
-    return { status: "ok", data: page && isCmsContentForLocale(page, lang) ? page : null };
+    return { status: "ok", data: page && isCmsContentForLocale(page, locale) ? page : null };
+  };
+
+  const resolved = (page: TPage, requestedLocale: string, contentLocale: string) => ({
+    page,
+    requestedLocale,
+    contentLocale,
+    isLocaleFallback: contentLocale !== requestedLocale,
+  });
+
+  const resolveCmsPageForRequest = async (
+    lang: string,
+    path: string | readonly string[],
+  ): Promise<ResolvedCmsPage<TPage> | null> => {
+    // A locale this app cannot even form a path for is not a translation gap — falling back
+    // there would turn every unknown first path segment into an English duplicate of the page.
+    if (!buildCmsPath(lang, path)) return null;
+
+    const requested = await getForLocale(lang, path);
+    if (requested) return resolved(requested, lang, lang);
+    if (lang === FALLBACK_LOCALE) return null;
+
+    const fallback = await getForLocale(FALLBACK_LOCALE, path);
+    return fallback ? resolved(fallback, lang, FALLBACK_LOCALE) : null;
+  };
+
+  const getCmsPageForRequest = async (
+    lang: string,
+    path: string | readonly string[],
+  ): Promise<TPage | null> => (await resolveCmsPageForRequest(lang, path))?.page ?? null;
+
+  const readResolvedCmsPageForRequest = async (
+    lang: string,
+    path: string | readonly string[],
+  ): Promise<CmsRead<ResolvedCmsPage<TPage> | null>> => {
+    // Same guard as resolveCmsPageForRequest — an unsupported locale is a real 404, never a
+    // fallback, and it needs no read at all to decide that.
+    if (!buildCmsPath(lang, path)) return { status: "ok", data: null };
+
+    const requested = await readForLocale(lang, path);
+    // An unreachable CMS must stay "unavailable" rather than silently becoming an English
+    // fallback — the caller turns "ok + null" into a cacheable 404, and we do not know yet
+    // whether this path is genuinely missing.
+    if (requested.status !== "ok") return requested;
+    if (requested.data) return { status: "ok", data: resolved(requested.data, lang, lang) };
+    if (lang === FALLBACK_LOCALE) return { status: "ok", data: null };
+
+    const fallback = await readForLocale(FALLBACK_LOCALE, path);
+    if (fallback.status !== "ok") return fallback;
+    return {
+      status: "ok",
+      data: fallback.data ? resolved(fallback.data, lang, FALLBACK_LOCALE) : null,
+    };
+  };
+
+  const readCmsPageForRequest = async (
+    lang: string,
+    path: string | readonly string[],
+  ): Promise<CmsRead<TPage | null>> => {
+    const read = await readResolvedCmsPageForRequest(lang, path);
+    return read.status === "ok" ? { status: "ok", data: read.data?.page ?? null } : read;
   };
 
   const generateCmsPageMetadata = (
@@ -140,16 +249,29 @@ export const createCmsPageHelpers = <TMetadata>({
     lang: string,
   ): TMetadata | Record<string, never> => {
     const parsed = parseCmsPath(page.path);
-    if (!parsed || parsed.locale !== lang) return {};
+    if (!parsed) return {};
+
+    // `lang` is what the visitor asked for; `parsed.locale` is the locale the resolved Page
+    // actually belongs to. They differ only on a locale fallback (an untranslated Page served
+    // in English), and there the canonical URL has to point at the page that really exists
+    // rather than at the untranslated request URL.
+    const contentLocale = isCmsContentForLocale(page, lang) ? lang : parsed.locale;
 
     return generatePageMetadata({
       title: page.seoTitle ?? page.title,
       description: page.seoDescription ?? "",
       path: parsed.pathWithoutLocale,
-      lang,
+      lang: contentLocale,
       type: "website",
     });
   };
 
-  return { getCmsPageForRequest, readCmsPageForRequest, generateCmsPageMetadata };
+  return {
+    getCmsPageForLocale: getForLocale,
+    getCmsPageForRequest,
+    resolveCmsPageForRequest,
+    readCmsPageForRequest,
+    readResolvedCmsPageForRequest,
+    generateCmsPageMetadata,
+  };
 };

--- a/packages/busabase-cms-sdk/tests/pages.test.ts
+++ b/packages/busabase-cms-sdk/tests/pages.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import type { CmsRead } from "../src/fallback";
+import { createCmsPageHelpers } from "../src/integration";
+import { createCmsPathHelpers } from "../src/routing";
+import type { PageVO } from "../src/types";
+
+const paths = createCmsPathHelpers({
+  supportedLocales: ["en", "zh-CN", "ja", "pt"],
+  defaultLocale: "en",
+});
+
+const page = (path: string, locale: string): PageVO =>
+  ({
+    id: `page-${path}`,
+    path,
+    locale,
+    title: `Title ${locale}`,
+    body: "<p>body</p>",
+    seoTitle: `SEO ${locale}`,
+    seoDescription: `Desc ${locale}`,
+  }) as unknown as PageVO;
+
+/**
+ * Builds helpers over a fixed set of Pages. `unavailable` makes every read report the CMS as
+ * unreachable, which the status-aware reads must never confuse with "no such page".
+ */
+const helpersFor = (pages: PageVO[], { unavailable = false } = {}) => {
+  const byPath = new Map(pages.map((p) => [p.path, p]));
+  const reads: string[] = [];
+
+  const helpers = createCmsPageHelpers({
+    integration: {
+      buildCmsPath: paths.buildPath,
+      parseCmsPath: paths.parsePath,
+      isCmsContentForLocale: paths.isForLocale,
+      getBusabaseLandingPageByPathOrFallback: async (path: string): Promise<PageVO | null> => {
+        reads.push(path);
+        return byPath.get(path) ?? null;
+      },
+      readBusabaseLandingPageByPath: async (path: string): Promise<CmsRead<PageVO | null>> => {
+        reads.push(path);
+        return unavailable
+          ? { status: "unavailable" }
+          : { status: "ok", data: byPath.get(path) ?? null };
+      },
+    },
+    generatePageMetadata: (options) => options,
+  });
+
+  return { helpers, reads };
+};
+
+const EN_ONLY = [page("/gpt-6-astra", "en")];
+const EN_AND_JA = [page("/gpt-6-astra", "en"), page("/ja/gpt-6-astra", "ja")];
+
+describe("createCmsPageHelpers — locale fallback", () => {
+  it("serves the English Page when the requested locale has no translation", async () => {
+    const { helpers } = helpersFor(EN_ONLY);
+
+    const resolved = await helpers.resolveCmsPageForRequest("pt", ["gpt-6-astra"]);
+    expect(resolved).toMatchObject({
+      requestedLocale: "pt",
+      contentLocale: "en",
+      isLocaleFallback: true,
+    });
+    expect(resolved?.page.path).toBe("/gpt-6-astra");
+  });
+
+  it("prefers the requested locale over English, and does not flag a fallback", async () => {
+    const { helpers, reads } = helpersFor(EN_AND_JA);
+
+    const resolved = await helpers.resolveCmsPageForRequest("ja", ["gpt-6-astra"]);
+    expect(resolved).toMatchObject({
+      contentLocale: "ja",
+      isLocaleFallback: false,
+    });
+    expect(resolved?.page.path).toBe("/ja/gpt-6-astra");
+    // The English original must not even be read when the translation exists.
+    expect(reads).toEqual(["/ja/gpt-6-astra"]);
+  });
+
+  it("still returns null for a slug that exists in no locale at all", async () => {
+    const { helpers } = helpersFor(EN_ONLY);
+
+    await expect(helpers.resolveCmsPageForRequest("pt", ["no-such-page"])).resolves.toBeNull();
+    await expect(helpers.getCmsPageForRequest("pt", ["no-such-page"])).resolves.toBeNull();
+  });
+
+  it("does not retry English when English itself is the requested locale", async () => {
+    const { helpers, reads } = helpersFor(EN_ONLY);
+
+    await expect(helpers.resolveCmsPageForRequest("en", ["no-such-page"])).resolves.toBeNull();
+    expect(reads).toEqual(["/no-such-page"]);
+  });
+
+  it("gives getCmsPageForRequest the same fallback, so existing callers stop 404ing", async () => {
+    const { helpers } = helpersFor(EN_ONLY);
+
+    const found = await helpers.getCmsPageForRequest("zh-CN", ["gpt-6-astra"]);
+    expect(found?.path).toBe("/gpt-6-astra");
+  });
+
+  it("returns null for a locale this app does not support at all", async () => {
+    const { helpers } = helpersFor(EN_ONLY);
+
+    await expect(helpers.resolveCmsPageForRequest("de", ["gpt-6-astra"])).resolves.toBeNull();
+  });
+});
+
+describe("createCmsPageHelpers — status-aware reads keep 'unreachable' distinct", () => {
+  it("reports unavailable rather than silently falling back to English", async () => {
+    const { helpers } = helpersFor(EN_ONLY, { unavailable: true });
+
+    await expect(helpers.readResolvedCmsPageForRequest("pt", ["gpt-6-astra"])).resolves.toEqual({
+      status: "unavailable",
+    });
+    await expect(helpers.readCmsPageForRequest("pt", ["gpt-6-astra"])).resolves.toEqual({
+      status: "unavailable",
+    });
+  });
+
+  it("reports a genuinely missing page as ok+null, not as unavailable", async () => {
+    const { helpers } = helpersFor(EN_ONLY);
+
+    await expect(helpers.readCmsPageForRequest("pt", ["no-such-page"])).resolves.toEqual({
+      status: "ok",
+      data: null,
+    });
+  });
+
+  it("falls back to English through the status-aware read too", async () => {
+    const { helpers } = helpersFor(EN_ONLY);
+
+    const read = await helpers.readResolvedCmsPageForRequest("ja", ["gpt-6-astra"]);
+    expect(read.status).toBe("ok");
+    expect(read.status === "ok" && read.data).toMatchObject({
+      contentLocale: "en",
+      isLocaleFallback: true,
+    });
+  });
+});
+
+describe("createCmsPageHelpers — metadata on a fallback", () => {
+  it("points the canonical URL at the locale that actually owns the content", async () => {
+    const { helpers } = helpersFor(EN_ONLY);
+    const resolved = await helpers.resolveCmsPageForRequest("pt", ["gpt-6-astra"]);
+    if (!resolved) throw new Error("expected the English original to resolve as a pt fallback");
+
+    // Previously this returned {} — a 200 page with no title or canonical at all.
+    expect(helpers.generateCmsPageMetadata(resolved.page, "pt")).toEqual({
+      title: "SEO en",
+      description: "Desc en",
+      path: "/gpt-6-astra",
+      lang: "en",
+      type: "website",
+    });
+  });
+
+  it("keeps using the requested locale when the Page really is in that locale", async () => {
+    const { helpers } = helpersFor(EN_AND_JA);
+    const resolved = await helpers.resolveCmsPageForRequest("ja", ["gpt-6-astra"]);
+    if (!resolved) throw new Error("expected the ja Page to resolve");
+
+    expect(helpers.generateCmsPageMetadata(resolved.page, "ja")).toMatchObject({
+      lang: "ja",
+      path: "/gpt-6-astra",
+    });
+  });
+});
+
+describe("createCmsPageHelpers — getCmsPageForLocale is strict", () => {
+  it("returns null for a locale with no translation, instead of the English original", async () => {
+    const { helpers, reads } = helpersFor(EN_ONLY);
+
+    // The whole point: a caller running its own cross-locale cascade (Buda's use-case resolver)
+    // must see a real miss here. If this ever falls back, every locale looks translated and the
+    // "showing English" notice silently disappears from /use-cases.
+    await expect(helpers.getCmsPageForLocale("pt", ["gpt-6-astra"])).resolves.toBeNull();
+    expect(reads).toEqual(["/pt/gpt-6-astra"]);
+  });
+
+  it("still returns the Page when that locale really has one", async () => {
+    const { helpers } = helpersFor(EN_AND_JA);
+
+    const ja = await helpers.getCmsPageForLocale("ja", ["gpt-6-astra"]);
+    expect(ja?.path).toBe("/ja/gpt-6-astra");
+    const en = await helpers.getCmsPageForLocale("en", ["gpt-6-astra"]);
+    expect(en?.path).toBe("/gpt-6-astra");
+  });
+});

--- a/packages/busabase-contract/package.json
+++ b/packages/busabase-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-contract",
   "description": "Client-safe Busabase surface: oRPC contracts (OSS + cloud), node-type kernel, VO types, and the oRPC client factories. Pure leaf \u2014 no db/logic/server deps. Consumed by busabase-cli, busabase-mobile, busabase-core, busabase, and busabase-cloud.",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/busabase-contract/src/domains/install/types.ts
+++ b/packages/busabase-contract/src/domains/install/types.ts
@@ -10,6 +10,7 @@
  * what would be created — so the tree becomes a flat, depth-tagged outline and
  * the bytes stay on the server.
  */
+import { iStringSchema } from "openlib/i18n/i-string";
 import { z } from "zod";
 
 /** Every node type the package format can install, as it appears in a plan outline. */
@@ -76,7 +77,9 @@ export type InstallPlanCountsVO = z.infer<typeof InstallPlanCountsVOSchema>;
 /** The package's own metadata, as declared in its `busabase.json`. */
 export const InstallPackageInfoVOSchema = z.object({
   name: z.string(),
-  description: z.string().default(""),
+  /** iString: `busabase.json`'s own description may be locale-keyed; render
+   * with `iStringParse(value, locale)`, never inserted into JSX directly. */
+  description: iStringSchema.default(""),
   version: z.string().optional(),
   author: z.string().optional(),
   license: z.string().optional(),

--- a/packages/busabase-contract/src/domains/package/types.ts
+++ b/packages/busabase-contract/src/domains/package/types.ts
@@ -11,7 +11,9 @@
  * install), and any future web consumer validate identically. Pure leaf: zod
  * plus sibling pure contract schemas only.
  */
+import { iStringSchema } from "openlib/i18n/i-string";
 import { z } from "zod";
+import { customAgentPromptsSchema } from "../../contract/node-agent-prompt-schemas";
 import {
   fieldNameSchema,
   fieldTypeSchema,
@@ -133,9 +135,27 @@ export const PACKAGE_MAX_RECORDS_PER_BASE = 50_000;
 
 export const PackageManifestSchema = z.object({
   format: z.literal(PACKAGE_FORMAT),
-  /** Default `--into-folder` name. Not the repo name — a repo can host many packages. */
+  /**
+   * Default `--into-folder` name. Not the repo name — a repo can host many
+   * packages. This is the package's IDENTITY, not a label: it must equal the
+   * on-disk directory name and the SKILL.md frontmatter name (enforced by
+   * `audit.ts`'s "one identity" rule), and it is used as a slug — CLI sort,
+   * `suggestSlug()`, the Dashboard's `/templates/:name` route, and the
+   * install-target folder name all key off it verbatim. Deliberately NOT an
+   * iString: none of those call sites expect a locale-keyed object, and
+   * "the directory name is the package's identity, not a label beside it"
+   * (audit.ts) is exactly the argument against ever making it one. A
+   * human-facing translated title belongs in `description` below, not here.
+   */
   name: z.string().min(1),
-  description: z.string().default(""),
+  /**
+   * The one-line blurb shown on a template's catalog card, and (via
+   * `layout-read.ts`) the description on the Folder node created at install
+   * time — Folder/node descriptions are already iString-capable text
+   * columns, so this single field legitimately serves both. Plain string
+   * stays valid forever; nothing that already writes a bare string breaks.
+   */
+  description: iStringSchema.default(""),
   /**
    * Informational / reserved for a future marketplace index. The real version pin
    * is always the git ref in the install URL.
@@ -158,12 +178,33 @@ export type PackageManifest = z.infer<typeof PackageManifestSchema>;
 
 // ── Sidecars ─────────────────────────────────────────────────────────────────
 
+/**
+ * Scenario Agent prompts for the node this sidecar describes — what a person can
+ * ask an agent to DO with it, carried so it survives export → install.
+ *
+ * Same schema the node's own column and `busabase-cli nodes set-agent-prompts`
+ * validate against (50 per node, 80 chars per label, 8 KiB per body per locale),
+ * so a package cannot smuggle in a list the API would reject.
+ *
+ * Optional and absent by default: a package written before this field, or one
+ * whose author wrote no prompts, is unchanged on disk and installs exactly as
+ * before — the nodes then show their node type's default prompts, which is the
+ * behaviour every package had until now.
+ *
+ * Distinct from `busabase.json`'s template-level `agentPrompts`: that one is a
+ * flat list of strings for the Template Center card and the install-time "Ask
+ * agent" action, about the template as a whole. This one is per node, structured,
+ * and becomes that node's prompts in the dialog after install.
+ */
+const packageNodeAgentPromptsSchema = customAgentPromptsSchema.optional();
+
 /** `_node.json` — marks a directory as a verbatim-content file-tree node. */
 export const PackageFileTreeNodeMetaSchema = z.object({
   type: z.enum(PACKAGE_FILE_TREE_NODE_TYPES),
   name: z.string().min(1),
   description: z.string().default(""),
   position: z.number().int().optional(),
+  agentPrompts: packageNodeAgentPromptsSchema,
 });
 export type PackageFileTreeNodeMeta = z.infer<typeof PackageFileTreeNodeMetaSchema>;
 
@@ -173,6 +214,7 @@ export const PackageFolderMetaSchema = z.object({
   name: z.string().optional(),
   description: z.string().default(""),
   position: z.number().int().optional(),
+  agentPrompts: packageNodeAgentPromptsSchema,
 });
 export type PackageFolderMeta = z.infer<typeof PackageFolderMetaSchema>;
 
@@ -204,6 +246,7 @@ export const PackageDocFrontmatterSchema = z.object({
   name: z.string().min(1),
   description: z.string().default(""),
   position: z.number().int().optional(),
+  agentPrompts: packageNodeAgentPromptsSchema,
 });
 export type PackageDocFrontmatter = z.infer<typeof PackageDocFrontmatterSchema>;
 
@@ -363,6 +406,7 @@ export const PackageBaseSchema = z.object({
     .optional(),
   fields: z.array(PackageBaseFieldSchema).default([]),
   views: z.array(PackageViewSchema).default([]),
+  agentPrompts: packageNodeAgentPromptsSchema,
 });
 export type PackageBase = z.infer<typeof PackageBaseSchema>;
 

--- a/packages/busabase-contract/src/domains/templates/types.ts
+++ b/packages/busabase-contract/src/domains/templates/types.ts
@@ -10,6 +10,7 @@
  *
  * Spec: `apps/busabase/content/spec/template-center.md` §6.4.
  */
+import { iStringSchema } from "openlib/i18n/i-string";
 import { z } from "zod";
 import { TemplateRiskLevelSchema } from "../package/template";
 
@@ -27,8 +28,17 @@ export type TemplateStatsVO = z.infer<typeof TemplateStatsVOSchema>;
 export const TemplateCardVOSchema = z.object({
   /** Stable across a catalog: `<repo>/<subdir>`. What a route keys on. */
   id: z.string(),
+  /**
+   * The package's identity/slug — route key, install-folder name, CLI sort
+   * key. Deliberately plain string, never iString: see the long comment on
+   * `PackageManifestSchema.name` in the package domain (re-declared here per
+   * this file's own convention, not imported, but the reasoning is shared).
+   */
   name: z.string(),
-  description: z.string(),
+  /** The catalog card's blurb. iString: `busabase.json`'s own description can
+   * be locale-keyed (`{ en: "...", "zh-CN": "..." }`); a plain string is still
+   * valid forever. */
+  description: iStringSchema,
   category: z.string(),
   /** Absent when undeclared or unrecognized — the card shows "undeclared", never a guess. */
   risk: TemplateRiskLevelSchema.optional(),

--- a/packages/busabase-core/package.json
+++ b/packages/busabase-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-core",
   "description": "Shared Busabase open-core protocol, local store, API helpers, and dashboard components.",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -180,6 +180,10 @@
     "./domains/templates/components/template-card-summary": {
       "types": "./src/domains/templates/components/template-card-summary.tsx",
       "default": "./src/domains/templates/components/template-card-summary.tsx"
+    },
+    "./domains/templates/components/template-grid": {
+      "types": "./src/domains/templates/components/template-grid.tsx",
+      "default": "./src/domains/templates/components/template-grid.tsx"
     },
     "./domains/templates/components/template-detail-content": {
       "types": "./src/domains/templates/components/template-detail-content.tsx",

--- a/packages/busabase-core/src/domains/agents/components/agent-detail-view.tsx
+++ b/packages/busabase-core/src/domains/agents/components/agent-detail-view.tsx
@@ -15,17 +15,30 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "kui/dropdown-menu";
-import { ArrowLeft, Bot, ChevronDown, MessageSquarePlus } from "lucide-react";
+import {
+  ArrowLeft,
+  AtSign,
+  Bot,
+  ChevronDown,
+  MessageSquarePlus,
+  PanelRight,
+  X,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCoreI18n, useCoreLocale } from "../../../i18n";
+import { resolveSpaceId } from "../../dashboard/components/node-agent-prompts-dialog";
 import {
   AGENT_CHAT_TAB_TYPE,
   type AgentChatTabPayload,
   agentChatTabId,
   consumeAgentChatDraft,
 } from "../../dashboard/components/side-panel-sources";
+import type { LoadedNode } from "../../dashboard/node-detail-registry";
 import { registerSidePanelTab, type SidePanelTabProps } from "../../dashboard/side-panel-registry";
+import { useCurrentNodeStore } from "../../dashboard/store/current-node-store";
 import { useSidePanelStore } from "../../dashboard/store/side-panel-store";
 import { useAgentSession } from "../hooks/use-agent-session";
+import { withNodeContext } from "../utils/agent-message-context";
 import { AgentLoadingState, AgentQueryErrorState } from "./agent-query-state";
 import { TransportBadge } from "./transport-badge";
 
@@ -64,6 +77,27 @@ interface AgentDetailViewProps {
   draft?: AcpComposerDraft | null;
   /** Fired once the draft is in the field, so the owner can retire it. */
   onDraftApplied?: (id: string) => void;
+  /**
+   * The node the user is looking at in the main area, offered as removable
+   * context above the composer.
+   *
+   * Only the side-panel instance passes this, and deliberately so: "the node
+   * you have open" is a fact that exists when a node is on the left and the
+   * agent is on the right. On the full agent page there is no such node — the
+   * agent IS what the user is looking at — so a chip there could only ever
+   * offer a stale one.
+   */
+  contextNode?: LoadedNode | null;
+  /**
+   * Move this conversation into the side panel, so it can sit beside the node
+   * the user goes on to work in.
+   *
+   * Only the full page passes it — inside the panel the conversation is already
+   * there, and a button that re-pins it where it is would be a no-op with a
+   * label. This is also what makes the context chip reachable: the chip only
+   * exists in the panel instance, so "open in side panel" is the door to it.
+   */
+  onOpenInSidePanel?: (sessionId: string, agentName: string) => void;
 }
 
 /**
@@ -80,6 +114,8 @@ export function AgentDetailView({
   initialSessionId,
   draft,
   onDraftApplied,
+  contextNode = null,
+  onOpenInSidePanel,
 }: AgentDetailViewProps) {
   const queryClient = useQueryClient();
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
@@ -134,14 +170,33 @@ export function AgentDetailView({
   // busabase's own.
   const chat = useAgentSession(orpc, activeSessionId);
 
+  /**
+   * The node whose context the user has waved off, by id.
+   *
+   * Keyed by id rather than a boolean so dismissing is scoped to THAT node:
+   * navigate to a different one and the chip comes back, because the answer to
+   * "did you mean this node?" changed. Nothing about "no, not the Visits table"
+   * implies "and never any node again".
+   */
+  const messages = useCoreI18n();
+  const locale = useCoreLocale();
+  const [dismissedContextId, setDismissedContextId] = useState<string | null>(null);
+  const activeContextNode =
+    contextNode && contextNode.id !== dismissedContextId ? contextNode : null;
+
   const send = useCallback(
     (text: string, attachments?: AcpAttachment[]) => {
       if (!activeSessionId) return;
-      void chat.sendPrompt(text, attachments).then(() => {
+      // The chip is a promise made in the UI ("your message will say which node
+      // you mean"), so it is kept here, at send time, rather than by pre-filling
+      // the textbox — which would make the user delete the line to opt out and
+      // leave them editing our words instead of writing their own.
+      const body = withNodeContext(text, activeContextNode, locale, resolveSpaceId());
+      void chat.sendPrompt(body, attachments).then(() => {
         void queryClient.invalidateQueries({ queryKey: orpc.agents.sessions.list.queryKey() });
       });
     },
-    [activeSessionId, chat, queryClient, orpc],
+    [activeContextNode, activeSessionId, chat, locale, queryClient, orpc],
   );
 
   const agentName = active?.agentName ?? agentSessions[0]?.agentName ?? agentSlug;
@@ -280,6 +335,19 @@ export function AgentDetailView({
               <span className="ml-auto shrink-0 text-muted-foreground text-xs">
                 {STATUS_LABEL[active.status]}
               </span>
+              {onOpenInSidePanel ? (
+                <Button
+                  aria-label={messages.agents.openInSidePanel}
+                  className="shrink-0 text-muted-foreground"
+                  onClick={() => onOpenInSidePanel(active.id, agentName)}
+                  size="icon-sm"
+                  title={messages.agents.openInSidePanel}
+                  type="button"
+                  variant="ghost"
+                >
+                  <PanelRight className="size-4" />
+                </Button>
+              ) : null}
             </header>
 
             {active.error ? (
@@ -295,6 +363,13 @@ export function AgentDetailView({
               emptyTitle="Connected."
               emptyDescription="Send a message to start."
             />
+
+            {activeContextNode ? (
+              <AgentContextChip
+                node={activeContextNode}
+                onDismiss={() => setDismissedContextId(activeContextNode.id)}
+              />
+            ) : null}
 
             <AcpComposer
               className="border-0 border-t p-3"
@@ -342,6 +417,46 @@ export function AgentDetailView({
 }
 
 /**
+ * "You have this node open — I'll mention it."
+ *
+ * Sits above the composer rather than inside it because the composer is shared
+ * with acprouter (`@acp-ui/web`), which has no notion of a workspace node. Kept
+ * out here, busabase gets its context affordance and the shared component stays
+ * as dumb as its README promises.
+ *
+ * Removable, and says what it does before it does it — the alternative (silently
+ * appending a line to what someone wrote) is the kind of helpfulness people
+ * discover only by reading their own message back in a transcript.
+ */
+function AgentContextChip({ node, onDismiss }: { node: LoadedNode; onDismiss: () => void }) {
+  const messages = useCoreI18n();
+  return (
+    // The hint is the row's `title`, not a third column of text: the panel is
+    // ~420px and the row already lost the end of that sentence to an ellipsis at
+    // that width. "Context @Companies ×" says it; the tooltip spells it out.
+    <div
+      className="flex shrink-0 items-center gap-2 border-t px-3 pt-2 text-xs"
+      title={messages.agents.contextChipHint}
+    >
+      <span className="shrink-0 text-muted-foreground">{messages.agents.contextChipLabel}</span>
+      <span className="flex min-w-0 items-center gap-1 rounded-md border bg-muted/50 px-2 py-0.5">
+        <AtSign className="size-3 shrink-0 text-muted-foreground" />
+        <span className="truncate font-medium">{node.name}</span>
+        <button
+          aria-label={messages.agents.contextChipRemove}
+          className="-mr-1 ml-0.5 shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          onClick={onDismiss}
+          title={messages.agents.contextChipRemove}
+          type="button"
+        >
+          <X className="size-3" />
+        </button>
+      </span>
+    </div>
+  );
+}
+
+/**
  * The same view, rendered inside the side panel.
  *
  * Deliberately not a second implementation: `AgentDetailView` adapts to its
@@ -351,6 +466,8 @@ export function AgentDetailView({
  */
 function AgentChatSidePanelTab({ orpc, payload }: SidePanelTabProps) {
   const { agentSlug, sessionId, draft } = payload as AgentChatTabPayload;
+  // Only the panel reads this: it is the instance that sits beside an open node.
+  const contextNode = useCurrentNodeStore((state) => state.node);
   const onDraftApplied = useCallback(
     (id: string) => consumeAgentChatDraft(agentSlug, id),
     [agentSlug],
@@ -358,6 +475,7 @@ function AgentChatSidePanelTab({ orpc, payload }: SidePanelTabProps) {
   return (
     <AgentDetailView
       agentSlug={agentSlug}
+      contextNode={contextNode}
       draft={draft ?? null}
       initialSessionId={sessionId}
       onBack={() => useSidePanelStore.getState().closeTab(agentChatTabId(agentSlug))}

--- a/packages/busabase-core/src/domains/agents/utils/agent-message-context.test.ts
+++ b/packages/busabase-core/src/domains/agents/utils/agent-message-context.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The rule the side panel's context chip promises: "your message will say which
+ * node you mean". What it must NOT do is edit what the person wrote.
+ */
+import { describe, expect, it } from "vitest";
+import type { LoadedNode } from "../../dashboard/node-detail-registry";
+import { withNodeContext } from "./agent-message-context";
+
+const node: LoadedNode = { id: "nod_visits", type: "base", name: "Visits", slug: "visits" };
+
+describe("sending with the open node as context", () => {
+  it("names the node above the message, leaving the message itself untouched", () => {
+    const out = withNodeContext("add a row for today", node, "en", "spc_acme");
+
+    const [target, blank, ...rest] = out.split("\n");
+    expect(target).toContain('the Busabase Base "Visits"');
+    expect(target).toContain("nod_visits");
+    expect(target).toContain("spc_acme");
+    // A blank line between, so the agent reads two statements rather than one
+    // run-on — the same shape the built-in prompts use.
+    expect(blank).toBe("");
+    expect(rest.join("\n")).toBe("add a row for today");
+  });
+
+  it("changes nothing at all when there is no node — the dismissed and the Home cases", () => {
+    expect(withNodeContext("hello", null, "en")).toBe("hello");
+    expect(withNodeContext("hello", undefined, "en")).toBe("hello");
+  });
+
+  it("speaks the user's language, because they will read it back in the transcript", () => {
+    const zh = withNodeContext("加一行", node, "zh-CN");
+    expect(zh).toContain("目标：Busabase");
+    expect(zh).toContain("「Visits」");
+    expect(zh.endsWith("加一行")).toBe(true);
+  });
+
+  it("still names the node when no space is known, rather than dropping the line", () => {
+    const out = withNodeContext("hi", node, "en");
+    expect(out).toContain("nod_visits");
+    expect(out).not.toContain("in space");
+  });
+});

--- a/packages/busabase-core/src/domains/agents/utils/agent-message-context.ts
+++ b/packages/busabase-core/src/domains/agents/utils/agent-message-context.ts
@@ -1,0 +1,28 @@
+import type { CoreLocale } from "../../../i18n";
+import { renderNodeTargetLine } from "../../dashboard/helpers/node-agent-prompts";
+import type { LoadedNode } from "../../dashboard/node-detail-registry";
+
+/**
+ * Prepend "which node the user means" to a message they typed themselves.
+ *
+ * Pure, and separate from the composer, because this is the part with a rule in
+ * it: the context goes ABOVE the user's text, never woven into it, and an absent
+ * node changes nothing at all. Both halves are easy to get subtly wrong in a
+ * component and impossible to see once they are.
+ *
+ * The line itself comes from the same renderer the Agent-prompts bodies use, so
+ * an agent meets one phrasing of this fact rather than two.
+ */
+export const withNodeContext = (
+  text: string,
+  node: LoadedNode | null | undefined,
+  locale: CoreLocale,
+  spaceId?: string,
+): string => {
+  if (!node) return text;
+  const target = renderNodeTargetLine(
+    { nodeId: node.id, nodeName: node.name, nodeType: node.type, spaceId },
+    locale,
+  );
+  return `${target}\n\n${text}`;
+};

--- a/packages/busabase-core/src/domains/airapp/logic/local-preview-proxy.test.ts
+++ b/packages/busabase-core/src/domains/airapp/logic/local-preview-proxy.test.ts
@@ -127,6 +127,30 @@ describe("AirApp preview proxy credential boundary", () => {
     }
   });
 
+  it("keeps root-relative redirects inside the AirApp preview path", async () => {
+    const upstream = await listen((_request, response) => {
+      response.writeHead(307, { location: "/docs?from=home" });
+      response.end();
+    });
+    await registerLocalPreview(NODE_ID, OWNER, upstream.origin);
+
+    try {
+      const response = await proxyLocalPreview(
+        new Request("https://busabase.example/api/airapp-preview/preview-node/"),
+        NODE_ID,
+        "",
+        OWNER,
+      );
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe(
+        "/api/airapp-preview/preview-node/docs?from=home",
+      );
+    } finally {
+      await upstream.close();
+    }
+  });
+
   it("never retries a non-idempotent request", async () => {
     let requests = 0;
     const upstream = await listen((_request, response) => {

--- a/packages/busabase-core/src/domains/airapp/logic/local-preview-proxy.ts
+++ b/packages/busabase-core/src/domains/airapp/logic/local-preview-proxy.ts
@@ -38,6 +38,15 @@ const isHtmlElement = (node: HtmlNode): node is HtmlElement => "tagName" in node
 
 const isBusabaseDataBridgeUrl = (url: string): boolean => /^\/api\/v1(?:[/?#]|$)/.test(url);
 
+const previewRedirectLocation = (location: string, nodeId: string): string => {
+  if (!location.startsWith("/") || location.startsWith("//") || isBusabaseDataBridgeUrl(location)) {
+    return location;
+  }
+  const previewPrefix = `/api/airapp-preview/${encodeURIComponent(nodeId)}`;
+  if (location === previewPrefix || location.startsWith(`${previewPrefix}/`)) return location;
+  return `${previewPrefix}${location}`;
+};
+
 const previewBridgeScript = (previewPrefix: string): string =>
   [
     "(() => {",
@@ -326,7 +335,7 @@ export async function proxyLocalPreview(
   }
   const location = upstream.headers.get("location");
   if (location) {
-    responseHeaders.set("location", location);
+    responseHeaders.set("location", previewRedirectLocation(location, nodeId));
   }
 
   // For the HTML document, inject a `<base href>` for relative URLs and rewrite

--- a/packages/busabase-core/src/domains/airapp/logic/sandock-runtime.integration.test.ts
+++ b/packages/busabase-core/src/domains/airapp/logic/sandock-runtime.integration.test.ts
@@ -164,6 +164,7 @@ const createCloudRun = (
   files: Record<string, string>,
   probePath?: string,
   owner = `${nodeId}-owner`,
+  entryPath = "/",
 ): CloudRun => {
   const controller = new AbortController();
   const events: AirAppRuntimeEvent[] = [];
@@ -192,7 +193,8 @@ const createCloudRun = (
             registeredNodeId === nodeId && registeredOwner === owner,
         )?.[2];
       expect(target).toBeDefined();
-      const previewResponse = await waitForPreview(target as string);
+      const entryUrl = new URL(entryPath, target as string);
+      const previewResponse = await waitForPreview(entryUrl.toString());
       const html = await previewResponse.text();
       const probeBody = probePath
         ? await (await fetch(new URL(probePath, target as string))).json()
@@ -217,8 +219,9 @@ const runCloudApp = async (
   nodeId: string,
   files: Record<string, string>,
   probePath?: string,
+  entryPath = "/",
 ): Promise<CloudRunResult> => {
-  const run = createCloudRun(nodeId, files, probePath);
+  const run = createCloudRun(nodeId, files, probePath, `${nodeId}-owner`, entryPath);
   try {
     return await run.ready();
   } finally {
@@ -249,18 +252,29 @@ describe.skipIf(!CLOUD_ENABLED)("runAirAppSandock — against Sandock Cloud", ()
   }, 300_000);
 
   it("installs and serves the Fumadocs demo, including its nested route", async () => {
-    const result = await runCloudApp("sandock-cloud-fumadocs", CLOUD_FUMADOCS_FILES);
-    const log = eventLog(result.events);
+    const run = createCloudRun(
+      "sandock-cloud-fumadocs",
+      CLOUD_FUMADOCS_FILES,
+      undefined,
+      "sandock-cloud-fumadocs-owner",
+      "/docs",
+    );
 
-    expect(log).toContain("provisioning a sandbox");
-    expect(log).toContain("fumadocs-mdx");
-    expect(log).toContain("next dev");
-    expect(result.html).toContain("Fumadocs AirApp");
+    try {
+      const result = await run.ready();
+      const log = eventLog(result.events);
 
-    const nestedUrl = new URL(result.target);
-    nestedUrl.pathname = `${nestedUrl.pathname.replace(/\/$/, "")}/docs/getting-started`;
-    const nestedResponse = await waitForPreview(nestedUrl.toString());
-    expect(await nestedResponse.text()).toContain("Getting Started");
+      expect(log).toContain("provisioning a sandbox");
+      expect(log).toContain("fumadocs-mdx");
+      expect(log).toContain("$ npm run dev");
+      expect(result.html).toContain("Fumadocs AirApp");
+
+      const nestedUrl = new URL("/docs/getting-started", result.target);
+      const nestedResponse = await waitForPreview(nestedUrl.toString());
+      expect(await nestedResponse.text()).toContain("Getting Started");
+    } finally {
+      await run.stop();
+    }
   }, 600_000);
 
   it("keeps concurrent runs of the same AirApp isolated by owner", async () => {

--- a/packages/busabase-core/src/domains/airapp/logic/sandock-runtime.test.ts
+++ b/packages/busabase-core/src/domains/airapp/logic/sandock-runtime.test.ts
@@ -53,8 +53,11 @@ const api = {
       calls.push({ op: "revokePreviewToken", args: { id, token } });
       return { success: true as const };
     }),
-    shell: vi.fn(async (id: string, options: Record<string, unknown>) => {
-      calls.push({ op: "shell", args: { id, ...options } });
+    shell: vi.fn(async (id: string, options: Record<string, unknown>, callbacks?: unknown) => {
+      calls.push({
+        op: "shell",
+        args: { id, ...options, ...(callbacks ? { streaming: true } : {}) },
+      });
       const next = shellResults.shift() ?? {};
       return envelope({
         stdout: next.stdout ?? "",
@@ -248,8 +251,8 @@ describe("runAirAppSandock", () => {
 
     // The container has to outlive its entrypoint, or there is nothing to exec into.
     expect(calls[0]?.args.command).toEqual(["/bin/sh", "-c", "sleep infinity"]);
-    expect(calls[0]?.args.cpu).toBe(500);
-    expect(calls[0]?.args.memory).toBe(500);
+    expect(calls[0]?.args.cpu).toBe(1000);
+    expect(calls[0]?.args.memory).toBe(1024);
     // Sandock's own deadline is a backstop that does not depend on Busabase
     // being alive to reap.
     expect(calls[0]?.args.activeDeadlineSeconds).toBeGreaterThan(0);
@@ -258,12 +261,18 @@ describe("runAirAppSandock", () => {
 
     // Node defaults, unchanged — this engine adds no per-language handling.
     const install = calls.find((c) => c.op === "shell" && String(c.args.cmd).includes("npm"));
-    expect(install?.args.cmd).toBe("npm install");
+    expect(String(install?.args.cmd)).toContain("npm install");
+    expect(String(install?.args.cmd)).toContain("install still running");
+    expect(install?.args.streaming).toBe(true);
 
     // A dev server never exits, so a foreground `shell` would just hang.
     const start = calls.filter((c) => c.op === "shell").at(-1);
     expect(String(start?.args.cmd)).toContain("setsid");
     expect(String(start?.args.cmd)).toContain("npm run dev");
+    expect(String(start?.args.cmd)).toContain("curl");
+    expect(String(start?.args.cmd)).toContain("http://127.0.0.1:3000/");
+    expect(String(start?.args.cmd)).toContain('wait "$app_pid"');
+    expect(String(start?.args.cmd)).not.toContain("&;");
 
     expect(events.at(-1)).toEqual({ type: "ready", previewUrl: "/api/airapp-preview/n1/" });
     // Registered as a proxy target so the preview stays same-origin. Pointing
@@ -304,6 +313,27 @@ describe("runAirAppSandock", () => {
       previewUrl: "/api/airapp-preview/n1/",
     });
     expect(registered).toEqual([["n1", "u1", "https://3000-tok.sandock.ai"]]);
+  });
+
+  it("accepts an app entry redirect without following it outside the preview origin", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(null, { status: 307, headers: { location: "/docs" } }),
+    );
+    shellResults = [{}, { stdout: "" }, {}];
+
+    const events = await drainUntilReady(
+      mod.runAirAppSandock({ nodeId: "n1", files: NODE_FILES, owner: "u1" }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://3000-tok.sandock.ai",
+      expect.objectContaining({ method: "GET", redirect: "manual" }),
+    );
+    expect(events.at(-1)).toEqual({
+      type: "ready",
+      previewUrl: "/api/airapp-preview/n1/",
+    });
   });
 
   it("targets the configured Space through both the client and create request", async () => {
@@ -383,7 +413,9 @@ describe("runAirAppSandock", () => {
     expect(
       calls.some(
         (call) =>
-          call.op === "shell" && call.args.id === "sbx_1" && call.args.cmd === "npm install",
+          call.op === "shell" &&
+          call.args.id === "sbx_1" &&
+          String(call.args.cmd).includes("npm install"),
       ),
     ).toBe(true);
     expect(events).toContainEqual({ type: "log", line: "installed again\n" });

--- a/packages/busabase-core/src/domains/airapp/logic/sandock-runtime.ts
+++ b/packages/busabase-core/src/domains/airapp/logic/sandock-runtime.ts
@@ -56,14 +56,15 @@ const LOG_POLL_MS = 700;
  * indefinitely.
  */
 const SANDBOX_DEADLINE_SECONDS = 4 * 60 * 60;
-const SANDBOX_CPU_MILLICORES = 500;
-const SANDBOX_MEMORY_LIMIT_MB = 500;
+const SANDBOX_CPU_MILLICORES = 1000;
+const SANDBOX_MEMORY_LIMIT_MB = 1024;
 
 const PREVIEW_URL_TTL_SECONDS = 3600;
 
 /** Do not expose an iframe until Sandock can actually reach the app port. */
-const PREVIEW_READY_TIMEOUT_MS = 60_000;
-const PREVIEW_PROBE_TIMEOUT_MS = 5_000;
+const PREVIEW_READY_TIMEOUT_MS = 180_000;
+/** A low-CPU Next.js sandbox may need most of a minute for its first SSR compile. */
+const PREVIEW_PROBE_TIMEOUT_MS = 60_000;
 /** Avoid exposing the iframe during a transient first-success window. */
 const PREVIEW_READY_CONSECUTIVE_SUCCESSES = 3;
 
@@ -252,10 +253,16 @@ const probePreview = async (
   try {
     const response = await fetch(previewUrl, {
       method: "GET",
-      redirect: "error",
+      // A healthy app may redirect `/` to its actual entry route (Fumadocs
+      // redirects to `/docs`). Do not follow arbitrary external redirects,
+      // but treat the response itself as proof that the app port is reachable.
+      redirect: "manual",
       signal: controller.signal,
     });
-    const result = { ready: response.ok, detail: `HTTP ${response.status}` };
+    const result = {
+      ready: response.ok || (response.status >= 300 && response.status < 400),
+      detail: `HTTP ${response.status}`,
+    };
     await response.body?.cancel().catch(() => undefined);
     return result;
   } catch (error) {
@@ -271,6 +278,26 @@ const probePreview = async (
 
 /** Single-quote for `sh -c`, so a path or command containing quotes can't break out. */
 const shellQuote = (value: string): string => `'${value.replaceAll("'", `'"'"'`)}'`;
+
+/** Keep the SSE shell response active while a package manager is quiet. */
+const installCommandWithHeartbeat = (command: string): string =>
+  [
+    `printf '%s\\n' '[busabase] install command started'`,
+    `(${command}) & install_pid=$!`,
+    `while kill -0 "$install_pid" 2>/dev/null; do sleep 20; if kill -0 "$install_pid" 2>/dev/null; then printf '%s\\n' '[busabase] install still running'; fi; done`,
+    `wait "$install_pid"`,
+  ].join("; ");
+
+/**
+ * Warm the app from inside the sandbox so a slow first SSR compile is not
+ * cancelled when an external Preview Proxy probe reaches its timeout.
+ */
+const detachedStartCommand = (command: string, port: number): string =>
+  [
+    `${command} > ${APP_LOG} 2>&1 & app_pid=$!`,
+    `(if command -v curl >/dev/null 2>&1; then attempt=0; while [ "$attempt" -lt 60 ]; do if curl --max-time 180 --silent --show-error --output /dev/null http://127.0.0.1:${port}/; then break; fi; attempt=$((attempt + 1)); sleep 1; done; fi) &`,
+    `wait "$app_pid"`,
+  ].join("\n");
 
 interface ExecutionResultLike {
   stdout?: unknown;
@@ -451,11 +478,19 @@ export async function* runAirAppSandock(
     if (signal?.aborted) return;
 
     yield { type: "log", line: `$ ${installCommand}\n` };
-    const install = await api.sandbox.shell(sandboxId, {
-      cmd: installCommand,
-      workdir: APP_DIR,
-      timeoutMs: INSTALL_TIMEOUT_MS,
-    });
+    const install = await api.sandbox.shell(
+      sandboxId,
+      {
+        cmd: installCommandWithHeartbeat(installCommand),
+        workdir: APP_DIR,
+        timeoutMs: INSTALL_TIMEOUT_MS,
+      },
+      {
+        // Supplying callbacks selects Sandock's streaming SSE endpoint.
+        onStdout: () => undefined,
+        onStderr: () => undefined,
+      },
+    );
     const installStdout = formatExecutionOutput(install.data.stdout);
     const installStderr = formatExecutionOutput(install.data.stderr);
     if (installStdout) yield { type: "log", line: installStdout };
@@ -475,7 +510,7 @@ export async function* runAirAppSandock(
     // does not. `setsid` makes it a session leader so it survives this exec
     // returning, and everything it prints goes to a file we tail below.
     const started = await api.sandbox.shell(sandboxId, {
-      cmd: `cd ${shellQuote(APP_DIR)} && rm -f ${shellQuote(APP_LOG)} && setsid sh -c ${shellQuote(`${startCommand} > ${APP_LOG} 2>&1`)} < /dev/null > /dev/null 2>&1 &`,
+      cmd: `cd ${shellQuote(APP_DIR)} && rm -f ${shellQuote(APP_LOG)} && setsid sh -c ${shellQuote(detachedStartCommand(startCommand, port))} < /dev/null > /dev/null 2>&1 &`,
       workdir: APP_DIR,
       timeoutMs: 60_000,
     });

--- a/packages/busabase-core/src/domains/dashboard/components/agent-prompts-view.test.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/agent-prompts-view.test.tsx
@@ -57,7 +57,7 @@ describe("Agent prompt sidebar sections", () => {
 
     expect(
       sections.find((section) => section.name === "Scenarios")?.items.map(({ key }) => key),
-    ).toEqual(["doc-draft", "doc-review"]);
+    ).toEqual(["doc-ask", "doc-draft", "doc-review"]);
     expect(sections.find((section) => section.name === "Content")?.items[0]?.key).toBe("doc-read");
   });
 

--- a/packages/busabase-core/src/domains/dashboard/components/install-from-github-modal.test.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/install-from-github-modal.test.tsx
@@ -39,15 +39,31 @@ const plan: InstallPlanVO = {
   applicable: true,
 };
 
-function PackageSummaryProbe({ initialPackageName }: { initialPackageName?: string }) {
+function PackageSummaryProbe({
+  initialPackageName,
+  plan: planOverride,
+}: {
+  initialPackageName?: string;
+  plan?: InstallPlanVO;
+}) {
   const messages = useCoreI18n();
-  return <PackageSummary initialPackageName={initialPackageName} messages={messages} plan={plan} />;
+  return (
+    <PackageSummary
+      initialPackageName={initialPackageName}
+      messages={messages}
+      plan={planOverride ?? plan}
+    />
+  );
 }
 
-const renderSummary = (initialPackageName?: string) =>
+const renderSummary = (
+  initialPackageName?: string,
+  locale: "en" | "zh-CN" = "en",
+  planOverride?: InstallPlanVO,
+) =>
   renderToStaticMarkup(
-    <CoreI18nProvider locale="en">
-      <PackageSummaryProbe initialPackageName={initialPackageName} />
+    <CoreI18nProvider locale={locale}>
+      <PackageSummaryProbe initialPackageName={initialPackageName} plan={planOverride} />
     </CoreI18nProvider>,
   );
 
@@ -62,5 +78,30 @@ describe("PackageSummary", () => {
     expect(markup).toContain("Customer Support");
     expect(markup).toContain("A ready-to-use customer support workspace");
     expect(markup).toContain("busabase/templates");
+  });
+
+  it("renders the active locale of a locale-keyed description", () => {
+    const localizedPlan: InstallPlanVO = {
+      ...plan,
+      package: {
+        ...plan.package,
+        description: { en: "A ready-to-use customer support workspace", "zh-CN": "客户支持工作台" },
+      },
+    };
+
+    const zh = renderSummary(undefined, "zh-CN", localizedPlan);
+    expect(zh).toContain("客户支持工作台");
+    expect(zh).not.toContain("A ready-to-use customer support workspace");
+  });
+
+  it("hides the description span instead of an empty tag when every locale is blank", () => {
+    const blankPlan: InstallPlanVO = {
+      ...plan,
+      package: { ...plan.package, description: { en: "", "zh-CN": "" } },
+    };
+
+    const markup = renderSummary(undefined, "en", blankPlan);
+    expect(markup).toContain("Customer Support");
+    expect(markup).not.toMatch(/<span[^>]*><\/span>/);
   });
 });

--- a/packages/busabase-core/src/domains/dashboard/components/install-from-github-modal.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/install-from-github-modal.tsx
@@ -23,8 +23,9 @@ import {
 import { Input } from "kui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "kui/tabs";
 import { CircleCheck, LoaderCircle, Sparkles, TriangleAlert } from "lucide-react";
+import { iStringParse } from "openlib/i18n/i-string";
 import { useEffect, useRef, useState } from "react";
-import { fmt, useCoreI18n } from "../../../i18n";
+import { fmt, useCoreI18n, useCoreLocale } from "../../../i18n";
 import { GithubIcon } from "../helpers/brand-icons";
 import { nodeIconForType } from "../helpers/node-icons";
 import { AgentInstallPanel, type AgentIntegrationTarget } from "./agent-install-panel";
@@ -713,6 +714,8 @@ export function PackageSummary({
   messages: ReturnType<typeof useCoreI18n>;
   plan: InstallPlanVO;
 }) {
+  // Called before the early return below — Rules of Hooks, not style.
+  const locale = useCoreLocale();
   // Template Center already showed this information on the detail page. The
   // manual GitHub flow still needs it because the URL is the user's only input.
   if (initialPackageName) {
@@ -737,12 +740,15 @@ export function PackageSummary({
     plan.source.subdir ? fmt(messages.install.sourceSubdir, { subdir: plan.source.subdir }) : null,
   ].filter((entry): entry is string => entry !== null);
 
+  // Checked after flattening, not before: an empty-per-locale iString object
+  // is still a truthy object, so the old `plan.package.description ? ...`
+  // guard would have rendered an empty <span> instead of hiding it.
+  const description = iStringParse(plan.package.description, locale);
+
   return (
     <section className="flex flex-col gap-1 rounded-md border border-border bg-muted/40 p-3">
       <span className="font-medium text-foreground text-sm">{plan.package.name}</span>
-      {plan.package.description ? (
-        <span className="text-muted-foreground text-sm">{plan.package.description}</span>
-      ) : null}
+      {description ? <span className="text-muted-foreground text-sm">{description}</span> : null}
       {meta.length > 0 ? (
         <span className="text-muted-foreground text-xs">{meta.join(" · ")}</span>
       ) : null}

--- a/packages/busabase-core/src/domains/dashboard/components/node-agent-prompts-dialog.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/node-agent-prompts-dialog.tsx
@@ -24,16 +24,12 @@
 // Layout mirrors `agent-skill-button.tsx` (kui Dialog + readonly textarea +
 // transient "Copied" state) so the two agent-facing dialogs feel like one feature.
 
-import { useQuery } from "@tanstack/react-query";
 import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "kui/dialog";
-import { useEffect, useMemo, useState } from "react";
-import { useCoreI18n, useCoreLocale } from "../../../i18n";
-import {
-  buildNodeAgentPrompts,
-  type NodePromptContext,
-  type NodePromptScope,
-} from "../helpers/node-agent-prompts";
+import { useEffect, useState } from "react";
+import { useCoreI18n } from "../../../i18n";
+import type { NodePromptScope } from "../helpers/node-agent-prompts";
+import { useNodeAgentPrompts } from "../hooks/use-node-agent-prompts";
 import { useDashboardOrpc } from "../orpc-context";
 import { AgentPromptsView } from "./agent-prompts-view";
 
@@ -100,7 +96,6 @@ export function NodeAgentPromptsDialog({
   orpc: BusabaseQueryUtils | null;
 }) {
   const messages = useCoreI18n();
-  const locale = useCoreLocale();
   // Two ways in, because the two callers differ: the node-detail toolbars mount
   // inside `DashboardOrpcProvider` and let the context supply this, while the
   // shell's sidebar dialog passes it explicitly. An explicit prop wins; the
@@ -122,39 +117,23 @@ export function NodeAgentPromptsDialog({
     setResolvedSpaceId(resolveSpaceId(spaceId));
   }, [spaceId]);
 
-  // `enabled: open` is the whole point of the move: closed dialogs cost nothing,
-  // and the request starts the moment one opens rather than riding along on
-  // every sidebar load whether or not anyone ever opens it.
-  const promptsOptions = orpc?.nodes.getAgentPrompts.queryOptions({ input: { nodeId } });
-  const promptsQuery = useQuery({
-    queryKey: promptsOptions?.queryKey ?? ["node-agent-prompts", "not-fetched", nodeId],
-    // Never runs — `enabled` is false whenever there are no real options — but
-    // it has to satisfy the same result type so the query stays typed.
-    queryFn: promptsOptions?.queryFn ?? (async () => ({ nodeId, agentPrompts: null })),
-    enabled: open && promptsOptions !== undefined,
+  // `enabled: open` is the whole point of the fetch living here: closed dialogs
+  // cost nothing, and the request starts the moment one opens rather than riding
+  // along on every sidebar load whether or not anyone ever opens it.
+  const {
+    scenarios,
+    capabilities,
+    loading: promptsLoading,
+  } = useNodeAgentPrompts({
+    enabled: open,
+    nodeId,
+    nodeName,
+    nodeType,
+    orpc,
+    scope,
+    spaceId: resolvedSpaceId,
+    spaceName,
   });
-  // A disabled query stays `pending` forever, so the spinner has to be gated on
-  // there being a fetch at all — otherwise a scoped dialog, which deliberately
-  // never fetches, would show a spinner that never resolves.
-  const promptsLoading = promptsOptions !== undefined && promptsQuery.isPending;
-
-  const context: NodePromptContext = useMemo(
-    () => ({
-      nodeType,
-      nodeName,
-      nodeId,
-      spaceId: resolvedSpaceId,
-      spaceName,
-      scope,
-      customPrompts: promptsQuery.data?.agentPrompts ?? undefined,
-    }),
-    [nodeType, nodeName, nodeId, resolvedSpaceId, spaceName, scope, promptsQuery.data],
-  );
-
-  const { scenarios, capabilities } = useMemo(
-    () => buildNodeAgentPrompts(context, locale, messages),
-    [context, locale, messages],
-  );
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] gap-4 overflow-hidden sm:max-w-3xl">

--- a/packages/busabase-core/src/domains/dashboard/components/node-detail-views.tsx
+++ b/packages/busabase-core/src/domains/dashboard/components/node-detail-views.tsx
@@ -4,11 +4,13 @@ import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-quer
 import type { FileTreeFileVO, FormVO, NodeVO } from "busabase-contract/types";
 import { CodeBlock } from "kui/ai-elements/code-block";
 import { Button } from "kui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "kui/tabs";
 import { cn } from "kui/utils";
 import {
   AppWindow,
   Download,
   File,
+  Files,
   FileText,
   Folder,
   Form,
@@ -19,7 +21,7 @@ import {
   Table2,
 } from "lucide-react";
 import { SPALink as Link } from "openlib/ui/dashboard";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useLocation, useSearch } from "wouter";
 import { fmt, useCoreI18n } from "../../../i18n";
@@ -39,11 +41,14 @@ import {
 import { mergeSearchIntoHref } from "../helpers/link-search";
 import { asNodeDetail } from "../helpers/node-detail";
 import { useFileTreeAssetUpload } from "../hooks/use-file-tree-asset-upload";
+import { useNodeAgentPrompts } from "../hooks/use-node-agent-prompts";
 import { useRegisterTopbarNodeActions } from "../hooks/use-register-topbar-node-actions";
 import { useReportLoadedNode } from "../hooks/use-report-loaded-node";
+import type { LoadedNode } from "../node-detail-registry";
 import { type NodeDetailProps, registerNodeDetail } from "../node-detail-registry";
 import { registerSidePanelTab, type SidePanelTabProps } from "../side-panel-registry";
 import { useIsAnonymousVisitor } from "../visitor-context";
+import { AgentPromptsView } from "./agent-prompts-view";
 import { AssetMediaPreview } from "./assets";
 import { MarkdownFieldPreview } from "./field-preview";
 import {
@@ -63,6 +68,7 @@ import {
 } from "./file-tree-file-actions";
 import { NodeActionsMenu } from "./node-actions-menu";
 import { NodeAgentPromptsButton } from "./node-agent-prompts-button";
+import { resolveSpaceId } from "./node-agent-prompts-dialog";
 import { NodePinButton, nodeSidePanelTabId } from "./node-pin-button";
 import { NodeSettingsDialog } from "./node-settings-dialog";
 import { NodeShareDialog } from "./node-share-button";
@@ -92,6 +98,17 @@ interface FileTreeDetailViewProps {
    *  preview (see `registerSidePanelTab` calls below), where those node-level
    *  actions don't apply to a "glance at it while working elsewhere" view. */
   hideActions?: boolean;
+  /**
+   * Renders AirApp-style tabs with this node as the FIRST one, ahead of the file
+   * browser. Omit and the view is exactly what it was: a file browser with no tab
+   * strip.
+   *
+   * A prop rather than a `nodeType === "skill"` branch because the two node types
+   * sharing this component want different things. A Skill IS a manual — what you
+   * want on opening one is what you can ask an agent to do with it, and the files
+   * are the implementation. A Drive is storage; its files ARE the point.
+   */
+  agentPromptsTab?: ReactNode;
   labels: {
     notFoundTitle: string;
     notFoundBody: string;
@@ -106,6 +123,7 @@ export function FileTreeDetailView({
   nodeType,
   onNodeLoaded,
   hideActions = false,
+  agentPromptsTab,
   labels,
 }: FileTreeDetailViewProps) {
   const messages = useCoreI18n();
@@ -522,8 +540,13 @@ export function FileTreeDetailView({
     ? inferFileTreeMimeType(openPath ?? "", fileQuery.data.mimeType)
     : "application/octet-stream";
 
+  // One wrapper for both shapes: `Tabs` when a prompts tab was supplied (its
+  // trigger list lives INSIDE the header, exactly as AirAppDetailView does it),
+  // a plain div otherwise — so a Drive renders the identical markup it always did.
+  const Frame = agentPromptsTab ? FileTreeTabsFrame : FileTreePlainFrame;
+
   return (
-    <div className="flex h-full min-h-0 w-full flex-col bg-background">
+    <Frame>
       {/* Single compact toolbar (identity + info trigger, actions) replaces the
           old stacked title-block / properties chrome, giving the file browser
           maximum vertical space — mirrors AirAppDetailView's header pattern.
@@ -558,9 +581,28 @@ export function FileTreeDetailView({
             />
           )}
         </div>
+
+        {agentPromptsTab ? (
+          <TabsList className="h-8 shrink-0 gap-1 bg-transparent p-0">
+            <TabsTrigger className={FILE_TREE_TAB_TRIGGER_CLASS} value="prompts">
+              <Sparkles className="size-3.5" />
+              {messages.agentPrompts.title}
+            </TabsTrigger>
+            <TabsTrigger className={FILE_TREE_TAB_TRIGGER_CLASS} value="files">
+              <Files className="size-3.5" />
+              {messages.nodeDetail.files}
+            </TabsTrigger>
+          </TabsList>
+        ) : null}
       </header>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)]">
+      {agentPromptsTab ? (
+        <TabsContent className="min-h-0 flex-1 overflow-auto p-4" value="prompts">
+          {agentPromptsTab}
+        </TabsContent>
+      ) : null}
+
+      <FileTreeBrowserPane hasTabs={agentPromptsTab !== undefined}>
         <aside className="min-h-[220px] border-border/60 border-b bg-muted/20 lg:min-h-0 lg:border-r lg:border-b-0">
           <div className="flex h-full min-h-0 flex-col">
             <div className="flex min-h-11 items-center justify-between gap-3 border-border/50 border-b px-4">
@@ -795,7 +837,7 @@ export function FileTreeDetailView({
             )}
           </div>
         </main>
-      </div>
+      </FileTreeBrowserPane>
       <FileTreeRenameDialog
         existingPaths={filePaths}
         file={renameTarget}
@@ -813,10 +855,64 @@ export function FileTreeDetailView({
         onSubmit={removeFile}
         open={removeTarget !== null}
       />
-    </div>
+    </Frame>
   );
 }
 
+/** Shared by both trigger buttons; lifted from `AirAppDetailView`'s tab strip. */
+const FILE_TREE_TAB_TRIGGER_CLASS =
+  "h-7 gap-1.5 rounded-lg bg-transparent px-2.5 text-muted-foreground shadow-none transition-colors hover:bg-muted/40 hover:text-foreground data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none";
+
+/** No tabs: the exact markup this view had before the Skill node grew a prompts tab. */
+const FileTreePlainFrame = ({ children }: { children: ReactNode }) => (
+  <div className="flex h-full min-h-0 w-full flex-col bg-background">{children}</div>
+);
+
+/**
+ * Tabs, with the prompts tab first.
+ *
+ * `Tabs` wraps the header rather than sitting under it because the trigger list
+ * belongs IN the header, beside the node's name — the same arrangement (and the
+ * same reason) as `AirAppDetailView`.
+ */
+const FileTreeTabsFrame = ({ children }: { children: ReactNode }) => (
+  <Tabs className="flex h-full min-h-0 w-full flex-col gap-0 bg-background" defaultValue="prompts">
+    {children}
+  </Tabs>
+);
+
+/**
+ * The file browser itself. Inside tabs it is the "files" tab's content;
+ * without them it is the whole body, and renders the same grid either way.
+ *
+ * `forceMount` is deliberate: the browser owns the open file, the edit draft and
+ * the expanded folders, and a tab switch must not silently discard someone's
+ * half-written edit.
+ */
+const FileTreeBrowserPane = ({ hasTabs, children }: { hasTabs: boolean; children: ReactNode }) => {
+  const className = "grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)]";
+  if (!hasTabs) return <div className={className}>{children}</div>;
+  return (
+    <TabsContent className={`${className} data-[state=inactive]:hidden`} forceMount value="files">
+      {children}
+    </TabsContent>
+  );
+};
+
+/**
+ * A Skill node opens on what you can ASK for, not on its file tree.
+ *
+ * The node is a manual: the useful first question is "what can an agent do with
+ * this", and the prompts answer it in one click (Copy, or Ask Agent). The files
+ * are one tab over for whoever wants to read or edit them — which is also why
+ * there is no separate "Source" tab: the Files tab already opens on `SKILL.md`
+ * (the node's entry file), so a third tab would be a second door to the same
+ * room.
+ *
+ * The prompts are keyed off the LOADED node rather than the route slug because
+ * they need the node's id and name; until it loads, the tab renders nothing and
+ * the file browser behaves exactly as before.
+ */
 export function SkillDetailView({
   orpc,
   slug,
@@ -824,8 +920,24 @@ export function SkillDetailView({
   hideActions,
 }: NodeDetailProps & { hideActions?: boolean }) {
   const messages = useCoreI18n();
+  const [loadedNode, setLoadedNode] = useState<LoadedNode | null>(null);
+  const reportLoaded = useCallback(
+    (node: LoadedNode) => {
+      setLoadedNode(node);
+      onNodeLoaded?.(node);
+    },
+    [onNodeLoaded],
+  );
+
   return (
     <FileTreeDetailView
+      agentPromptsTab={
+        loadedNode ? (
+          <SkillAgentPromptsTab node={loadedNode} orpc={orpc} />
+        ) : (
+          <div className="text-muted-foreground text-sm">{messages.common.loading}</div>
+        )
+      }
       hideActions={hideActions}
       labels={{
         notFoundTitle: messages.nodeDetail.skillNotFoundTitle,
@@ -834,9 +946,36 @@ export function SkillDetailView({
         skeletonVariant: "skill",
       }}
       nodeType="skill"
-      onNodeLoaded={onNodeLoaded}
+      onNodeLoaded={reportLoaded}
       orpc={orpc}
       slug={slug}
+    />
+  );
+}
+
+/**
+ * The same surface the prompts dialog shows — same component, same hook, same
+ * Copy and Ask Agent — rendered inline instead of inside a Dialog.
+ *
+ * `onHandedOff` is a no-op here: there is no dialog to close once the prompt
+ * reaches an agent, and the side panel it opens is its own confirmation.
+ */
+function SkillAgentPromptsTab({ node, orpc }: { node: LoadedNode; orpc: BusabaseQueryUtils }) {
+  const { scenarios, capabilities, loading } = useNodeAgentPrompts({
+    nodeId: node.id,
+    nodeName: node.name,
+    nodeType: "skill",
+    orpc,
+    spaceId: resolveSpaceId(),
+  });
+
+  return (
+    <AgentPromptsView
+      askAgent={{ orpc, sessionScopeId: node.id }}
+      capabilities={capabilities}
+      loading={loading}
+      onHandedOff={() => {}}
+      scenarios={scenarios}
     />
   );
 }

--- a/packages/busabase-core/src/domains/dashboard/helpers/node-agent-prompts.test.ts
+++ b/packages/busabase-core/src/domains/dashboard/helpers/node-agent-prompts.test.ts
@@ -99,6 +99,19 @@ describe("buildNodeAgentPrompts scoping", () => {
     expect(capabilities.map((prompt) => prompt.key)).toEqual(["record_update"]);
   });
 
+  /**
+   * Scenario keys declared `intent: "read-only"`. `NodePrompt` deliberately does
+   * not carry `intent` (the renderer has no use for it once the footer is
+   * built), so the tests name them.
+   */
+  const MUTATION_EXEMPT = new Set([
+    "base-find",
+    "base-summarize",
+    "field-audit",
+    "record-explain",
+    "cell-explain",
+  ]);
+
   it("keeps the do-not-self-approve guidance on mutating scenarios and every capability", () => {
     for (const scope of [
       undefined,
@@ -107,11 +120,72 @@ describe("buildNodeAgentPrompts scoping", () => {
       { kind: "cell", ...RECORD, ...FIELD } as const,
     ]) {
       const { scenarios, capabilities } = build(scope);
-      expect(scenarios[0]?.body).toContain("never merge it without my approval");
+      // Named rather than positional. This used to assert on `scenarios[0]`,
+      // which passed only because the first entry happened to be a mutating one
+      // — so the day a read-only scenario was promoted to the top of a list, the
+      // test failed without a single mutating prompt having lost its guidance.
+      const mutating = scenarios.filter((prompt) => !MUTATION_EXEMPT.has(prompt.key));
+      expect(mutating.length).toBeGreaterThan(0);
+      for (const prompt of mutating) {
+        expect(prompt.body).toContain("never merge it without my approval");
+      }
       for (const prompt of capabilities) {
         expect(prompt.body).toContain("never merge it without my approval");
       }
     }
+  });
+
+  it("leaves the approval line OFF read-only scenarios, so 'read-only' means it", () => {
+    const { scenarios } = build();
+    const readOnly = scenarios.filter((prompt) => MUTATION_EXEMPT.has(prompt.key));
+    expect(readOnly.map((prompt) => prompt.key)).toEqual(["base-find", "base-summarize"]);
+    for (const prompt of readOnly) {
+      expect(prompt.body).not.toContain("never merge it without my approval");
+    }
+  });
+});
+
+/**
+ * Every node type has to offer USING the thing, not only maintaining it.
+ *
+ * This list was maintenance-only for its whole life, and the Skill node made it
+ * obvious: its single scenario was "Improve this skill", so the one node type
+ * that exists to BE run offered no way to run it. The same shape was in the
+ * others — a Doc you could redraft but not ask, a Drive you could reorganise but
+ * not search, a Base you could summarise but not query, an AirApp you could
+ * modify but not understand.
+ *
+ * Pinned by key, because the failure mode is silent: a list with the "use it"
+ * entry deleted still renders, still looks complete, and just quietly sends
+ * everyone back to editing.
+ */
+describe("using the node, not only maintaining it", () => {
+  const scenarioKeys = (nodeType: string) =>
+    buildNodeAgentPrompts(
+      { nodeId: "nod_x", nodeName: "X", nodeType, spaceId: "local" },
+      "en",
+      coreMessagesEn,
+    ).scenarios.map((prompt) => prompt.key);
+
+  it.each([
+    ["skill", "skill-run"],
+    ["doc", "doc-ask"],
+    ["drive", "drive-find"],
+    ["base", "base-find"],
+    ["airapp", "airapp-explain"],
+  ])("%s offers %s", (nodeType, expectedKey) => {
+    expect(scenarioKeys(nodeType)).toContain(expectedKey);
+  });
+
+  it("puts running a Skill first, because that is what the list is opened for", () => {
+    // Not just present — first. The Skill node opens straight onto this list
+    // (its detail view leads with the Agent-prompts tab), and the first entry is
+    // the one already selected when it renders.
+    expect(scenarioKeys("skill")[0]).toBe("skill-run");
+  });
+
+  it("still offers improving a Skill, for the person who authored it", () => {
+    expect(scenarioKeys("skill")).toContain("skill-improve");
   });
 });
 
@@ -384,7 +458,7 @@ describe("Doc read prompt", () => {
   it("is a Content capability rather than a scenario and keeps mutating Doc prompts review-gated", () => {
     const { scenarios, capabilities } = buildNodeAgentPrompts(DOC_CONTEXT, "en", coreMessagesEn);
 
-    expect(scenarios.map((prompt) => prompt.key)).toEqual(["doc-draft", "doc-review"]);
+    expect(scenarios.map((prompt) => prompt.key)).toEqual(["doc-ask", "doc-draft", "doc-review"]);
     expect(scenarios.map((prompt) => prompt.key)).not.toContain("doc-read");
     const contentPrompts = capabilities.filter((prompt) => prompt.group === "Content");
     expect(contentPrompts[0]?.key).toBe("doc-read");

--- a/packages/busabase-core/src/domains/dashboard/helpers/node-agent-prompts.ts
+++ b/packages/busabase-core/src/domains/dashboard/helpers/node-agent-prompts.ts
@@ -329,6 +329,26 @@ interface PromptDef {
 
 const BASE_SCENARIOS: PromptDef[] = [
   {
+    key: "base-find",
+    intent: "read-only",
+    label: {
+      en: "Find the records I mean",
+      "zh-CN": "帮我找出符合条件的记录",
+      "zh-TW": "幫我找出符合條件的記錄",
+      ja: "条件に合うレコードを探す",
+    },
+    body: {
+      en: (t) =>
+        `${t}\n\nI'll describe which records I want in plain language. Read the field schema first so you filter on the right fields, then show me the matching records and say how you filtered — I need to be able to tell a wrong filter from an empty result. Read-only; don't change anything.`,
+      "zh-CN": (t) =>
+        `${t}\n\n我会用大白话描述我想要哪些记录。请先读字段结构，确保你筛的是对的字段，然后把符合的记录列给我，并说明你是按什么条件筛的——我需要能分清"筛错了"和"确实没有"。只读，不要改动任何数据。`,
+      "zh-TW": (t) =>
+        `${t}\n\n我會用白話描述我想要哪些記錄。請先讀欄位結構，確保你篩的是對的欄位，然後把符合的記錄列給我，並說明你是按什麼條件篩的——我需要能分清「篩錯了」和「確實沒有」。唯讀，不要改動任何資料。`,
+      ja: (t) =>
+        `${t}\n\n欲しいレコードを普通の言葉で説明します。まずフィールド構成を読んで正しいフィールドで絞り込み、該当レコードを見せたうえで、どう絞り込んだかも教えてください——「条件を間違えた」のか「本当に無い」のかを私が区別できる必要があります。読み取り専用、データは変更しないでください。`,
+    },
+  },
+  {
     key: "base-bulk-import",
     label: {
       en: "Bulk-add records",
@@ -430,6 +450,26 @@ const DOC_READ_PROMPT: PromptDef = {
 
 const DOC_SCENARIOS: PromptDef[] = [
   {
+    key: "doc-ask",
+    intent: "read-only",
+    label: {
+      en: "Answer my question from this doc",
+      "zh-CN": "根据这篇文档回答我",
+      "zh-TW": "根據這篇文件回答我",
+      ja: "この文書に基づいて答えて",
+    },
+    body: {
+      en: (t) =>
+        `${t}\n\nRead this doc, then answer the question I ask next using only what it actually says. Quote the part you are relying on. If the doc does not answer it, say so instead of filling the gap from your own knowledge. Read-only.`,
+      "zh-CN": (t) =>
+        `${t}\n\n请读这篇文档，然后只依据它里面真正写了的内容回答我接下来的问题，并引用你依据的那一段。如果文档里没写，就直接说没写，不要用你自己的知识补上。只读，不要改动。`,
+      "zh-TW": (t) =>
+        `${t}\n\n請讀這篇文件，然後只依據它裡面真正寫了的內容回答我接下來的問題，並引用你依據的那一段。如果文件裡沒寫，就直接說沒寫，不要用你自己的知識補上。唯讀，不要改動。`,
+      ja: (t) =>
+        `${t}\n\nこの文書を読み、次の質問には文書に実際に書かれている内容だけで答えてください。根拠にした箇所を引用してください。文書が答えていない場合は、自分の知識で埋めずに「書かれていない」と伝えてください。読み取り専用です。`,
+    },
+  },
+  {
     key: "doc-draft",
     label: {
       en: "Draft / expand this doc",
@@ -471,6 +511,26 @@ const DOC_SCENARIOS: PromptDef[] = [
 
 const DRIVE_SCENARIOS: PromptDef[] = [
   {
+    key: "drive-find",
+    intent: "read-only",
+    label: {
+      en: "Find something in these files",
+      "zh-CN": "在这些文件里找东西",
+      "zh-TW": "在這些檔案裡找東西",
+      ja: "ファイルの中から探す",
+    },
+    body: {
+      en: (t) =>
+        `${t}\n\nI'll tell you what I'm looking for. Search these files and tell me which file it is in and where, quoting enough of it that I can tell you found the right thing. If it is in several places, list them all rather than picking one. Read-only.`,
+      "zh-CN": (t) =>
+        `${t}\n\n我接下来告诉你我要找什么。请在这些文件里检索，告诉我它在哪个文件、哪个位置，并引用足够的原文让我能判断你找对了。如果多处都有，请全部列出，不要只挑一个。只读，不要改动。`,
+      "zh-TW": (t) =>
+        `${t}\n\n我接下來告訴你我要找什麼。請在這些檔案裡檢索，告訴我它在哪個檔案、哪個位置，並引用足夠的原文讓我能判斷你找對了。如果多處都有，請全部列出，不要只挑一個。唯讀，不要改動。`,
+      ja: (t) =>
+        `${t}\n\n次に探しているものを伝えます。これらのファイルを検索し、どのファイルのどこにあるかを、正しいものを見つけたと私が判断できるだけの原文を引用して教えてください。複数箇所にあるなら、ひとつ選ばず全部挙げてください。読み取り専用です。`,
+    },
+  },
+  {
     key: "drive-organize",
     label: {
       en: "Organize these files",
@@ -511,7 +571,53 @@ const DRIVE_SCENARIOS: PromptDef[] = [
   },
 ];
 
+/**
+ * A Skill node is a CAPABILITY, and the thing people do with a capability is use
+ * it. This list opened with "Improve this skill" and had nothing else — every
+ * prompt on offer treated the reader as the skill's maintainer, when almost
+ * everyone opening one is a person who wants it to do its job for them. Running
+ * it comes first now; improving it is still here, third, for the author.
+ */
 const SKILL_SCENARIOS: PromptDef[] = [
+  {
+    key: "skill-run",
+    label: {
+      en: "Use this skill",
+      "zh-CN": "调用这个 Skill",
+      "zh-TW": "呼叫這個 Skill",
+      ja: "この Skill を実行",
+    },
+    body: {
+      en: (t) =>
+        `${t}\n\nRead this skill's \`SKILL.md\` and any reference files it points at, then follow its workflow to do what I describe next. Follow the skill's own rules over your usual habits, and tell me if it says something you cannot do here.`,
+      "zh-CN": (t) =>
+        `${t}\n\n请读这个 skill 的 \`SKILL.md\` 以及它引用的参考文件，然后按它写的流程完成我接下来描述的任务。以这个 skill 自己的规则为准，不要用你平时的习惯覆盖它；如果它要求的事情你在这里做不到，直接告诉我。`,
+      "zh-TW": (t) =>
+        `${t}\n\n請讀這個 skill 的 \`SKILL.md\` 以及它引用的參考檔案，然後按它寫的流程完成我接下來描述的任務。以這個 skill 自己的規則為準，不要用你平時的習慣覆蓋它；如果它要求的事情你在這裡做不到，直接告訴我。`,
+      ja: (t) =>
+        `${t}\n\nこの skill の \`SKILL.md\` と参照ファイルを読み、そのワークフローに従って次に説明する作業を行ってください。あなたの通常のやり方より skill 自身のルールを優先し、ここでは実行できないことが書かれていれば教えてください。`,
+    },
+  },
+  {
+    key: "skill-explain",
+    intent: "read-only",
+    label: {
+      en: "What can this do for me?",
+      "zh-CN": "这个 Skill 能帮我做什么？",
+      "zh-TW": "這個 Skill 能幫我做什麼？",
+      ja: "これで何ができる？",
+    },
+    body: {
+      en: (t) =>
+        `${t}\n\nRead this skill and tell me in plain language what it does, when I should reach for it, and what it needs from me before it can run — credentials, data, a decision. Read-only; don't run it or change it yet.`,
+      "zh-CN": (t) =>
+        `${t}\n\n请读这个 skill，用大白话告诉我：它是干什么的、什么时候该用它、以及在它能跑起来之前需要我先准备什么（凭据、数据、还是某个决定）。只读——先别执行它，也别改它。`,
+      "zh-TW": (t) =>
+        `${t}\n\n請讀這個 skill，用白話告訴我：它是做什麼的、什麼時候該用它、以及在它能跑起來之前需要我先準備什麼（憑證、資料、還是某個決定）。唯讀——先別執行它，也別改它。`,
+      ja: (t) =>
+        `${t}\n\nこの skill を読んで、平易な言葉で教えてください：何をするものか、どんなときに使うべきか、動かす前に私が用意すべきもの（認証情報・データ・判断）は何か。読み取り専用——まだ実行も変更もしないでください。`,
+    },
+  },
   {
     key: "skill-improve",
     label: {
@@ -534,6 +640,26 @@ const SKILL_SCENARIOS: PromptDef[] = [
 ];
 
 const AIRAPP_SCENARIOS: PromptDef[] = [
+  {
+    key: "airapp-explain",
+    intent: "read-only",
+    label: {
+      en: "What does this app do?",
+      "zh-CN": "这个应用是干什么的？",
+      "zh-TW": "這個應用是做什麼的？",
+      ja: "このアプリは何をする？",
+    },
+    body: {
+      en: (t) =>
+        `${t}\n\nRead the app's source and the tables it reads, then tell me what it is for, who it is for, and which data it shows or writes. I want to understand it before I change it. Read-only.`,
+      "zh-CN": (t) =>
+        `${t}\n\n请读这个应用的代码，以及它读取的那些表，然后告诉我：它是干什么的、给谁用的、展示和写入的分别是哪些数据。我想先看懂它，再谈改它。只读，不要改动。`,
+      "zh-TW": (t) =>
+        `${t}\n\n請讀這個應用的程式碼，以及它讀取的那些表，然後告訴我：它是做什麼的、給誰用的、展示和寫入的分別是哪些資料。我想先看懂它，再談改它。唯讀，不要改動。`,
+      ja: (t) =>
+        `${t}\n\nこのアプリのコードと、それが読んでいるテーブルを読んだうえで、何のためのアプリか、誰向けか、どのデータを表示・書き込みするかを教えてください。変更する前にまず理解したいです。読み取り専用です。`,
+    },
+  },
   {
     key: "airapp-add-feature",
     label: {
@@ -959,6 +1085,20 @@ const buildCuratedPrompt = (
     group,
     body: `${prompt.body[locale](target)}\n\n${footer}`,
   };
+};
+
+/**
+ * Just the "which node am I talking about" sentence, without a prompt around it.
+ *
+ * Exported for the side panel's context chip: when someone types their own
+ * message to an agent with a node open, the chip sends this same line. Sharing
+ * it with the prompts (rather than writing a second, similar sentence in the
+ * agents domain) is what keeps an agent from having to recognise two different
+ * phrasings of the same fact.
+ */
+export const renderNodeTargetLine = (context: NodePromptContext, locale: CoreLocale): string => {
+  const definition = getNodeType(context.nodeType);
+  return TARGET_LINE[locale](context, definition?.label ?? context.nodeType);
 };
 
 export function buildNodeAgentPrompts(

--- a/packages/busabase-core/src/domains/dashboard/hooks/use-node-agent-prompts.ts
+++ b/packages/busabase-core/src/domains/dashboard/hooks/use-node-agent-prompts.ts
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * One node's Agent prompts, ready to render: the node type's curated scenarios
+ * and derived capabilities, with this node's CUSTOM scenarios already fetched
+ * and substituted in.
+ *
+ * Extracted from `node-agent-prompts-dialog` when the Skill node grew a prompts
+ * TAB: the dialog and the tab differ in what frames them and in nothing else, so
+ * the fetch, the loading rule and the context assembly live here once. Feed the
+ * result straight into `AgentPromptsView`.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import type { BusabaseQueryUtils } from "busabase-contract/api-client/react-query";
+import { useMemo } from "react";
+import { useCoreI18n, useCoreLocale } from "../../../i18n";
+import {
+  buildNodeAgentPrompts,
+  type NodePrompt,
+  type NodePromptContext,
+  type NodePromptScope,
+} from "../helpers/node-agent-prompts";
+
+export interface NodeAgentPrompts {
+  scenarios: NodePrompt[];
+  capabilities: NodePrompt[];
+  /** True only while a FIRST read of the custom prompts is in flight. */
+  loading: boolean;
+}
+
+export const useNodeAgentPrompts = ({
+  nodeId,
+  nodeName,
+  nodeType,
+  spaceId,
+  spaceName,
+  scope,
+  orpc,
+  enabled = true,
+}: {
+  nodeId: string;
+  nodeName: string;
+  nodeType: string;
+  spaceId?: string;
+  spaceName?: string;
+  scope?: NodePromptScope;
+  /**
+   * `null`/`undefined` for a host that never wired oRPC (the chromeless mobile
+   * WebView, SSR): the node then shows its type's defaults, which is what it did
+   * before custom prompts existed.
+   */
+  orpc: BusabaseQueryUtils | null | undefined;
+  /**
+   * `false` to skip the fetch entirely — a closed dialog, or a field/record/cell
+   * scope, where custom prompts never apply (they replace the whole-node
+   * scenario tier only, see `buildNodeAgentPrompts`).
+   */
+  enabled?: boolean;
+}): NodeAgentPrompts => {
+  const messages = useCoreI18n();
+  const locale = useCoreLocale();
+
+  const promptsOptions = orpc?.nodes.getAgentPrompts.queryOptions({ input: { nodeId } });
+  const promptsQuery = useQuery({
+    queryKey: promptsOptions?.queryKey ?? ["node-agent-prompts", "not-fetched", nodeId],
+    // Never runs — `enabled` is false whenever there are no real options — but it
+    // has to satisfy the same result type so the query stays typed.
+    queryFn: promptsOptions?.queryFn ?? (async () => ({ nodeId, agentPrompts: null })),
+    enabled: enabled && promptsOptions !== undefined,
+  });
+  // A disabled query stays `pending` forever, so the spinner has to be gated on
+  // there being a fetch at all — otherwise a caller that deliberately never
+  // fetches would show a spinner that never resolves.
+  const loading = promptsOptions !== undefined && enabled && promptsQuery.isPending;
+
+  const context: NodePromptContext = useMemo(
+    () => ({
+      nodeType,
+      nodeName,
+      nodeId,
+      spaceId,
+      spaceName,
+      scope,
+      customPrompts: promptsQuery.data?.agentPrompts ?? undefined,
+    }),
+    [nodeType, nodeName, nodeId, spaceId, spaceName, scope, promptsQuery.data],
+  );
+
+  const { scenarios, capabilities } = useMemo(
+    () => buildNodeAgentPrompts(context, locale, messages),
+    [context, locale, messages],
+  );
+
+  return { scenarios, capabilities, loading };
+};

--- a/packages/busabase-core/src/domains/dashboard/index.tsx
+++ b/packages/busabase-core/src/domains/dashboard/index.tsx
@@ -74,7 +74,11 @@ import { NodeRouteStateView } from "./components/node-route-state";
 import { RecordDetailView, RecordEditorView, RecordTopbarActions } from "./components/record-views";
 import { SearchDialog } from "./components/search-dialog";
 import { SidePanel, SidePanelToggle } from "./components/side-panel";
-import { isPinnableNode, pinNodeToSidePanel } from "./components/side-panel-sources";
+import {
+  isPinnableNode,
+  openAgentChatTab,
+  pinNodeToSidePanel,
+} from "./components/side-panel-sources";
 import { BaseTableSkeleton, NodeDetailSkeleton } from "./components/skeletons";
 import { SubmitPermissionProvider } from "./components/split-submit-button";
 import { BusabaseTopbarBreadcrumb, TopbarNodeActionsSlot } from "./components/topbar";
@@ -105,6 +109,7 @@ import { useKeyboardShortcut } from "./hooks/use-keyboard-shortcut";
 import { useBusabaseLiveSync } from "./hooks/use-live-sync";
 import { getNodeDetail, type LoadedNode } from "./node-detail-registry";
 import { DashboardOrpcProvider } from "./orpc-context";
+import { useCurrentNodeStore } from "./store/current-node-store";
 import { type DashboardVisitorKind, DashboardVisitorProvider } from "./visitor-context";
 
 // Flattens the (already-fetched, for sidebar-tree rendering) node tree into
@@ -311,6 +316,7 @@ function BusabaseDashboardContent({
     () => createKnownNodeCache(`${cacheSpaceKey}:${currentUserId ?? "anonymous"}`),
     [cacheSpaceKey, currentUserId],
   );
+  const setCurrentNode = useCurrentNodeStore((state) => state.setNode);
   const [loadedDetailNode, setLoadedDetailNode] = useState<{
     node: LoadedNode;
     scopeKey: string;
@@ -1954,6 +1960,38 @@ function BusabaseDashboardContent({
     }
   }, [activeBase, locationPath, recordLoadedNode, selectedBaseSlug]);
 
+  /**
+   * Publish "the node the user is looking at" for the side panel to offer as
+   * context (see `store/current-node-store`).
+   *
+   * Two sources because node detail has two: the generic registry resolves
+   * `activeDetailNode` for every node type, and Bases render from their own
+   * query. Both are already route-gated, so navigating to Home or the agents
+   * list lands here as `null` — which is the point. A stale node offered as
+   * context for an unrelated question is worse than no context at all.
+   */
+  useEffect(() => {
+    if (activeDetailNode) {
+      setCurrentNode({
+        id: activeDetailNode.id,
+        type: activeDetailNode.type,
+        name: activeDetailNode.name,
+        slug: activeDetailNode.slug,
+      });
+      return;
+    }
+    if (locationPath.startsWith("/base/") && activeBase) {
+      setCurrentNode({
+        id: activeBase.nodeId,
+        type: "base",
+        name: activeBase.name,
+        slug: activeBase.slug,
+      });
+      return;
+    }
+    setCurrentNode(null);
+  }, [activeBase, activeDetailNode, locationPath, setCurrentNode]);
+
   // Global Cmd+K (Mac) / Ctrl+K (Windows/Linux) quick-jump shortcut — opens the
   // search dialog from anywhere in the dashboard. Registered as two separate
   // bindings (not one "meta-or-ctrl" combo) since `useKeyboardShortcut` treats
@@ -2172,6 +2210,13 @@ function BusabaseDashboardContent({
           orpc={orpc}
           agentSlug={agentDetailParams?.agentSlug ?? ""}
           onBack={() => setLocation("/agents")}
+          // Moving the conversation to the panel means leaving this page — the
+          // point is to have it beside something else — so this navigates away
+          // rather than leaving the same chat mounted twice on screen.
+          onOpenInSidePanel={(sessionId, agentName) => {
+            openAgentChatTab(agentDetailParams?.agentSlug ?? "", agentName, { sessionId });
+            setLocation("/home");
+          }}
         />
       );
     }

--- a/packages/busabase-core/src/domains/dashboard/store/current-node-store.ts
+++ b/packages/busabase-core/src/domains/dashboard/store/current-node-store.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { create } from "zustand";
+import type { LoadedNode } from "../node-detail-registry";
+
+/**
+ * What the main area is currently showing — so the side panel can offer it as
+ * context without the user re-describing their own screen.
+ *
+ * A store rather than a prop because of where it has to arrive: side-panel tabs
+ * are looked up through `side-panel-registry` by tab type, and their props are
+ * deliberately just `{ orpc, payload }`. Threading "the node the user is looking
+ * at" down that path would mean widening that contract for every tab type, when
+ * exactly one of them wants it.
+ *
+ * `null` whenever the main area is not on a node — the agents list, Home,
+ * settings. That is the honest answer, and it is what keeps the composer from
+ * offering a stale node as context for a question that has nothing to do with it.
+ *
+ * Unpersisted, single-slot, same shape and reasoning as
+ * `topbar-node-actions-store.ts`: one main area, one current node, nothing worth
+ * surviving a reload.
+ */
+export interface CurrentNodeStoreState {
+  node: LoadedNode | null;
+  setNode: (node: LoadedNode | null) => void;
+}
+
+export const useCurrentNodeStore = create<CurrentNodeStoreState>()((set) => ({
+  node: null,
+  setNode: (node) =>
+    set((state) => {
+      // Same node, same object identity out — this is fed by a route/tree effect
+      // that re-runs on unrelated renders, and every new object here would
+      // re-render the composer's context chip for no reason.
+      const current = state.node;
+      if (current?.id === node?.id && current?.name === node?.name) return state;
+      return { node };
+    }),
+}));

--- a/packages/busabase-core/src/domains/templates/components/template-card-summary.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-card-summary.tsx
@@ -1,6 +1,7 @@
 import type { TemplateCardVO } from "busabase-contract/domains/templates/types";
 import { Badge } from "kui/badge";
 import { AppWindow, Bot, FileText, Rows3, Table2 } from "lucide-react";
+import { iStringParse, type LocaleType } from "openlib/i18n/i-string";
 import type { ReactNode } from "react";
 import { TemplateCardImage } from "./template-card-image";
 
@@ -28,6 +29,13 @@ interface TemplateCardSummaryProps {
   statLabels?: TemplateStatLabels;
   headingHref?: string;
   children?: ReactNode;
+  /**
+   * `description` is an iString; this resolves it to one language. A prop, not
+   * `useCoreLocale()` called internally — this component renders in both a
+   * Dashboard client tree and a marketing Server Component tree (see the note
+   * below), and a hook would break the second one outright.
+   */
+  descriptionLocale?: LocaleType;
 }
 
 /**
@@ -46,6 +54,7 @@ export function TemplateCardSummary({
   statLabels = defaultStatLabels,
   headingHref,
   children,
+  descriptionLocale = "en",
 }: TemplateCardSummaryProps) {
   const [screenshot] = template.screenshots;
   const Heading = headingLevel;
@@ -108,7 +117,7 @@ export function TemplateCardSummary({
               : "line-clamp-2 flex-1 text-xs text-muted-foreground"
           }
         >
-          {template.description}
+          {iStringParse(template.description, descriptionLocale)}
         </p>
 
         {stats.length > 0 ? (

--- a/packages/busabase-core/src/domains/templates/components/template-detail-content.test.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-detail-content.test.tsx
@@ -60,4 +60,20 @@ describe("TemplateDetailContent", () => {
     expect(markup).toContain(">Bases</dt>");
     expect(markup).not.toContain(">Tables</dt>");
   });
+
+  it("renders the requested locale of a locale-keyed description", () => {
+    const localized: TemplateCardVO = {
+      ...template,
+      description: { en: "Email operations workspace", "zh-CN": "邮件运营工作台" },
+    };
+
+    const zh = renderToStaticMarkup(
+      <TemplateDetailContent template={localized} descriptionLocale="zh-CN" />,
+    );
+    expect(zh).toContain("邮件运营工作台");
+    expect(zh).not.toContain("Email operations workspace");
+
+    const en = renderToStaticMarkup(<TemplateDetailContent template={localized} />);
+    expect(en).toContain("Email operations workspace");
+  });
 });

--- a/packages/busabase-core/src/domains/templates/components/template-detail-content.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-detail-content.tsx
@@ -1,6 +1,7 @@
 import type { TemplateCardVO } from "busabase-contract/domains/templates/types";
 import { Badge } from "kui/badge";
 import { ExternalLink, MessageSquare, PackageOpen } from "lucide-react";
+import { iStringParse, type LocaleType } from "openlib/i18n/i-string";
 import type { ReactNode } from "react";
 import { TemplateScreenshotShowcase } from "./template-screenshot-showcase";
 
@@ -64,6 +65,9 @@ interface TemplateDetailContentProps {
   template: TemplateCardVO;
   labels?: TemplateDetailLabels;
   actions?: ReactNode;
+  /** See the identical note on `TemplateCardSummaryProps` — a prop, not a
+   * hook, because this renders in a Server Component tree too. */
+  descriptionLocale?: LocaleType;
 }
 
 /**
@@ -74,6 +78,7 @@ export function TemplateDetailContent({
   template,
   labels = defaultLabels,
   actions,
+  descriptionLocale = "en",
 }: TemplateDetailContentProps) {
   const { stats } = template;
   const contents = [
@@ -102,7 +107,9 @@ export function TemplateDetailContent({
               <span className="text-xs text-muted-foreground">v{template.version}</span>
             ) : null}
           </div>
-          <p className="text-sm leading-6 text-muted-foreground">{template.description}</p>
+          <p className="text-sm leading-6 text-muted-foreground">
+            {iStringParse(template.description, descriptionLocale)}
+          </p>
           {template.tags.length > 0 ? (
             <ul className="flex flex-wrap gap-1.5" aria-label={labels.tags}>
               {template.tags.map((tag) => (

--- a/packages/busabase-core/src/domains/templates/components/template-detail-view.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-detail-view.tsx
@@ -3,6 +3,7 @@
 import type { TemplateCardVO } from "busabase-contract/domains/templates/types";
 import { Button } from "kui/button";
 import { ArrowLeft } from "lucide-react";
+import { useCoreLocale } from "../../../i18n";
 import { TemplateDetailContent } from "./template-detail-content";
 
 interface TemplateDetailViewProps {
@@ -29,6 +30,7 @@ export function TemplateDetailView({
   onInstall,
   canInstall,
 }: TemplateDetailViewProps) {
+  const locale = useCoreLocale();
   return (
     // Same scroll shell as the gallery, `h-full` included — see the note there
     // for why that class is the one doing the work. This page is the taller of
@@ -44,6 +46,7 @@ export function TemplateDetailView({
 
           <TemplateDetailContent
             template={template}
+            descriptionLocale={locale}
             actions={
               <div className="flex flex-col items-end gap-1">
                 <Button onClick={onInstall} disabled={!canInstall}>

--- a/packages/busabase-core/src/domains/templates/components/template-grid.tsx
+++ b/packages/busabase-core/src/domains/templates/components/template-grid.tsx
@@ -18,6 +18,8 @@
  */
 
 import type { TemplateCardVO } from "busabase-contract/domains/templates/types";
+import type { ReactNode } from "react";
+import { useCoreLocale } from "../../../i18n";
 import { ShimmerSkeleton as Skeleton } from "../../dashboard/components/shimmer-skeleton";
 import { TemplateCardSummary, type TemplateStatLabels } from "./template-card-summary";
 
@@ -41,6 +43,7 @@ export function TemplateCard({
   density?: "compact" | "comfortable";
   statLabels?: TemplateStatLabels;
 }) {
+  const locale = useCoreLocale();
   return (
     <button
       className="group flex flex-col overflow-hidden rounded-lg border border-border bg-card text-left transition-colors hover:border-primary/50"
@@ -49,6 +52,7 @@ export function TemplateCard({
     >
       <TemplateCardSummary
         density={density}
+        descriptionLocale={locale}
         screenshotAlt=""
         statLabels={statLabels}
         template={template}
@@ -63,9 +67,11 @@ export function TemplateGrid({
   error,
   emptyLabel,
   onOpenTemplate,
+  children,
   density,
   statLabels,
   columnsClassName = "sm:grid-cols-2 lg:grid-cols-3",
+  gapClassName = "gap-4",
   skeletonCount = TEMPLATE_SKELETON_IDS.length,
 }: {
   templates: readonly TemplateCardVO[];
@@ -78,16 +84,34 @@ export function TemplateGrid({
    */
   error?: string | null;
   emptyLabel: string;
-  onOpenTemplate: (template: TemplateCardVO) => void;
+  /** Click-to-open (the Dashboard picker). Ignored when `children` is given. */
+  onOpenTemplate?: (template: TemplateCardVO) => void;
+  /**
+   * Full control over the cards' markup, pre-rendered by the caller — a
+   * public page needs a real `<a>` (crawlable, works with JS disabled) and
+   * extra body content (tags, a version/author/license table), neither of
+   * which the click-to-open `TemplateCard` supports. `TemplateCardSummary` is
+   * deliberately event-free so callers can wrap it in either a `<button>` or
+   * an `<article>`/`<Link>`; this is the extension point for the latter.
+   *
+   * Deliberately pre-rendered nodes, not a render-prop function: this
+   * component is a Client Component (`"use client"` above) and the public
+   * template page that needs this is a Server Component. A function prop
+   * crossing that boundary is a hard RSC error ("Functions cannot be passed
+   * directly to Client Components"); a tree of already-rendered elements
+   * serializes across it fine, the same way any other `children` does.
+   */
+  children?: ReactNode;
   density?: "compact" | "comfortable";
   statLabels?: TemplateStatLabels;
   /** Grid columns — the modal is narrower than the page and says so here. */
   columnsClassName?: string;
+  gapClassName?: string;
   skeletonCount?: number;
 }) {
   if (isPending) {
     return (
-      <div aria-hidden className={`grid gap-4 ${columnsClassName}`}>
+      <div aria-hidden className={`grid ${gapClassName} ${columnsClassName}`}>
         {TEMPLATE_SKELETON_IDS.slice(0, skeletonCount).map((id) => (
           <div className="overflow-hidden rounded-lg border border-border bg-card" key={id}>
             <Skeleton className="aspect-[16/10] w-full rounded-none" />
@@ -118,16 +142,17 @@ export function TemplateGrid({
   }
 
   return (
-    <div className={`grid gap-4 ${columnsClassName}`}>
-      {templates.map((template) => (
-        <TemplateCard
-          density={density}
-          key={template.id}
-          onOpen={() => onOpenTemplate(template)}
-          statLabels={statLabels}
-          template={template}
-        />
-      ))}
+    <div className={`grid ${gapClassName} ${columnsClassName}`}>
+      {children ??
+        templates.map((template) => (
+          <TemplateCard
+            density={density}
+            key={template.id}
+            onOpen={() => onOpenTemplate?.(template)}
+            statLabels={statLabels}
+            template={template}
+          />
+        ))}
     </div>
   );
 }

--- a/packages/busabase-core/src/domains/templates/components/templates-list-view.tsx
+++ b/packages/busabase-core/src/domains/templates/components/templates-list-view.tsx
@@ -6,6 +6,7 @@ import type { TemplateCardVO } from "busabase-contract/domains/templates/types";
 import { Button } from "kui/button";
 import { Input } from "kui/input";
 import { ExternalLink, RefreshCw } from "lucide-react";
+import { iStringConcat } from "openlib/i18n/i-string";
 import { useMemo, useState } from "react";
 import { TemplateGrid } from "./template-grid";
 
@@ -52,7 +53,7 @@ export function TemplatesListView({ orpc, onOpenTemplate, canInstall }: Template
     const all = catalog.data?.templates ?? [];
     if (!needle) return all;
     return all.filter((template) =>
-      [template.name, template.description, template.category, ...template.tags]
+      [template.name, iStringConcat(template.description), template.category, ...template.tags]
         .join(" ")
         .toLowerCase()
         .includes(needle),

--- a/packages/busabase-core/src/domains/templates/logic/catalog.test.ts
+++ b/packages/busabase-core/src/domains/templates/logic/catalog.test.ts
@@ -56,3 +56,23 @@ describe("listTemplates — risk normalization", () => {
     expect(catalog.templates[0].risk).toBeUndefined();
   });
 });
+
+describe("listTemplates — description is iString", () => {
+  it("passes through a plain-string description unchanged", async () => {
+    mockCatalog([baseEntry]);
+    const catalog = await listTemplates();
+    expect(catalog.templates[0].description).toBe("The gated desk.");
+  });
+
+  it("does not throw oRPC's .output() validation on a locale-keyed description", async () => {
+    mockCatalog([
+      { ...baseEntry, description: { en: "The gated desk.", "zh-CN": "受限工作台。" } },
+    ]);
+    const catalog = await listTemplates();
+    expect(catalog.error).toBeUndefined();
+    expect(catalog.templates[0].description).toEqual({
+      en: "The gated desk.",
+      "zh-CN": "受限工作台。",
+    });
+  });
+});

--- a/packages/busabase-core/src/i18n/ja.ts
+++ b/packages/busabase-core/src/i18n/ja.ts
@@ -350,6 +350,10 @@ export const dashboardJa: CoreI18nMessages = {
     mineEmptyBody: "Claude Code、Codex、または Buda AI Agent を接続してください。",
     spaceEmptyTitle: "このスペースには共有エージェントがまだありません",
     spaceEmptyBody: "スペースのメンバーが追加したエージェントをチームで利用できます。",
+    openInSidePanel: "サイドパネルで続ける",
+    contextChipLabel: "コンテキスト",
+    contextChipHint: "送信時に、開いているノードを添えます。",
+    contextChipRemove: "このコンテキストを付けない",
   },
   form: {
     alreadyExists:

--- a/packages/busabase-core/src/i18n/messages.ts
+++ b/packages/busabase-core/src/i18n/messages.ts
@@ -376,6 +376,10 @@ export const coreMessagesEn = {
     mineEmptyBody: "Connect Claude Code, Codex, or a Buda AI Agent to get started.",
     spaceEmptyTitle: "No shared agents in this space yet",
     spaceEmptyBody: "Agents added by space members will appear here for the team to use.",
+    openInSidePanel: "Continue in side panel",
+    contextChipLabel: "Context",
+    contextChipHint: "Your message will say which node you mean.",
+    contextChipRemove: "Don't send this as context",
   },
   form: {
     alreadyExists:

--- a/packages/busabase-core/src/i18n/zh-CN.ts
+++ b/packages/busabase-core/src/i18n/zh-CN.ts
@@ -338,6 +338,10 @@ export const dashboardZhCN: CoreI18nMessages = {
     mineEmptyBody: "连接 Claude Code、Codex 或 Buda AI Agent 后即可开始使用。",
     spaceEmptyTitle: "此空间站还没有共享 Agent",
     spaceEmptyBody: "空间站成员添加的 Agent 会显示在这里，供团队共同使用。",
+    openInSidePanel: "在侧栏继续",
+    contextChipLabel: "上下文",
+    contextChipHint: "发送时会带上你正在看的节点。",
+    contextChipRemove: "不要带上这个上下文",
   },
   form: {
     alreadyExists: "这个节点已经存在表单，请更新现有表单，不要重复创建。",

--- a/packages/busabase-package/package.json
+++ b/packages/busabase-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-package",
   "description": "The `busabase-package@1` format: GitHub source, layout read/write, install planning, and the five-pass apply. Shared by busabase-cli (`install` / `export`) and busabase-core's server-side install domain. Node-only APIs are fine here \u2014 it is never browser-bundled.",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/packages/busabase-package",
@@ -138,6 +138,7 @@
   "dependencies": {
     "@orpc/contract": "^1.14.6",
     "@zip.js/zip.js": "^2.8.20",
+    "openlib": "workspace:*",
     "yaml": "^2.9.0",
     "zod": "^4.3.6"
   },

--- a/packages/busabase-package/src/apply.test.ts
+++ b/packages/busabase-package/src/apply.test.ts
@@ -72,6 +72,11 @@ const createFakeServer = (): FakeServer => {
         nodeSeq++;
         return { id: `crq_${++crSeq}`, operations: [{ nodeId: `nod_${nodeSeq}` }] };
       },
+      updateAgentPrompts: async (input: unknown) => {
+        record("nodes.updateAgentPrompts", input);
+        const typed = input as { nodeId: string; agentPrompts: unknown };
+        return { nodeId: typed.nodeId, agentPrompts: typed.agentPrompts };
+      },
     },
     bases: {
       list: async () => [],
@@ -84,7 +89,7 @@ const createFakeServer = (): FakeServer => {
           slug: field.slug,
         }));
         fieldsByBase.set(baseId, fields);
-        return { materialized: true as const, id: baseId, fields };
+        return { materialized: true as const, id: baseId, nodeId: `nod_base_${baseSeq}`, fields };
       },
       createField: async (input: unknown) => {
         record("bases.createField", input);
@@ -265,6 +270,87 @@ describe("target folder", () => {
     expect(calls.some((call) => call.method === "nodes.createChangeRequest")).toBe(false);
     const docCreate = calls.find((call) => call.method === "docs.create");
     expect((docCreate?.input as { parentNodeId: string }).parentNodeId).toBe("nod_root");
+  });
+});
+
+describe("the prompts a package carries", () => {
+  const PROMPTS = [
+    {
+      key: "log-visit",
+      label: "Log a customer visit",
+      body: "Read the `crm` skill in this folder, then add a visit to {target}.",
+    },
+  ];
+
+  it("writes them onto the node it just created", async () => {
+    const { calls, client } = createFakeServer();
+    const base = plainBase("contacts");
+    const result = await applyInstall(client, planFor([{ ...base, agentPrompts: PROMPTS }]), {
+      autoMerge: true,
+    });
+
+    const call = calls.find((entry) => entry.method === "nodes.updateAgentPrompts");
+    expect(call?.input).toEqual({ nodeId: "nod_base_1", agentPrompts: PROMPTS });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("says nothing at all for a package that carries none — the shape every package had", async () => {
+    const { calls, client } = createFakeServer();
+    await applyInstall(client, planFor([plainBase("contacts")]), { autoMerge: true });
+
+    expect(calls.some((entry) => entry.method === "nodes.updateAgentPrompts")).toBe(false);
+  });
+
+  it("warns instead of failing when the node is still a pending change request", async () => {
+    const { calls, client } = createFakeServer();
+    // Review-first: `docs.create` answers with a change request, so there is no
+    // node id to hang prompts on until a human merges it.
+    const pendingClient = {
+      ...client,
+      docs: {
+        create: async () => ({ materialized: false as const, id: "crq_pending" }),
+      },
+    } as unknown as PackageClient;
+
+    const result = await applyInstall(
+      pendingClient,
+      planFor([
+        {
+          type: "doc",
+          slug: "guide",
+          name: "Guide",
+          description: "",
+          position: 0,
+          body: "",
+          agentPrompts: PROMPTS,
+        },
+      ]),
+      { autoMerge: false },
+    );
+
+    expect(calls.some((entry) => entry.method === "nodes.updateAgentPrompts")).toBe(false);
+    expect(result.warnings.join("\n")).toContain("set-agent-prompts");
+  });
+
+  it("warns instead of failing when the server refuses the write", async () => {
+    const { client } = createFakeServer();
+    const refusing = {
+      ...client,
+      nodes: {
+        ...client.nodes,
+        updateAgentPrompts: async () => {
+          throw new Error("no such route");
+        },
+      },
+    } as unknown as PackageClient;
+
+    const base = plainBase("contacts");
+    const result = await applyInstall(refusing, planFor([{ ...base, agentPrompts: PROMPTS }]), {
+      autoMerge: true,
+    });
+
+    expect(result.created.bases).toBe(1);
+    expect(result.warnings.join("\n")).toContain("no such route");
   });
 });
 

--- a/packages/busabase-package/src/apply.ts
+++ b/packages/busabase-package/src/apply.ts
@@ -31,6 +31,7 @@
  */
 
 import { createHash } from "node:crypto";
+import type { CustomAgentPrompts } from "busabase-contract/contract/node-agent-prompt-schemas";
 import {
   APP_ROOT_RESOURCE_KEY,
   type AppResourceOwnership,
@@ -43,6 +44,7 @@ import {
   type PackageBaseField,
   type PackageFieldOptions,
 } from "busabase-contract/domains/package/types";
+import { iStringParse } from "openlib/i18n/i-string";
 import type { PackageClient } from "./client";
 import { reportUnresolvableDocAssets, rewriteDocAssetIds } from "./doc-asset-refs";
 import type { InstallPlan } from "./plan";
@@ -196,7 +198,12 @@ export const applyInstall = async (
         parentNodeId: undefined,
         slug: plan.targetFolderSlug,
         name: plan.tree.manifest.name,
-        description: plan.tree.manifest.description,
+        // The real node-creation contract (filetree/contract.ts) takes a plain
+        // string today, not iString — flatten here rather than widen that API
+        // as a side effect of this change. The catalog card the user picked
+        // this from still shows every declared locale; only the installed
+        // Folder's own description is single-locale, for now.
+        description: iStringParse(plan.tree.manifest.description, "en"),
         submittedBy: options.submittedBy,
         // Only a folder we just created is stamped. Installing into a folder the
         // user already had — or into the space root — must not claim it for this
@@ -580,6 +587,44 @@ const stampResource = async (
   }
 };
 
+/**
+ * Write a node's carried scenario prompts onto the node install just created.
+ *
+ * After creation rather than inline, because the prompts live in their own
+ * column with their own route — no create endpoint accepts them. That has one
+ * visible consequence, and it is the reason for the warning below: on the
+ * review-first path a Doc or File node is a PENDING change request with no node
+ * id yet, so there is nothing to write them to. Structure (folders, Bases,
+ * Skills/AirApps/Drives) is always materialized (see {@link createBase}), so the
+ * nodes that carry most prompts are unaffected.
+ *
+ * Never fails the install, for the same reason {@link stampResource} does not:
+ * the resources are already there and useful, and prompts can be re-applied with
+ * `busabase-cli nodes set-agent-prompts` at any time.
+ */
+const applyAgentPrompts = async (
+  client: PackageClient,
+  nodeId: string | undefined,
+  node: { slug: string; agentPrompts?: CustomAgentPrompts },
+  state: ApplyResult,
+): Promise<void> => {
+  const agentPrompts = node.agentPrompts;
+  if (!agentPrompts?.length) return;
+  if (!nodeId) {
+    state.warnings.push(
+      `"${node.slug}" installs as a change request, so its ${agentPrompts.length} agent prompt(s) were not applied. After merging it, run \`busabase-cli nodes set-agent-prompts\` for that node, or re-install with --auto-merge.`,
+    );
+    return;
+  }
+  try {
+    await client.nodes.updateAgentPrompts({ nodeId, agentPrompts });
+  } catch (error) {
+    state.warnings.push(
+      `Could not set agent prompts on "${node.slug}": ${(error as Error).message}. The node installed fine; it will show its node type's default prompts.`,
+    );
+  }
+};
+
 // ── Pass 1 helpers ───────────────────────────────────────────────────────────
 
 /**
@@ -647,6 +692,7 @@ const createStructure = async (
           submittedBy: options.submittedBy,
         });
         state.created.folders++;
+        await applyAgentPrompts(client, nodeId, node, state);
         await createStructure(
           client,
           node.children,
@@ -686,6 +732,12 @@ const createStructure = async (
         });
         if (result.materialized) state.created.docs++;
         else state.pendingChangeRequests++;
+        await applyAgentPrompts(
+          client,
+          result.materialized ? result.node.id : undefined,
+          node,
+          state,
+        );
         break;
       }
       case "base": {
@@ -725,6 +777,12 @@ const createStructure = async (
         });
         if (result.materialized) state.created.files++;
         else state.pendingChangeRequests++;
+        await applyAgentPrompts(
+          client,
+          result.materialized ? result.node.id : undefined,
+          node,
+          state,
+        );
         break;
       }
     }
@@ -821,6 +879,7 @@ const createBase = async (
   bases.push({ node, baseId: result.id });
   indexFields(fieldIds, node.slug, result.fields);
   await stampResource(client, app, result.nodeId, node.slug, state);
+  await applyAgentPrompts(client, result.nodeId, node, state);
 
   for (const view of node.base.views) {
     const created = await client.views.changeRequest({
@@ -905,6 +964,7 @@ const createFileTreeNode = async (
     // The stamp went with the proposal, so it lands when a human merges.
     state.pendingChangeRequests++;
   }
+  await applyAgentPrompts(client, result.materialized ? result.node.id : undefined, node, state);
 };
 
 // ── Assets ───────────────────────────────────────────────────────────────────

--- a/packages/busabase-package/src/audit.test.ts
+++ b/packages/busabase-package/src/audit.test.ts
@@ -40,7 +40,22 @@ const MANIFEST = {
   },
 };
 
-const BASE = { name: "Reviews", description: "Review items", position: 0, fields: [], views: [] };
+const BASE = {
+  name: "Reviews",
+  description: "Review items",
+  position: 0,
+  // A publishable package tells the user what THIS app is for, per node — see
+  // the `template/node-without-prompts` case below.
+  agentPrompts: [
+    {
+      key: "triage",
+      label: "Triage today's review queue",
+      body: "Read the `fixture-desk` skill in this folder, then triage {target}.",
+    },
+  ],
+  fields: [],
+  views: [],
+};
 
 const files = (overrides: Record<string, string | null> = {}): PackageFiles => {
   const base: Record<string, string> = {
@@ -167,6 +182,45 @@ describe("the manual an agent acts on", () => {
   it("reports nothing for a plain package with no manual", () => {
     const map = files({ "SKILL.md": null, "references/taxonomy.md": null });
     expect(auditSkill(map)).toEqual([]);
+  });
+});
+
+describe('installs, then leaves the user asking "now what?"', () => {
+  it("warns when the package ships no manual to install beside its resources", () => {
+    expect(rules(audit({ "SKILL.md": null, "references/taxonomy.md": null }), "warning")).toContain(
+      "template/no-skill-node",
+    );
+  });
+
+  it("warns about nodes with no scenario prompts, and names them", () => {
+    const { agentPrompts: _drop, ...noPrompts } = BASE;
+    const warnings = audit({ "content/reviews/base.json": JSON.stringify(noPrompts) }).filter(
+      (finding) => finding.rule === "template/node-without-prompts",
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain("reviews");
+  });
+
+  it("does not count folders — a container has nothing to ask an agent for", () => {
+    const map = files({
+      "content/reviews/base.json": null,
+      "content/reviews/records.ndjson": null,
+      "content/notes/_folder.json": JSON.stringify({ name: "Notes" }),
+    });
+    const tree = readPackageTree(map);
+    expect(
+      auditPackage(tree, map, { directoryName: NAME }).map((finding) => finding.rule),
+    ).not.toContain("template/node-without-prompts");
+  });
+
+  it("stays a warning — nothing here stops a package installing", () => {
+    const { agentPrompts: _drop, ...noPrompts } = BASE;
+    const findings = audit({
+      "SKILL.md": null,
+      "references/taxonomy.md": null,
+      "content/reviews/base.json": JSON.stringify(noPrompts),
+    });
+    expect(findings.filter((finding) => finding.severity === "error")).toEqual([]);
   });
 });
 

--- a/packages/busabase-package/src/audit.ts
+++ b/packages/busabase-package/src/audit.ts
@@ -31,7 +31,7 @@ import { SkillFrontmatterSchema } from "busabase-contract/domains/skill/frontmat
 
 import { parseFrontmatter } from "./frontmatter";
 import type { PackageFiles } from "./layout-read";
-import type { PackageTree } from "./tree";
+import type { PackageNode, PackageTree } from "./tree";
 
 export type AuditSeverity = "error" | "warning";
 
@@ -170,7 +170,49 @@ export const auditPackage = (
     }
   }
 
+  // ── Installs, then leaves the user asking "now what?" ──────────────────────
+  //
+  // Warnings, never errors, and deliberately so: a package with neither is still
+  // correct and still installs. What it is not is *self-driving* — the person who
+  // installs it gets resources and has to supply the knowledge of how to work them,
+  // which is the gap these two rules exist to name at publish time rather than in
+  // a support thread.
+  if (!tree.rootSkill) {
+    warn(
+      "template/no-skill-node",
+      `This package carries no ${PACKAGE_SKILL_ENTRY}, so nothing installs a manual beside its resources. An agent working in the installed folder has nothing to read, and the person who installed it has nothing to point one at.`,
+    );
+  }
+
+  const promptless = nodesWithoutAgentPrompts(tree.nodes);
+  if (promptless.length > 0) {
+    warn(
+      "template/node-without-prompts",
+      `${promptless.length} installed node(s) carry no agentPrompts (${promptless.slice(0, 5).join(", ")}${promptless.length > 5 ? ", …" : ""}). They will show their node type's generic prompts, so nothing tells the user what THIS app is for. Write scenario prompts per node — see \`busabase-cli nodes set-agent-prompts\`.`,
+    );
+  }
+
   return findings;
+};
+
+/**
+ * Node slugs (dotted by folder) with no scenario prompts of their own.
+ *
+ * Folders are exempt: a folder is a container, and the useful prompts hang off the
+ * things inside it. Everything else is something a person opens and then has to
+ * work out what to ask for.
+ */
+const nodesWithoutAgentPrompts = (nodes: readonly PackageNode[], prefix = ""): string[] => {
+  const out: string[] = [];
+  for (const node of nodes) {
+    const path = `${prefix}${node.slug}`;
+    if (node.type === "folder") {
+      out.push(...nodesWithoutAgentPrompts(node.children, `${path}/`));
+      continue;
+    }
+    if (!node.agentPrompts?.length) out.push(path);
+  }
+  return out;
 };
 
 /**

--- a/packages/busabase-package/src/collect-agent-prompts.test.ts
+++ b/packages/busabase-package/src/collect-agent-prompts.test.ts
@@ -1,0 +1,89 @@
+/**
+ * A node's scenario prompts are what tell the person who installs a package what
+ * THIS app is for. They live in their own column with their own route (they are
+ * deliberately absent from `nodes.list`), so export has to ask for them per node
+ * — and must survive a server that cannot answer.
+ */
+
+import { PACKAGE_FORMAT, type PackageManifest } from "busabase-contract/domains/package/types";
+import { describe, expect, it } from "vitest";
+import type { PackageClient } from "./client";
+import { collectPackageTree, type SourceNode } from "./collect";
+
+const manifest = (): PackageManifest => ({
+  format: PACKAGE_FORMAT,
+  name: "crm",
+  description: "",
+  tags: [],
+});
+
+const PROMPTS = [{ key: "log-visit", label: "Log a visit", body: "Add a visit to {target}." }];
+
+const root: SourceNode = {
+  id: "nod-crm",
+  slug: "crm",
+  name: "CRM",
+  type: "folder",
+  description: "",
+  position: 0,
+  children: [
+    { id: "nod-guide", slug: "guide", name: "Guide", type: "doc", description: "", position: 0 },
+    { id: "nod-notes", slug: "notes", name: "Notes", type: "doc", description: "", position: 1 },
+  ],
+};
+
+const stubClient = (
+  getAgentPrompts: (input: { nodeId: string }) => Promise<{ agentPrompts: unknown }>,
+): PackageClient =>
+  ({
+    nodes: {
+      get: async () => ({ type: "doc", body: "" }),
+      getAgentPrompts,
+    },
+  }) as unknown as PackageClient;
+
+const collect = async (client: PackageClient) => {
+  const warnings: string[] = [];
+  const tree = await collectPackageTree(client, root, {
+    manifest: manifest(),
+    warn: (message) => warnings.push(message),
+    baseUrl: "http://localhost",
+  });
+  return { tree, warnings };
+};
+
+describe("collecting a node's agent prompts", () => {
+  it("carries them into the package", async () => {
+    const { tree, warnings } = await collect(
+      stubClient(async ({ nodeId }) => ({
+        agentPrompts: nodeId === "nod-guide" ? PROMPTS : null,
+      })),
+    );
+
+    expect(tree.nodes[0]).toMatchObject({ slug: "guide", agentPrompts: PROMPTS });
+    // `null` means "never set" — the node carries no key at all rather than an
+    // empty list, so the package looks identical to one written before the field.
+    expect(tree.nodes[1]).not.toHaveProperty("agentPrompts.0");
+    expect(warnings).toEqual([]);
+  });
+
+  it("treats an empty list as none, so it does not round-trip a key that changes nothing", async () => {
+    const { tree } = await collect(stubClient(async () => ({ agentPrompts: [] })));
+
+    expect(tree.nodes[0]).not.toHaveProperty("agentPrompts.0");
+  });
+
+  it("warns once and keeps exporting when the server cannot answer", async () => {
+    // A server predating the route fails on every node; one warning is as
+    // informative as fifty.
+    const { tree, warnings } = await collect(
+      stubClient(async () => {
+        throw new Error("no such route");
+      }),
+    );
+
+    expect(tree.nodes).toHaveLength(2);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("no such route");
+  });
+});

--- a/packages/busabase-package/src/collect.ts
+++ b/packages/busabase-package/src/collect.ts
@@ -8,6 +8,7 @@
  * self-containment rule: a relation may not leave the package.
  */
 
+import type { CustomAgentPrompts } from "busabase-contract/contract/node-agent-prompt-schemas";
 import {
   APP_ROOT_RESOURCE_KEY,
   TEMPLATE_SKILL_METADATA_KEY,
@@ -71,6 +72,15 @@ export interface CollectOptions {
    * omit it — it defaults to empty, meaning "nothing was install-renamed."
    */
   baseResourceKeys?: ReadonlyMap<string, string>;
+  /**
+   * Internal, set by {@link collectPackageTree}: has the prompts read already
+   * failed once this export?
+   *
+   * A server without the route fails it for EVERY node, and a hundred identical
+   * warnings is not a hundred times as informative as one. The first failure is
+   * reported and the rest of the export stops asking.
+   */
+  agentPromptsUnavailable?: { value: boolean };
 }
 
 /** Find the subtree to export by node slug or id. */
@@ -102,6 +112,7 @@ export const collectPackageTree = async (
   const collectOptions: CollectOptions = {
     ...options,
     baseResourceKeys: collectBaseResourceKeys(children),
+    agentPromptsUnavailable: options.agentPromptsUnavailable ?? { value: false },
   };
   const nodes = await collectNodes(client, rest, collectOptions);
   const tree: PackageTree = {
@@ -287,6 +298,36 @@ const collectNodes = async (
   return sortNodes(nodes);
 };
 
+/**
+ * This node's scenario Agent prompts, read from the column they live in.
+ *
+ * A separate read per node because that is the only way to get them: they are
+ * deliberately absent from `nodes.list` (50 prompts x 8 KiB per locale is why
+ * they have their own column and their own route).
+ *
+ * Never fatal. A server that predates the route, or a node this key may read but
+ * whose prompts it may not, costs the export those prompts and nothing else —
+ * the package still installs, and its nodes fall back to their type's defaults,
+ * exactly as every package did before the field existed.
+ */
+const collectAgentPrompts = async (
+  client: PackageClient,
+  source: SourceNode,
+  options: CollectOptions,
+): Promise<CustomAgentPrompts | undefined> => {
+  if (options.agentPromptsUnavailable?.value) return undefined;
+  try {
+    const result = await client.nodes.getAgentPrompts({ nodeId: source.id });
+    return result.agentPrompts?.length ? result.agentPrompts : undefined;
+  } catch (error) {
+    if (options.agentPromptsUnavailable) options.agentPromptsUnavailable.value = true;
+    options.warn(
+      `Could not read agent prompts for "${source.slug}": ${(error as Error).message}. Exported without them for this node and every node after it; the installed nodes will show their node type's default prompts.`,
+    );
+    return undefined;
+  }
+};
+
 const collectNode = async (
   client: PackageClient,
   source: SourceNode,
@@ -298,6 +339,7 @@ const collectNode = async (
     description: source.description ?? "",
     // `export` always writes position, so round trips preserve sibling order exactly.
     position: source.position,
+    agentPrompts: await collectAgentPrompts(client, source, options),
   };
 
   switch (source.type) {
@@ -333,7 +375,7 @@ const collectNode = async (
   }
 };
 
-type NodeCommon = Pick<PackageNode, "slug" | "name" | "description" | "position">;
+type NodeCommon = Pick<PackageNode, "slug" | "name" | "description" | "position" | "agentPrompts">;
 
 const collectBase = async (
   client: PackageClient,

--- a/packages/busabase-package/src/discover.test.ts
+++ b/packages/busabase-package/src/discover.test.ts
@@ -73,6 +73,27 @@ describe("discoverPackages", () => {
     expect(discoverPackages(singlePackage())[0].templateErrors).toEqual([]);
   });
 
+  it("carries a locale-keyed manifest description through untouched", () => {
+    const files: PackageFiles = new Map([
+      [
+        "busabase.json",
+        utf8(
+          JSON.stringify({
+            format: PACKAGE_FORMAT,
+            name: "support-kb",
+            description: { en: "The support-kb desk.", "zh-CN": "支持知识库工作台。" },
+          }),
+        ),
+      ],
+      ["content/faq.md", utf8("---\nname: FAQ\n---\n\nHello.\n")],
+    ]);
+    const found = discoverPackages(files);
+    expect(found[0].description).toEqual({
+      en: "The support-kb desk.",
+      "zh-CN": "支持知识库工作台。",
+    });
+  });
+
   it("explains itself to an author whose template does not quite validate", () => {
     const files = skillsRepo();
     files.set("skills/kelly-email/busabase.json", utf8(manifest("wrong-name")));

--- a/packages/busabase-package/src/discover.ts
+++ b/packages/busabase-package/src/discover.ts
@@ -20,6 +20,7 @@
 
 import type { TemplateRiskLevel } from "busabase-contract/domains/package/template";
 import { PACKAGE_MANIFEST_FILENAME } from "busabase-contract/domains/package/types";
+import type { iString } from "openlib/i18n/i-string";
 import { type PackageFiles, readPackageTree } from "./layout-read";
 import { countTree, type PlanCounts } from "./plan";
 import { validateTemplate } from "./template";
@@ -28,7 +29,10 @@ export interface DiscoveredPackage {
   /** Path from the URL's root; `""` when the repo itself is the package. */
   subdir: string;
   name: string;
-  description: string;
+  /** Propagated as-is (not flattened) so a catalog card can render every
+   * declared locale; `name` stays plain because it also doubles as the
+   * install-target slug — see the comment on `PackageManifestSchema.name`. */
+  description: iString;
   /** Installs as an app: Skill node, ownership stamps, sample rows merged. */
   isTemplate: boolean;
   /**

--- a/packages/busabase-package/src/frontmatter.ts
+++ b/packages/busabase-package/src/frontmatter.ts
@@ -1,11 +1,13 @@
 /**
- * YAML frontmatter for doc nodes (§6.3): `name`, `description?`, `position?` above
- * the markdown body.
+ * YAML frontmatter for doc nodes (§6.3): `name`, `description?`, `position?`,
+ * `agentPrompts?` above the markdown body.
  *
  * Writing is deterministic (§6.6): a fixed key order and LF endings, so re-exporting
  * an unchanged doc is byte-identical.
  */
+import type { CustomAgentPrompts } from "busabase-contract/contract/node-agent-prompt-schemas";
 import { parse, stringify } from "yaml";
+import { serializeAgentPrompts } from "./tree";
 
 const DELIMITER = "---";
 
@@ -58,6 +60,8 @@ export interface DocFrontmatterFields {
   name: string;
   description: string;
   position: number | undefined;
+  /** This Doc's scenario Agent prompts; omitted from the frontmatter when empty. */
+  agentPrompts?: CustomAgentPrompts;
 }
 
 /** Serialize a doc to `---\n<frontmatter>\n---\n<body>` with a trailing newline. */
@@ -67,6 +71,8 @@ export const serializeDoc = (fields: DocFrontmatterFields, body: string): string
   const data: Record<string, unknown> = { name: fields.name };
   if (fields.description) data.description = fields.description;
   if (fields.position !== undefined) data.position = fields.position;
+  const agentPrompts = serializeAgentPrompts(fields.agentPrompts);
+  if (agentPrompts) data.agentPrompts = agentPrompts;
 
   const yaml = stringify(data, { lineWidth: 0 }).replace(/\n$/, "");
   return `${DELIMITER}\n${yaml}\n${DELIMITER}\n\n${normalizeDocBody(body)}\n`;

--- a/packages/busabase-package/src/index-build.test.ts
+++ b/packages/busabase-package/src/index-build.test.ts
@@ -70,4 +70,21 @@ describe("buildTemplateIndex", () => {
     });
     expect(index.templates[0].risk).toBeUndefined();
   });
+
+  it("carries a locale-keyed manifest description onto the index entry untouched", () => {
+    const localizedManifest = JSON.stringify({
+      format: PACKAGE_FORMAT,
+      name: "gated",
+      description: { en: "The gated desk.", "zh-CN": "受限工作台。" },
+      template: { category: "ops" },
+    });
+    const index = buildTemplateIndex(repo({ "templates/gated/busabase.json": localizedManifest }), {
+      repo: "busabase/templates",
+      ref: "main",
+    });
+    expect(index.templates[0].description).toEqual({
+      en: "The gated desk.",
+      "zh-CN": "受限工作台。",
+    });
+  });
 });

--- a/packages/busabase-package/src/index-build.ts
+++ b/packages/busabase-package/src/index-build.ts
@@ -15,6 +15,7 @@
  * Spec: `apps/busabase/content/spec/template-center.md` §6.4.
  */
 import type { TemplateRiskLevel } from "busabase-contract/domains/package/template";
+import type { iString } from "openlib/i18n/i-string";
 import { type DiscoveredPackage, discoverPackages } from "./discover";
 import type { PackageFiles } from "./layout-read";
 
@@ -25,7 +26,7 @@ export interface TemplateIndexEntry {
   /** Install target: `<repo>` + this subdir is the URL a card's button uses. */
   subdir: string;
   name: string;
-  description: string;
+  description: iString;
   category: string;
   /** Not what it does but whether it acts on your behalf — see `TemplateRiskLevel`. */
   risk?: TemplateRiskLevel;

--- a/packages/busabase-package/src/layout-read.ts
+++ b/packages/busabase-package/src/layout-read.ts
@@ -19,6 +19,7 @@
  * what keeps a template byte-identical to a plain package below the root.
  */
 
+import type { CustomAgentPrompts } from "busabase-contract/contract/node-agent-prompt-schemas";
 import {
   PACKAGE_AIRAPP_IGNORE,
   PACKAGE_SKILL_ENTRY,
@@ -36,6 +37,7 @@ import {
   PACKAGE_NODE_META_FILENAME,
   PACKAGE_NODE_META_SUFFIX,
   PACKAGE_RECORDS_FILENAME,
+  type PackageBase,
   PackageBaseSchema,
   PackageDocAssetMetaSchema,
   PackageDocFrontmatterSchema,
@@ -45,6 +47,7 @@ import {
   PackageManifestSchema,
   PackageRecordLineSchema,
 } from "busabase-contract/domains/package/types";
+import { iStringParse } from "openlib/i18n/i-string";
 import type { z } from "zod";
 import { parseFrontmatter } from "./frontmatter";
 import { IGNORE_NOTHING, type IgnoreMatcher, parseIgnoreFile } from "./ignore";
@@ -160,6 +163,24 @@ const zodParse = <T>(schema: z.ZodType<T>, value: unknown, filePath: string): T 
   return result.data;
 };
 
+/**
+ * A sidecar's `agentPrompts` as the tree carries it — as a spread, so a node that
+ * has none carries no `agentPrompts` KEY at all rather than one set to `undefined`.
+ *
+ * `[]` and "absent" mean the same thing on disk (the node falls back to its type's
+ * default prompts either way), so an empty list is dropped rather than
+ * round-tripping as a sidecar key that changes nothing.
+ */
+/** `base.json` minus the node-level key, so the list lives in exactly one place. */
+const baseWithoutAgentPrompts = (base: PackageBase): PackageBase => {
+  const { agentPrompts: _agentPrompts, ...rest } = base;
+  return rest;
+};
+
+const agentPromptsField = (
+  prompts: CustomAgentPrompts | undefined,
+): { agentPrompts?: CustomAgentPrompts } => (prompts?.length ? { agentPrompts: prompts } : {});
+
 /** Direct children of `dir` (which must end in `/`, or be "" for the root). */
 interface DirEntries {
   files: string[];
@@ -216,7 +237,15 @@ export const readPackageTree = (
 
   const contentDir = `${root}${PACKAGE_CONTENT_DIRNAME}/`;
   const nodes = readNodes(files, contentDir);
-  const rootSkill = readRootSkill(files, root, manifest.name, manifest.description);
+  // readRootSkill's shape mirrors SKILL.md frontmatter, which we deliberately
+  // keep single-locale (it is agent-dispatch text, not a translated display
+  // string) — flatten here rather than widen the function to iString.
+  const rootSkill = readRootSkill(
+    files,
+    root,
+    manifest.name,
+    iStringParse(manifest.description, "en"),
+  );
   return {
     manifest,
     nodes,
@@ -403,6 +432,7 @@ const readDirNode = (files: PackageFiles, dir: string, slug: string): PackageNod
       name: meta.name,
       description: meta.description,
       position: meta.position,
+      ...agentPromptsField(meta.agentPrompts),
       files: entries,
     };
   }
@@ -418,7 +448,12 @@ const readDirNode = (files: PackageFiles, dir: string, slug: string): PackageNod
       name: base.name,
       description: base.description,
       position: base.position,
-      base,
+      ...agentPromptsField(base.agentPrompts),
+      // Stripped from the Base payload itself: `base.json` doubles as this node's
+      // sidecar, so its `agentPrompts` describe the NODE. Leaving a copy on
+      // `node.base` would mean the same list existed twice in the tree and the
+      // writer would have to decide which one wins.
+      base: baseWithoutAgentPrompts(base),
       records,
     };
   }
@@ -427,13 +462,14 @@ const readDirNode = (files: PackageFiles, dir: string, slug: string): PackageNod
   const metaPath = `${dir}${PACKAGE_FOLDER_META_FILENAME}`;
   const meta = files.has(metaPath)
     ? zodParse(PackageFolderMetaSchema, parseJsonFile(files, metaPath), metaPath)
-    : { name: undefined, description: "", position: undefined };
+    : { name: undefined, description: "", position: undefined, agentPrompts: undefined };
   return {
     type: "folder",
     slug,
     name: meta.name ?? humanizeSlug(slug),
     description: meta.description,
     position: meta.position,
+    ...agentPromptsField(meta.agentPrompts),
     children: readNodes(files, dir),
   };
 };
@@ -520,13 +556,14 @@ const readFileNode = (
   const sidecarPath = `${dir}${fileName}${PACKAGE_NODE_META_SUFFIX}`;
   const meta = files.has(sidecarPath)
     ? zodParse(PackageFileNodeMetaSchema, parseJsonFile(files, sidecarPath), sidecarPath)
-    : { name: undefined, description: "", position: undefined };
+    : { name: undefined, description: "", position: undefined, agentPrompts: undefined };
   return {
     type: "file",
     slug,
     name: meta.name ?? fileName,
     description: meta.description,
     position: meta.position,
+    ...agentPromptsField(meta.agentPrompts),
     fileName,
     mimeType: guessMimeType(fileName),
     bytes,
@@ -549,6 +586,7 @@ const readDocNode = (bytes: Buffer, dir: string, fileName: string): PackageDocNo
     name: frontmatter.name,
     description: frontmatter.description,
     position: frontmatter.position,
+    ...agentPromptsField(frontmatter.agentPrompts),
     body,
   };
 };

--- a/packages/busabase-package/src/layout-write.ts
+++ b/packages/busabase-package/src/layout-write.ts
@@ -13,6 +13,7 @@
  */
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import type { CustomAgentPrompts } from "busabase-contract/contract/node-agent-prompt-schemas";
 import {
   PACKAGE_SKILL_ENTRY,
   PACKAGE_SKILL_SIDECAR_DIRS,
@@ -43,6 +44,7 @@ import {
   type PackageDocAsset,
   type PackageNode,
   type PackageTree,
+  serializeAgentPrompts,
   sortNodes,
 } from "./tree";
 
@@ -124,13 +126,20 @@ const serializeView = (view: PackageView): Record<string, unknown> =>
     }),
   });
 
-const serializeBase = (base: PackageBase, position: number | undefined): Buffer =>
+const serializeBase = (
+  base: PackageBase,
+  position: number | undefined,
+  agentPrompts: CustomAgentPrompts | undefined,
+): Buffer =>
   toJsonFile(
     compact({
       name: base.name,
       description: base.description || undefined,
       position,
       reviewPolicy: base.reviewPolicy,
+      // Before `fields`, so a reviewer reading the diff meets what the Base is
+      // FOR before the column list it is made of.
+      agentPrompts: serializeAgentPrompts(agentPrompts),
       fields: base.fields.map(serializeField),
       views: base.views.map(serializeView),
     }),
@@ -232,6 +241,7 @@ const renderNode = (node: PackageNode, dir: string, files: PackageFiles): void =
         node.children.length === 0 ||
         node.description !== "" ||
         node.position !== undefined ||
+        node.agentPrompts !== undefined ||
         node.name !== undefined;
       if (needsMeta) {
         files.set(
@@ -241,6 +251,7 @@ const renderNode = (node: PackageNode, dir: string, files: PackageFiles): void =
               name: node.name,
               description: node.description || undefined,
               position: node.position,
+              agentPrompts: serializeAgentPrompts(node.agentPrompts),
             }),
           ),
         );
@@ -253,7 +264,12 @@ const renderNode = (node: PackageNode, dir: string, files: PackageFiles): void =
         `${dir}${node.slug}.md`,
         Buffer.from(
           serializeDoc(
-            { name: node.name, description: node.description, position: node.position },
+            {
+              name: node.name,
+              description: node.description,
+              position: node.position,
+              agentPrompts: node.agentPrompts,
+            },
             node.body,
           ),
           "utf8",
@@ -264,7 +280,7 @@ const renderNode = (node: PackageNode, dir: string, files: PackageFiles): void =
     case "base": {
       files.set(
         `${dir}${node.slug}/${PACKAGE_BASE_FILENAME}`,
-        serializeBase(node.base, node.position),
+        serializeBase(node.base, node.position, node.agentPrompts),
       );
       const records = serializeRecords(node.records);
       if (records.byteLength > 0)
@@ -287,6 +303,7 @@ const renderNode = (node: PackageNode, dir: string, files: PackageFiles): void =
             name: node.name,
             description: node.description || undefined,
             position: node.position,
+            agentPrompts: serializeAgentPrompts(node.agentPrompts),
           }),
         ),
       );
@@ -301,7 +318,10 @@ const renderNode = (node: PackageNode, dir: string, files: PackageFiles): void =
       files.set(`${dir}${node.fileName}`, node.bytes);
       // The sidecar only exists when it carries something the filename can't.
       const hasMeta =
-        node.name !== node.fileName || node.description !== "" || node.position !== undefined;
+        node.name !== node.fileName ||
+        node.description !== "" ||
+        node.position !== undefined ||
+        node.agentPrompts !== undefined;
       if (hasMeta) {
         files.set(
           `${dir}${node.fileName}${PACKAGE_NODE_META_SUFFIX}`,
@@ -310,6 +330,7 @@ const renderNode = (node: PackageNode, dir: string, files: PackageFiles): void =
               name: node.name,
               description: node.description || undefined,
               position: node.position,
+              agentPrompts: serializeAgentPrompts(node.agentPrompts),
             }),
           ),
         );

--- a/packages/busabase-package/src/layout.test.ts
+++ b/packages/busabase-package/src/layout.test.ts
@@ -25,6 +25,12 @@ const buildFixture = (): PackageTree => ({
       name: "Getting Started",
       description: "Read me first",
       position: 0,
+      // One carrier of each sidecar kind carries prompts, so the round trip
+      // covers doc frontmatter, `_folder.json`, `base.json`, `_node.json` and a
+      // file node's `.node.json`.
+      agentPrompts: [
+        { key: "summarize", label: "Summarize this for a new hire", body: "Summarize {target}." },
+      ],
       // The image is referenced by ASSET id; its bytes ride along in `assets` below.
       body: "# Hello\n\n![Diagram](/api/assets/astfixture1/raw)\n\nSome body text.",
     },
@@ -34,6 +40,7 @@ const buildFixture = (): PackageTree => ({
       name: "Guides",
       description: "",
       position: 1,
+      agentPrompts: [{ key: "index", label: "Index these guides", body: "Index {target}." }],
       children: [
         {
           type: "doc",
@@ -51,6 +58,14 @@ const buildFixture = (): PackageTree => ({
       name: "Vendors",
       description: "Who we buy from",
       position: 2,
+      agentPrompts: [
+        {
+          key: "add-vendor",
+          label: "Add a vendor",
+          body: "Read the `support-kb` skill in this folder, then add a vendor to {target}.",
+          intent: "change" as const,
+        },
+      ],
       base: {
         name: "Vendors",
         description: "Who we buy from",
@@ -134,6 +149,7 @@ const buildFixture = (): PackageTree => ({
       name: "PDF Summarizer",
       description: "Summarizes PDFs",
       position: 4,
+      agentPrompts: [{ key: "run", label: "Summarize a PDF", body: "Use {target} on my PDF." }],
       files: [
         { path: "SKILL.md", bytes: text("# Skill\n") },
         { path: "scripts/extract.py", bytes: text("print('hi')\n") },
@@ -153,6 +169,7 @@ const buildFixture = (): PackageTree => ({
       name: "Quarterly Report",
       description: "Q3 numbers",
       position: 6,
+      agentPrompts: [{ key: "read", label: "Pull the Q3 numbers", body: "Read {target}." }],
       fileName: "quarterly-report.pdf",
       mimeType: "application/pdf",
       bytes: Buffer.from([0x25, 0x50, 0x44, 0x46]),

--- a/packages/busabase-package/src/plan.test.ts
+++ b/packages/busabase-package/src/plan.test.ts
@@ -5,6 +5,7 @@ import {
   buildInstallPlan,
   type ExistingNode,
   findPlanBlockers,
+  renderPlan,
 } from "./plan";
 import type { PackageBaseNode, PackageTree } from "./tree";
 
@@ -419,6 +420,39 @@ describe("plan reporting", () => {
     expect(buildInstallPlan(tree([]), noTarget, { intoFolder: "support" }).targetFolderSlug).toBe(
       "support",
     );
+  });
+
+  it("flattens a locale-keyed manifest description to English in the dry-run text", () => {
+    const localizedTree: PackageTree = {
+      manifest: {
+        format: PACKAGE_FORMAT,
+        name: "my-package",
+        description: { en: "The my-package desk.", "zh-CN": "工作台。" },
+        tags: [],
+      },
+      nodes: [],
+    };
+    const plan = buildInstallPlan(localizedTree, noTarget);
+    const rendered = renderPlan(plan);
+    expect(rendered).toContain("The my-package desk.");
+    expect(rendered).not.toContain("[object Object]");
+    expect(rendered).not.toContain("工作台。");
+  });
+
+  it("omits the description line when every locale is blank, rather than printing an empty object", () => {
+    const blankTree: PackageTree = {
+      manifest: {
+        format: PACKAGE_FORMAT,
+        name: "my-package",
+        description: { en: "", "zh-CN": "" },
+        tags: [],
+      },
+      nodes: [],
+    };
+    const plan = buildInstallPlan(blankTree, noTarget);
+    const rendered = renderPlan(plan);
+    expect(rendered).not.toContain("[object Object]");
+    expect(rendered.split("\n")[1]).toBe("");
   });
 
   it("counts every node type and its records", () => {

--- a/packages/busabase-package/src/plan.ts
+++ b/packages/busabase-package/src/plan.ts
@@ -8,6 +8,7 @@
  * must also rewrite every relation `targetBaseSlug` that points at it.
  */
 import { PACKAGE_MAX_FILE_COUNT } from "busabase-contract/domains/package/types";
+import { iStringParse } from "openlib/i18n/i-string";
 import type { PackageClient } from "./client";
 import { buildRecordCreateLayers } from "./record-dependencies";
 import { validateTemplate } from "./template";
@@ -503,7 +504,11 @@ export const countTree = (tree: PackageTree): PlanCounts => {
 export const renderPlan = (plan: InstallPlan): string => {
   const lines: string[] = [];
   lines.push(`Package: ${plan.tree.manifest.name}`);
-  if (plan.tree.manifest.description) lines.push(`  ${plan.tree.manifest.description}`);
+  // CLI dry-run output has no locale context to render in — flatten to "en"
+  // first, since a falsiness check on the raw iString object would never be
+  // true even when every locale is blank.
+  const description = iStringParse(plan.tree.manifest.description, "en");
+  if (description) lines.push(`  ${description}`);
   lines.push("");
   lines.push(`Target folder: ${plan.targetFolderSlug}`);
   lines.push("");

--- a/packages/busabase-package/src/template.test.ts
+++ b/packages/busabase-package/src/template.test.ts
@@ -321,6 +321,44 @@ describe("deriveSkillDraft", () => {
     // Never invented: the draft must not assert what the app does.
     expect(draft).toContain("kelly-email-app");
   });
+
+  it("flattens a locale-keyed manifest description to its English line", () => {
+    const tree = readPackageTree(
+      templateFiles({
+        "SKILL.md": null,
+        "references/schema.md": null,
+        "scripts/setup.mjs": null,
+        "busabase.json": JSON.stringify({
+          format: PACKAGE_FORMAT,
+          name: "kelly-email",
+          description: { en: "Inbox triage: drafts and approvals", "zh-CN": "收件箱分诊与审批" },
+          template: { category: "email", airapp: "kelly-email-app" },
+        }),
+      }),
+    );
+    const draft = deriveSkillDraft(tree);
+    expect(draft).toContain("Inbox triage: drafts and approvals");
+    expect(draft).not.toContain("[object Object]");
+    expect(draft).not.toContain("收件箱分诊与审批");
+  });
+
+  it("still falls back to a TODO placeholder when every locale is blank", () => {
+    const tree = readPackageTree(
+      templateFiles({
+        "SKILL.md": null,
+        "references/schema.md": null,
+        "scripts/setup.mjs": null,
+        "busabase.json": JSON.stringify({
+          format: PACKAGE_FORMAT,
+          name: "kelly-email",
+          description: { en: "", "zh-CN": "" },
+          template: { category: "email", airapp: "kelly-email-app" },
+        }),
+      }),
+    );
+    const draft = deriveSkillDraft(tree);
+    expect(draft).toContain("TODO: one line on what kelly-email does.");
+  });
 });
 
 describe("round trip", () => {

--- a/packages/busabase-package/src/template.ts
+++ b/packages/busabase-package/src/template.ts
@@ -36,6 +36,7 @@ import {
   type TemplateManifest,
   type TemplateRiskLevel,
 } from "busabase-contract/domains/package/template";
+import { iStringParse } from "openlib/i18n/i-string";
 import { parseFrontmatter } from "./frontmatter";
 import { resolveAirAppPackageLifecycle } from "./layout-read";
 import { type PackageFileTreeNode, type PackageNode, type PackageTree, walkNodes } from "./tree";
@@ -250,7 +251,12 @@ export const deriveSkillDraft = (tree: PackageTree): string => {
   const bases = nodes.filter((node) => node.type === "base");
   const airapps = nodes.filter(isAirApp);
   const name = tree.manifest.name;
-  const description = tree.manifest.description || `TODO: one line on what ${name} does.`;
+  // The generated SKILL.md draft is single-locale by design (same reasoning as
+  // readRootSkill in layout-read.ts): flatten before falling back to the TODO
+  // placeholder, since an empty-string check on an iString object would never
+  // be true even when every locale is blank.
+  const flatDescription = iStringParse(tree.manifest.description, "en");
+  const description = flatDescription || `TODO: one line on what ${name} does.`;
 
   // Quoted, always. A description is free text and routinely contains a colon
   // ("Inbox triage: drafts and approvals"), which unquoted turns the line into a

--- a/packages/busabase-package/src/tree.ts
+++ b/packages/busabase-package/src/tree.ts
@@ -4,6 +4,7 @@
  * `plan`/`apply` consume. Plus the format's shared validation rules (§6.3).
  */
 import { extname } from "node:path";
+import type { CustomAgentPrompts } from "busabase-contract/contract/node-agent-prompt-schemas";
 import {
   PACKAGE_BASE_FILENAME,
   PACKAGE_FOLDER_META_FILENAME,
@@ -16,6 +17,30 @@ import {
   type PackageManifest,
   type PackageRecordLine,
 } from "busabase-contract/domains/package/types";
+
+/**
+ * A node's scenario prompts in a fixed key order — determinism (§6.6).
+ *
+ * Written through instead of spread verbatim because the list reaches the writer
+ * from two directions: hand-authored on disk (whatever order the author typed)
+ * and via a zod parse (schema order). Without this, re-exporting an unchanged
+ * package would diff on key order alone.
+ *
+ * `intent` is omitted when absent rather than defaulted to `"change"` here — the
+ * schema owns that default, and writing it out would silently rewrite every
+ * author's file on the first round trip.
+ */
+export const serializeAgentPrompts = (
+  prompts: CustomAgentPrompts | undefined,
+): Record<string, unknown>[] | undefined =>
+  prompts?.length
+    ? prompts.map((prompt) => ({
+        key: prompt.key,
+        ...(prompt.intent ? { intent: prompt.intent } : {}),
+        label: prompt.label,
+        body: prompt.body,
+      }))
+    : undefined;
 
 /** A file carried verbatim inside a skill/airapp/drive, or a `file` node's bytes. */
 export interface PackageFileEntry {
@@ -30,6 +55,17 @@ interface PackageNodeCommon {
   description: string;
   /** Sibling order. Absent → alphabetical by slug. `export` always writes it. */
   position: number | undefined;
+  /**
+   * This node's scenario Agent prompts — "log a customer visit", not an API
+   * restatement — carried in its sidecar so they survive export → install.
+   *
+   * Absent means "the author wrote none", and the installed node falls back to
+   * its node type's default prompts: the behaviour of every package written
+   * before the field existed. Never `[]` from a read — an empty sidecar list is
+   * normalised away, because "set, and deliberately empty" is not a distinction
+   * the on-disk format needs to carry.
+   */
+  agentPrompts?: CustomAgentPrompts;
 }
 
 export interface PackageFolderNode extends PackageNodeCommon {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,6 +828,9 @@ importers:
       '@zip.js/zip.js':
         specifier: ^2.8.20
         version: 2.8.20
+      openlib:
+        specifier: workspace:*
+        version: link:../openlib
       yaml:
         specifier: ^2.9.0
         version: 2.9.0


### PR DESCRIPTION
Busabase v0.51.0.

- fix(core): stabilize Sandock Fumadocs runtime
- feat(server): let a side-panel agent see the node you have open
- feat(cli): make template card descriptions multilingual (iString)
- feat(desktop): default prompts offer using the node, not only maintai...
- fix(cms): fall back to English on untranslated CMS Pages instead of 4...
- chore(packages): shared packages updates
- chore(release): v0.51.0

Merging this publishes to npm and builds the Docker image, so let CI finish
first.