### PR TITLE
fix(core): make demo file-tree seeds idempotent

### DIFF
--- a/packages/busabase-core/src/logic/seed.ts
+++ b/packages/busabase-core/src/logic/seed.ts
@@ -532,8 +532,10 @@ const FILE_TREE_FOLDER_CONFIG: Record<SeedFileTreeDef["nodeType"], FileTreeFolde
  * `writeFileTreeTextFile` — so one generic, scenario-driven seeder replaces
  * what used to be `seedSkillNodeIfMissing`/`seedDriveNodeIfMissing` (each
  * hardcoding its own fixed content, with no AirApp equivalent at all).
- * Idempotent per def, keyed by `def.nodeId`, exactly like the two functions
- * it replaces.
+ * Idempotent per def. A live node with the same space/type/slug is adopted
+ * before falling back to the canonical scenario id, so installations seeded
+ * before stable demo ids were introduced do not collide with the live-slug
+ * uniqueness constraint.
  */
 const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef[]) => {
   if (defs.length === 0) {
@@ -592,11 +594,26 @@ const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef
       visibility: "workspace" as const,
       version: "0.1.0",
     };
-    const [existingNode] = await db
+    let [existingNode] = await db
       .select()
       .from(busabaseNodes)
-      .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, def.nodeId)))
+      .where(
+        and(
+          eq(busabaseNodes.spaceId, spaceId),
+          eq(busabaseNodes.type, def.nodeType),
+          eq(busabaseNodes.slug, def.slug),
+          isNull(busabaseNodes.archivedAt),
+        ),
+      )
       .limit(1);
+    if (!existingNode) {
+      [existingNode] = await db
+        .select()
+        .from(busabaseNodes)
+        .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, def.nodeId)))
+        .limit(1);
+    }
+    const actualNodeId = existingNode?.id ?? def.nodeId;
     if (existingNode) {
       await db
         .update(busabaseNodes)
@@ -611,7 +628,7 @@ const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef
           position: def.position,
           updatedAt: createdAt,
         })
-        .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, def.nodeId)));
+        .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, actualNodeId)));
     } else {
       await db.insert(busabaseNodes).values({
         id: def.nodeId,
@@ -631,7 +648,7 @@ const seedFileTreeNodesIfMissing = async (createdAt: Date, defs: SeedFileTreeDef
     const [node] = await db
       .select()
       .from(busabaseNodes)
-      .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, def.nodeId)))
+      .where(and(eq(busabaseNodes.spaceId, spaceId), eq(busabaseNodes.id, actualNodeId)))
       .limit(1);
     if (!node) {
       throw new Error(`Failed to seed ${def.nodeType} node: ${def.nodeId}`);

--- a/packages/busabase-core/tests/seed-file-tree-existing-folder.test.ts
+++ b/packages/busabase-core/tests/seed-file-tree-existing-folder.test.ts
@@ -7,13 +7,16 @@ import { LOCAL_SPACE_ID } from "../src/context";
 import { getDb } from "../src/db";
 import { busabaseNodes } from "../src/db/schema";
 import { englishScenario } from "../src/demo/dataset";
+import { AIRAPP_DEMO_PURE_HTML } from "../src/domains/airapp/demo-content";
+import { readAirAppFile } from "../src/domains/airapp/handlers";
 import { ensureReady, seedScenario } from "../src/logic/store";
 
 const MIGRATIONS_CWD = path.resolve(__dirname, "../../../apps/busabase");
 const EXISTING_SKILLS_FOLDER_ID = "nod_existing_skills";
+const EXISTING_PURE_HTML_AIRAPP_ID = "nod_existing_pure_html_airapp";
 const OTHER_SPACE_SKILLS_FOLDER_ID = "nod_other_space_skills";
 
-describe("file-tree seed folder adoption", () => {
+describe("file-tree seed identity adoption", () => {
   let dataDir = "";
   let storageDir = "";
   let originalCwd = "";
@@ -53,6 +56,17 @@ describe("file-tree seed folder adoption", () => {
         createdAt,
         updatedAt: createdAt,
       },
+      {
+        id: EXISTING_PURE_HTML_AIRAPP_ID,
+        parentId: "nod_root",
+        type: "airapp",
+        slug: "demo-pure-html",
+        name: "Historical Pure HTML Demo",
+        description: "Created before demo AirApps received canonical ids.",
+        position: 99,
+        createdAt,
+        updatedAt: createdAt,
+      },
     ]);
   });
 
@@ -87,6 +101,32 @@ describe("file-tree seed folder adoption", () => {
       .limit(1);
     expect(seededSkill?.parentId).toBe(EXISTING_SKILLS_FOLDER_ID);
 
+    const localPureHtmlAirApps = await db
+      .select({
+        id: busabaseNodes.id,
+        parentId: busabaseNodes.parentId,
+        name: busabaseNodes.name,
+      })
+      .from(busabaseNodes)
+      .where(
+        and(
+          eq(busabaseNodes.spaceId, LOCAL_SPACE_ID),
+          eq(busabaseNodes.type, "airapp"),
+          eq(busabaseNodes.slug, "demo-pure-html"),
+        ),
+      );
+    expect(localPureHtmlAirApps).toEqual([
+      {
+        id: EXISTING_PURE_HTML_AIRAPP_ID,
+        parentId: "nod_airapps",
+        name: "Pure HTML Demo",
+      },
+    ]);
+    const packageFile = await readAirAppFile(EXISTING_PURE_HTML_AIRAPP_ID, "package.json");
+    expect(packageFile.content).toBe(
+      AIRAPP_DEMO_PURE_HTML.files.find((file) => file.path === "package.json")?.content,
+    );
+
     const [otherSpaceFolder] = await db
       .select({ name: busabaseNodes.name })
       .from(busabaseNodes)
@@ -107,5 +147,17 @@ describe("file-tree seed folder adoption", () => {
       .where(eq(busabaseNodes.id, "nod_skill_ai_research_editor"))
       .limit(1);
     expect(seededSkillAfterRerun?.parentId).toBe(EXISTING_SKILLS_FOLDER_ID);
+
+    const pureHtmlAirAppsAfterRerun = await db
+      .select({ id: busabaseNodes.id })
+      .from(busabaseNodes)
+      .where(
+        and(
+          eq(busabaseNodes.spaceId, LOCAL_SPACE_ID),
+          eq(busabaseNodes.type, "airapp"),
+          eq(busabaseNodes.slug, "demo-pure-html"),
+        ),
+      );
+    expect(pureHtmlAirAppsAfterRerun).toEqual([{ id: EXISTING_PURE_HTML_AIRAPP_ID }]);
   }, 60_000);
 });


### PR DESCRIPTION
> Verification level: Partially verified. Real PGlite regression testing and a standalone build passed; concurrent initialization and archived-node combinations remain untested.

## Problem and Fix

Demo AirApps in existing installations can have historical IDs. Reinitializing them could violate the unique slug constraint. Seeding now reuses an active node with the same workspace, type, and slug before falling back to the canonical ID, and uses the actual node ID for updates and file writes.

The version remains 0.51.0. Version manifests, the lockfile, and release workflows are unchanged. Auto-merge is disabled.

## Validation

- Passed: standalone frozen install, `pnpm --filter busabase-core typecheck`, Biome checks for both changed files, and `pnpm --filter busabase build`.
- Regression: `pnpm --filter busabase-core exec vitest run tests/seed-file-tree-existing-folder.test.ts` passed 1 test in 33.42 seconds using a temporary PGlite database and local file storage, without mocking the database.
- Observed: historical folder and AirApp IDs are reused, the AirApp package.json content can be read, repeated initialization preserves the node count, and folders in other workspaces remain unchanged.
- Repository checks: relative README links resolve, no real environment files or private keys were found, and existing public files are preserved.
- Not covered: concurrent initialization, combinations of archived nodes and canonical IDs, and the full test suite. The build reported three dynamic filesystem tracing warnings in files unchanged by this PR.
- This is a backend initialization fix. No browser verification was performed, so there are no screenshots or recordings.

## Files Affected

- `packages/busabase-core/src/logic/seed.ts`
- `packages/busabase-core/tests/seed-file-tree-existing-folder.test.ts`
