### PR TITLE
Release v0.51.1

### DIFF
--- a/apps/busabase-cli/package.json
+++ b/apps/busabase-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-cli",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "description": "Command-line client for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server`.",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-cli",

--- a/apps/busabase-desktop/package.json
+++ b/apps/busabase-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@busabase/desktop",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.51.1",
   "type": "module",
   "scripts": {
     "dev": "next dev --port 3064",

--- a/apps/busabase-desktop/src-tauri/Cargo.lock
+++ b/apps/busabase-desktop/src-tauri/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "busabase_desktop"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "semver",
  "serde",

--- a/apps/busabase-desktop/src-tauri/Cargo.toml
+++ b/apps/busabase-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busabase_desktop"
-version = "0.51.0"
+version = "0.51.1"
 description = "Busabase Desktop - private local-first Busabase knowledge base shell"
 authors = ["Busabase Team"]
 edition = "2021"

--- a/apps/busabase-desktop/src-tauri/tauri.conf.json
+++ b/apps/busabase-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Busabase Desktop",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "identifier": "com.busabase.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/apps/busabase-mobile/app.json
+++ b/apps/busabase-mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Busabase",
     "slug": "busabase-mobile",
     "scheme": "busabase",
-    "version": "0.51.0",
+    "version": "0.51.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/busabase-mobile/package.json
+++ b/apps/busabase-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-mobile",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "main": "expo-router/entry",
   "private": true,
   "scripts": {

--- a/apps/busabase-sdk/package.json
+++ b/apps/busabase-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "busabase-sdk",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "description": "Typed TypeScript/JavaScript SDK for the Busabase OpenAPI REST API. Talks to a local or remote `busabase server` (or Busabase Cloud).",
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase-sdk",

--- a/apps/busabase/package.json
+++ b/apps/busabase/package.json
@@ -18,7 +18,7 @@
     "pglite",
     "cli"
   ],
-  "version": "0.51.0",
+  "version": "0.51.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/apps/busabase",

--- a/apps/busabase/public/assets/readme/coverage.svg
+++ b/apps/busabase/public/assets/readme/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="107" height="20" role="img" aria-label="coverage: 75.9%">
-  <title>coverage: 75.9%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="107" height="20" role="img" aria-label="coverage: 76.1%">
+  <title>coverage: 76.1%</title>
   <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
   <clipPath id="r"><rect width="107" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
@@ -10,7 +10,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="310" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="520">coverage</text>
     <text x="310" y="140" transform="scale(.1)" fill="#fff" textLength="520">coverage</text>
-    <text aria-hidden="true" x="845" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">75.9%</text>
-    <text x="845" y="140" transform="scale(.1)" fill="#fff" textLength="330">75.9%</text>
+    <text aria-hidden="true" x="845" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">76.1%</text>
+    <text x="845" y="140" transform="scale(.1)" fill="#fff" textLength="330">76.1%</text>
   </g>
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-repo",
   "private": true,
-  "version": "0.51.0",
+  "version": "0.51.1",
   "packageManager": "pnpm@10.15.1",
   "workspaces": [
     "apps/*",

--- a/packages/busabase-contract/package.json
+++ b/packages/busabase-contract/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-contract",
   "description": "Client-safe Busabase surface: oRPC contracts (OSS + cloud), node-type kernel, VO types, and the oRPC client factories. Pure leaf \u2014 no db/logic/server deps. Consumed by busabase-cli, busabase-mobile, busabase-core, busabase, and busabase-cloud.",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/busabase-core/package.json
+++ b/packages/busabase-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-core",
   "description": "Shared Busabase open-core protocol, local store, API helpers, and dashboard components.",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/busabase-package/package.json
+++ b/packages/busabase-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "busabase-package",
   "description": "The `busabase-package@1` format: GitHub source, layout read/write, install planning, and the five-pass apply. Shared by busabase-cli (`install` / `export`) and busabase-core's server-side install domain. Node-only APIs are fine here \u2014 it is never browser-bundled.",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/busabase/busabase/tree/main/packages/busabase-package",
@@ -138,13 +138,13 @@
   "dependencies": {
     "@orpc/contract": "^1.14.6",
     "@zip.js/zip.js": "^2.8.20",
-    "openlib": "workspace:*",
     "yaml": "^2.9.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^26.3.0",
     "busabase-contract": "workspace:*",
+    "openlib": "workspace:*",
     "tsdown": "^0.22.14",
     "typescript": "^7.0.2",
     "vitest": "^4.1.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,9 +828,6 @@ importers:
       '@zip.js/zip.js':
         specifier: ^2.8.20
         version: 2.8.20
-      openlib:
-        specifier: workspace:*
-        version: link:../openlib
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -844,6 +841,9 @@ importers:
       busabase-contract:
         specifier: workspace:*
         version: link:../busabase-contract
+      openlib:
+        specifier: workspace:*
+        version: link:../openlib
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.21.0)(typescript@7.0.2)


### PR DESCRIPTION
Busabase v0.51.1.

- chore(release): v0.51.1

Merging this publishes to npm and builds the Docker image, so let CI finish
first.