### PR TITLE
fix(core): replace relation projections by stable field identity

### DIFF
--- a/packages/busabase-core/src/logic/field-values.ts
+++ b/packages/busabase-core/src/logic/field-values.ts
@@ -193,16 +193,18 @@ export const projectCommitFields = async (input: {
   }
 
   if (input.recordId && !input.isNewRecord) {
-    const relationFieldSlugs = Object.entries(input.fields)
-      .filter(([fieldSlug]) => fieldsBySlug.get(fieldSlug)?.type === "relation")
-      .map(([fieldSlug]) => fieldSlug);
-    if (relationFieldSlugs.length > 0) {
+    // Slugs can change; replace links by the stable identity used by their unique index.
+    const relationFieldIds = Object.keys(input.fields).flatMap((fieldSlug) => {
+      const field = fieldsBySlug.get(fieldSlug);
+      return field?.type === "relation" ? [field.id] : [];
+    });
+    if (relationFieldIds.length > 0) {
       await db
         .delete(busabaseRecordLinks)
         .where(
           and(
             eq(busabaseRecordLinks.sourceRecordId, input.recordId),
-            inArray(busabaseRecordLinks.fieldSlug, relationFieldSlugs),
+            inArray(busabaseRecordLinks.fieldId, relationFieldIds),
           ),
         );
     }

--- a/packages/busabase-core/tests/field-values-projection.test.ts
+++ b/packages/busabase-core/tests/field-values-projection.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { createRouterClient } from "@orpc/server";
 import { and, eq } from "drizzle-orm";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, assert, beforeAll, describe, expect, it } from "vitest";
 import { DEMO_BASES, DEMO_FOLDERS } from "../src/demo/dataset";
 // Import logic through the same entry points the router uses (store barrel /
 // dynamic imports) — a direct deep import of logic modules at load time flips
@@ -77,6 +77,87 @@ describe("field-values projection layer", () => {
     expect(getRelationRecordIds("")).toEqual([]);
     expect(getRelationRecordIds({ nope: true })).toEqual([]);
   });
+
+  it.each([false, true])(
+    "replaces historical relation slugs by field identity (deleted: %s)",
+    async (deleted) => {
+      const { projectCommitFields } = await import("../src/logic/field-values");
+      const db = await getDb();
+      const { busabaseRecordLinks, busabaseRecords } = await getSchema();
+      const title = `Historical relation ${deleted}`;
+      const otherSlug = `unrelated_${deleted}`;
+      await client.bases.createField({
+        baseId,
+        slug: otherSlug,
+        name: "Unrelated relation",
+        type: "relation",
+        options: { targetBaseId: baseId },
+      });
+      await client.bases.createChangeRequest({
+        baseId,
+        fields: { title },
+        autoMerge: true,
+      });
+      const records = await client.records.list({ baseId });
+      const record = records.records.find((item) => item.headCommit.payload.title === title);
+      assert(record);
+      const [stored] = await db
+        .select()
+        .from(busabaseRecords)
+        .where(eq(busabaseRecords.id, record.id));
+      assert(stored);
+      const projection = {
+        baseId,
+        commitId: stored.headCommitId,
+        recordId: record.id,
+        fields: { title, ref: [record.id] },
+      };
+      await projectCommitFields({
+        ...projection,
+        fields: { ...projection.fields, [otherSlug]: [record.id] },
+      });
+      const links = () =>
+        db
+          .select()
+          .from(busabaseRecordLinks)
+          .where(eq(busabaseRecordLinks.sourceRecordId, record.id));
+      const original = (await links()).find((link) => link.fieldSlug === "ref");
+      const unrelated = (await links()).find((link) => link.fieldSlug === otherSlug);
+      assert(original);
+      assert(unrelated);
+
+      // Historical projections can retain a slug from before a field rename.
+      await db
+        .update(busabaseRecordLinks)
+        .set({ fieldSlug: "previous_ref", deletedAt: deleted ? new Date() : null })
+        .where(eq(busabaseRecordLinks.id, original.id));
+
+      await projectCommitFields(projection);
+      await projectCommitFields(projection);
+      expect((await links()).filter((link) => link.fieldId === original.fieldId)).toEqual([
+        expect.objectContaining({
+          fieldId: original.fieldId,
+          fieldSlug: "ref",
+          targetRecordId: record.id,
+          commitId: stored.headCommitId,
+          deletedAt: null,
+          position: 0,
+        }),
+      ]);
+
+      await db
+        .update(busabaseRecordLinks)
+        .set({ fieldSlug: "previous_ref" })
+        .where(
+          and(
+            eq(busabaseRecordLinks.sourceRecordId, record.id),
+            eq(busabaseRecordLinks.fieldId, original.fieldId),
+          ),
+        );
+      await projectCommitFields({ ...projection, fields: { title, ref: [] } });
+      expect(await links()).toEqual([unrelated]);
+    },
+  );
 
   // ── archived/deleted listing queries ───────────────────────────────────────
 


### PR DESCRIPTION
> Verification level: Partially verified. Real PostgreSQL production seed reruns and PGlite regressions passed; concurrent seed processes and the affected deployment's database were not tested.

## Problem and Fix

Seeding an existing installation can fail with PostgreSQL error 23505 on `busabase_record_links_source_field_target_uniq`. Relation replacement deleted old rows by the current field slug, but the unique index identifies a relation by source record ID, field ID, and target record ID. Historical rows with a different stored slug therefore survived deletion and conflicted with the next insert.

Replace links by stable field ID instead. Tests cover active and soft-deleted historical links, repeated projection, clearing a relation, and preserving unrelated field links. No version, schema, migration, or release-workflow changes.

## Validation

- Before the fix, both new real PGlite regression cases fail with the same 23505 unique constraint.
- Reproduced the production failure on disposable PostgreSQL 16: seed the database, change one existing `related_social` link's stored slug, then run the original `node dist/seed/seed-all.cjs`. It fails at `projectCommitFields` via `seedRecordIfMissing`, with the same four-link insert and constraint as the reported failure.
- Rebuilt the seed bundles and ran the English production seed twice on that same failing database. Both runs print `Done` and preserve **520 records and 181 links**, with **0 historical slugs and 0 duplicate relation identities**. No manual cleanup was needed to repair the test data. A test-only preload closes the PostgreSQL client after `Done`; it does not change seed queries.
- Independent PGlite verification: **9 tests passed across 3 files**, covering field projection, merge projection, and file-tree seed adoption.
- Scoped core typecheck and production seed bundle build pass. Biome reports no errors and two existing warnings in unchanged test code.

## Limits

The affected deployment's actual database, concurrent seed processes, and duplicate target IDs within one input were not tested. No browser tests were needed for this backend-only change. The complete workspace checks were not available in the source checkout because its dependencies were absent; scoped verification ran in a frozen-installed standalone workspace.

This PR does not update an already running container or enable auto-merge. Deploy a build containing this fix before rerunning the production seed command.
